### PR TITLE
fix: add /etc folder

### DIFF
--- a/distroless/private/cacerts.bzl
+++ b/distroless/private/cacerts.bzl
@@ -53,7 +53,11 @@ def _cacerts_impl(ctx):
 
     output = ctx.actions.declare_file(ctx.attr.name + ".tar.gz")
     mtree = tar_lib.create_mtree(ctx)
-    mtree.add_parents("/etc/ssl/certs", time = ctx.attr.time)
+
+    # TODO: We should have a rule `rootfs` that creates the filesystem root.
+    # We'll add this for now to match distroless images.
+    mtree.add_dir("/etc", mode = "0755", time = "946684800")
+    mtree.add_parents("/etc/ssl/certs", mode = "0755", time = ctx.attr.time, skip = [1])
     mtree.add_file("/etc/ssl/certs/ca-certificates.crt", cacerts, time = ctx.attr.time, mode = ctx.attr.mode)
     mtree.add_parents("/usr/share/doc/ca-certificates", time = ctx.attr.time)
     mtree.add_file("/usr/share/doc/ca-certificates/copyright", copyright, time = ctx.attr.time, mode = ctx.attr.mode)

--- a/distroless/private/group.bzl
+++ b/distroless/private/group.bzl
@@ -37,8 +37,12 @@ def group(name, entries, time = "0.0", mode = "0644", **kwargs):
     )
 
     mtree = tar_lib.create_mtree()
+
+    # TODO: We should have a rule `rootfs` that creates the filesystem root.
+    # We'll add this for now to match distroless images.
+    mtree.add_dir("/etc", mode = "0755", time = "946684800")
     mtree.entry(
-        "etc/group",
+        "/etc/group",
         "file",
         mode = mode,
         time = time,

--- a/distroless/private/java_keystore.bzl
+++ b/distroless/private/java_keystore.bzl
@@ -23,7 +23,11 @@ def _java_keystore_impl(ctx):
 
     output = ctx.actions.declare_file(ctx.attr.name + ".tar.gz")
     mtree = tar_lib.create_mtree(ctx)
-    mtree.add_parents("/etc/ssl/certs/java", mode = ctx.attr.mode, time = ctx.attr.time)
+
+    # TODO: We should have a rule `rootfs` that creates the filesystem root.
+    # We'll add this for now to match distroless images.
+    mtree.add_dir("/etc", mode = "0755", time = "946684800")
+    mtree.add_parents("/etc/ssl/certs/java", mode = ctx.attr.mode, time = ctx.attr.time, skip = [1])
     mtree.add_file("/etc/ssl/certs/java/cacerts", jks, mode = ctx.attr.mode, time = ctx.attr.time)
     mtree.build(output = output, mnemonic = "JavaKeyStore", inputs = [jks])
 

--- a/distroless/private/passwd.bzl
+++ b/distroless/private/passwd.bzl
@@ -47,6 +47,10 @@ def passwd(name, entries, mode = "0644", time = "0.0", **kwargs):
     )
 
     mtree = tar_lib.create_mtree()
+
+    # TODO: We should have a rule `rootfs` that creates the filesystem root.
+    # We'll add this for now to match distroless images.
+    mtree.add_dir("/etc", mode = "0755", time = "946684800")
     mtree.entry(
         "/etc/passwd",
         "file",

--- a/distroless/private/tar.bzl
+++ b/distroless/private/tar.bzl
@@ -32,12 +32,12 @@ def _mtree_line(dest, type, content = None, uid = DEFAULT_UID, gid = DEFAULT_GID
         spec.append("content=" + content)
     return " ".join(spec)
 
-def _add_parents(path, uid = DEFAULT_UID, gid = DEFAULT_GID, time = DEFAULT_TIME, mode = DEFAULT_MODE):
+def _add_parents(path, uid = DEFAULT_UID, gid = DEFAULT_GID, time = DEFAULT_TIME, mode = DEFAULT_MODE, skip = []):
     lines = []
     segments = path.split("/")
     for i in range(0, len(segments)):
         parent = "/".join(segments[:i + 1])
-        if not parent:
+        if not parent or i in skip:
             continue
         lines.append(
             _mtree_line(parent, "dir", uid = uid, gid = gid, time = time, mode = mode),

--- a/examples/cacerts/BUILD.bazel
+++ b/examples/cacerts/BUILD.bazel
@@ -11,7 +11,7 @@ assert_tar_listing(
     actual = "cacerts",
     expected = """\
 #mtree
-./etc time=0.0 mode=755 gid=0 uid=0 type=dir
+./etc time=946684800.0 mode=755 gid=0 uid=0 type=dir
 ./etc/ssl time=0.0 mode=755 gid=0 uid=0 type=dir
 ./etc/ssl/certs time=0.0 mode=755 gid=0 uid=0 type=dir
 ./etc/ssl/certs/ca-certificates.crt time=0.0 mode=555 gid=0 uid=0 type=file size=200313 sha1digest=01b4ff230afaeeda5cddaf9a002cec9bc9a6d1b4

--- a/examples/flatten/BUILD.bazel
+++ b/examples/flatten/BUILD.bazel
@@ -52,6 +52,7 @@ assert_tar_listing(
     actual = "flatten",
     expected = """\
 #mtree
+./etc time=946684800.0 mode=755 gid=0 uid=0 type=dir
 ./etc/passwd time=0.0 mode=644 gid=0 uid=0 type=file size=34 sha1digest=240bc4b96dc5e13ffcc715bda7aaa9665fc1069c
 ./examples time=1672560000.0 mode=755 gid=0 uid=0 type=dir
 ./examples/flatten time=1672560000.0 mode=755 gid=0 uid=0 type=dir

--- a/examples/group/BUILD.bazel
+++ b/examples/group/BUILD.bazel
@@ -37,6 +37,7 @@ assert_tar_listing(
     actual = "group",
     expected = """\
 #mtree
+./etc time=946684800.0 mode=755 gid=0 uid=0 type=dir
 ./etc/group time=0.0 mode=644 gid=0 uid=0 type=file size=46 sha1digest=73eab1fb5cf810c5811e9594a9180bee97011ed1
 """,
 )

--- a/examples/java_keystore/BUILD.bazel
+++ b/examples/java_keystore/BUILD.bazel
@@ -28,7 +28,7 @@ assert_tar_listing(
     actual = "java_keystore",
     expected = """\
 #mtree
-./etc time=0.0 mode=555 gid=0 uid=0 type=dir
+./etc time=946684800.0 mode=755 gid=0 uid=0 type=dir
 ./etc/ssl time=0.0 mode=555 gid=0 uid=0 type=dir
 ./etc/ssl/certs time=0.0 mode=555 gid=0 uid=0 type=dir
 ./etc/ssl/certs/java time=0.0 mode=555 gid=0 uid=0 type=dir

--- a/examples/passwd/BUILD.bazel
+++ b/examples/passwd/BUILD.bazel
@@ -27,6 +27,7 @@ assert_tar_listing(
     actual = "passwd",
     expected = """\
 #mtree
+./etc time=946684800.0 mode=755 gid=0 uid=0 type=dir
 ./etc/passwd time=0.0 mode=644 gid=0 uid=0 type=file size=36 sha1digest=a158dcecfd75d6502cdb1086eb5b0756d08fc423
 """,
 )


### PR DESCRIPTION
This is needed for again minimizing the diff between current images distroless builds. I believe this is an historic mistake made in distroless i believe, we should ideally remove these and should be created by a rule called `rootfs`? that does this only once. 