### PR TITLE
fix: always install highest version

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -35,3 +35,14 @@ deb_index(
 load("@bullseye//:packages.bzl", "bullseye_packages")
 
 bullseye_packages()
+
+# bazel run @apt_security//:lock
+deb_index(
+    name = "apt_security",
+    # lock = "//examples/apt_security:security.lock.json",
+    manifest = "//examples/apt_security:security.yaml",
+)
+
+load("@apt_security//:packages.bzl", "apt_security_packages")
+
+apt_security_packages()

--- a/apt/private/resolve.bzl
+++ b/apt/private/resolve.bzl
@@ -120,6 +120,7 @@ filegroup(
     name = "lockfile",
     srcs = ["lock.json"],
     tags = ["manual"],
+    visibility = ["//visibility:public"]
 )
 sh_binary(
     name = "lock",

--- a/apt/private/version.bzl
+++ b/apt/private/version.bzl
@@ -131,6 +131,19 @@ def _compare_version(va, vb):
     # compare debian revision
     return _version_cmp_part(vap[2] or "0", vbp[2] or "0")
 
+def _sort(versions, reverse = False):
+    vr = versions
+    for i in range(len(vr)):
+        for j in range(i + 1, len(vr)):
+            # if vr[i] is greater than vr[i+1] then swap their indices.
+            if _compare_version(vr[i], vr[j]) == 1:
+                vri = vr[i]
+                vr[i] = vr[j]
+                vr[j] = vri
+    if reverse:
+        vr = reversed(vr)
+    return vr
+
 version = struct(
     parse = _parse_version,
     gt = lambda va, vb: _compare_version(va, vb) == 1,
@@ -138,4 +151,5 @@ version = struct(
     lt = lambda va, vb: _compare_version(va, vb) == -1,
     lte = lambda va, vb: _compare_version(va, vb) <= 0,
     eq = lambda va, vb: _compare_version(va, vb) == 0,
+    sort = lambda versions, reverse = False: _sort(versions, reverse = reverse),
 )

--- a/apt/tests/BUILD.bazel
+++ b/apt/tests/BUILD.bazel
@@ -1,8 +1,10 @@
 load(":package_resolution_test.bzl", "version_depends_test")
-load(":version_test.bzl", "version_compare_test", "version_parse_test")
+load(":version_test.bzl", "version_compare_test", "version_parse_test", "version_sort_test")
 
 version_compare_test(name = "version_compare_test")
 
 version_parse_test(name = "version_parse_test")
 
 version_depends_test(name = "version_depends")
+
+version_sort_test(name = "version_sort_test")

--- a/apt/tests/version_test.bzl
+++ b/apt/tests/version_test.bzl
@@ -53,3 +53,11 @@ def _version_compare_test(ctx):
     return unittest.end(env)
 
 version_compare_test = unittest.make(_version_compare_test)
+
+def _version_sort_test(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, version.sort(["1.5~rc2", "1.0.4-2", "1.5~rc1"]), ["1.0.4-2", "1.5~rc1", "1.5~rc2"])
+    asserts.equals(env, version.sort(["1.0a7-2", "1.0final-5sarge1", "1.0final-5"], reverse = True), ["1.0final-5sarge1", "1.0final-5", "1.0a7-2"])
+    return unittest.end(env)
+
+version_sort_test = unittest.make(_version_sort_test)

--- a/examples/apt_security/BUILD.bazel
+++ b/examples/apt_security/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@aspect_bazel_lib//lib:jq.bzl", "jq")
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
+
+jq(
+    name = "pick_libuuid_version",
+    srcs = [
+        "@apt_security_resolution//:lockfile",
+    ],
+    args = ["-rj"],
+    filter = '.packages | map(select(.name == "libuuid1")) | .[0].version',
+)
+
+assert_contains(
+    name = "test_libuuid_version",
+    actual = ":pick_libuuid_version",
+    expected = "2.38.1-5+deb12u1",
+)

--- a/examples/apt_security/security.yaml
+++ b/examples/apt_security/security.yaml
@@ -1,0 +1,15 @@
+version: 1
+
+sources:
+  - channel: bookworm main
+    url: https://snapshot-cloudflare.debian.org/archive/debian/20240401T030239Z
+  - channel: bookworm-updates main
+    url: https://snapshot-cloudflare.debian.org/archive/debian/20240401T030239Z
+  - channel: bookworm-security main
+    url: https://snapshot-cloudflare.debian.org/archive/debian-security/20240401T030239Z
+
+archs:
+  - amd64
+
+packages:
+  - libuuid1


### PR DESCRIPTION
This fixes an issue where package resolution did not pick the latest version of a package due to missing logic in the resolution algorithm. 

https://askubuntu.com/questions/1395561/what-is-regarded-as-the-latest-version-of-a-package-by-apt