### PR TITLE
Fail on manifest duplicate packages

### DIFF
--- a/apt/private/resolve.bzl
+++ b/apt/private/resolve.bzl
@@ -76,7 +76,12 @@ def _deb_resolve_impl(rctx):
     lockf = lockfile.empty(rctx)
 
     for arch in manifest["archs"]:
+        dep_constraint_set = {}
         for dep_constraint in manifest["packages"]:
+            if dep_constraint in dep_constraint_set:
+                fail("Duplicate package, {}. Please remove it from your manifest".format(dep_constraint))
+            dep_constraint_set[dep_constraint] = True
+
             constraint = package_resolution.parse_depends(dep_constraint).pop()
 
             rctx.report_progress("Resolving %s" % dep_constraint)


### PR DESCRIPTION
Currently having duplicate packages in your manifest will cause bad behavior when actually using those packages.
Fail when duplicate packages are seen in the manifest file.

Ex: 2 dpkg packages in packagesand `bazel run @bullseye//:lock`
```
packages:
  - "dpkg"
  - "dpkg"
```

Without changes and duplicates, the lock passes, but will have duplicate dependencies which leads to errors when actually using the package "@bullseye//dpkg".
```
				{
					"key": "libcrypt1_1-4.4.18-4_amd64",
					"name": "libcrypt1",
					"version": "1:4.4.18-4"
				},
				...
				{
					"key": "libcrypt1_1-4.4.18-4_amd64",
					"name": "libcrypt1",
					"version": "1:4.4.18-4"
				},
```
```
ERROR: /home/eric/.cache/bazel/_bazel_eric/0dc37115db8d04cb9adf89231812a093/external/bullseye/dpkg/amd64/BUILD.bazel:18:10: Label '@bullseye//libcrypt1/amd64:amd64' is duplicated in the 'srcs' attribute of rule 'amd64'
```

With PR:
```
ERROR: An error occurred during the fetch of repository 'bullseye_resolution':
   Traceback (most recent call last):
        File "/home/eric/Documents/rules_distroless/apt/private/resolve.bzl", line 82, column 21, in _deb_resolve_impl
                fail("Duplicate package, {}. Please remove it from your manifest".format(dep_constraint))
Error in fail: Duplicate package, dpkg. Please remove it from your manifest
ERROR: /home/eric/Documents/rules_distroless/WORKSPACE.bazel:29:10: fetching deb_resolve rule //external:bullseye_resolution: Traceback (most recent call last):
        File "/home/eric/Documents/rules_distroless/apt/private/resolve.bzl", line 82, column 21, in _deb_resolve_impl
                fail("Duplicate package, {}. Please remove it from your manifest".format(dep_constraint))
Error in fail: Duplicate package, dpkg. Please remove it from your manifest
```