### PR TITLE
support zstd compressed {control,data}.tar files

### DIFF
--- a/apt/private/dpkg_status.bzl
+++ b/apt/private/dpkg_status.bzl
@@ -37,7 +37,7 @@ dpkg_status = rule(
             default = ":dpkg_status.sh",
         ),
         "controls": attr.label_list(
-            allow_files = [".tar.xz", ".tar.gz", ".tar"],
+            allow_files = [".tar.zst", ".tar.xz", ".tar.gz", ".tar"],
             mandatory = True,
         ),
     },

--- a/apt/private/dpkg_statusd.bzl
+++ b/apt/private/dpkg_statusd.bzl
@@ -41,7 +41,7 @@ dpkg_statusd = rule(
         ),
         "package_name": attr.string(mandatory = True),
         "control": attr.label(
-            allow_single_file = [".tar.xz", ".tar.gz", ".tar"],
+            allow_single_file = [".tar.zst", ".tar.xz", ".tar.gz", ".tar"],
             mandatory = True,
         ),
         "compression": attr.string(

--- a/apt/private/index.bzl
+++ b/apt/private/index.bzl
@@ -11,13 +11,13 @@ _DEB_IMPORT_TMPL = '''\
 filegroup(
     name = "data",
     visibility = ["//visibility:public"],
-    srcs = ["data.tar.xz"]
+    srcs = glob(["data.tar.*"]),
 )
 
 filegroup(
     name = "control",
     visibility = ["//visibility:public"],
-    srcs = ["control.tar.xz"]
+    srcs = glob(["control.tar.*"]),
 )
 """
     )

--- a/distroless/private/cacerts.bzl
+++ b/distroless/private/cacerts.bzl
@@ -76,7 +76,7 @@ cacerts = rule(
             default = ":cacerts.sh",
         ),
         "package": attr.label(
-            allow_single_file = [".tar.xz", ".tar.gz", ".tar"],
+            allow_single_file = [".tar.zst", ".tar.xz", ".tar.gz", ".tar"],
             mandatory = True,
         ),
         "mode": attr.string(


### PR DESCRIPTION
I built an Ubuntu based image and ran into `control.tar.zst` and `data.tar.zst` files inside the `.debs`

This relatively minor patch adds support (`zstd` needs to be on `$PATH` for `bsdtar` to find it)

I have another branch with an `//examples/apt-ubuntu` copy that riffs on `//examples/apt` to test this with ... I could include it in examples if you'd like to have it around for testing, or leave it out like I've left this diff.