### PR TITLE
fix `cacert()` to work with openssl's defaults

### DIFF
--- a/distroless/private/cacerts.bzl
+++ b/distroless/private/cacerts.bzl
@@ -58,6 +58,7 @@ def _cacerts_impl(ctx):
     mtree.add_dir("/etc", mode = "0755", time = ctx.attr.time)
     mtree.add_parents("/etc/ssl/certs", mode = "0755", time = ctx.attr.time, skip = [1])
     mtree.add_file("/etc/ssl/certs/ca-certificates.crt", cacerts, time = ctx.attr.time, mode = ctx.attr.mode)
+    mtree.add_link("/usr/lib/ssl/cert.pem", "/etc/ssl/certs/ca-certificates.crt", time = ctx.attr.time, mode = ctx.attr.mode)
     mtree.add_parents("/usr/share/doc/ca-certificates", time = ctx.attr.time)
     mtree.add_file("/usr/share/doc/ca-certificates/copyright", copyright, time = ctx.attr.time, mode = ctx.attr.mode)
     mtree.build(output = output, mnemonic = "CaCertsTarGz", inputs = [cacerts, copyright])

--- a/distroless/private/tar.bzl
+++ b/distroless/private/tar.bzl
@@ -15,7 +15,7 @@ DEFAULT_ARGS = [
     "--options=gzip:!timestamp",
 ]
 
-def _mtree_line(dest, type, content = None, uid = DEFAULT_UID, gid = DEFAULT_GID, time = DEFAULT_TIME, mode = DEFAULT_MODE):
+def _mtree_line(dest, type, content = None, link = None, uid = DEFAULT_UID, gid = DEFAULT_GID, time = DEFAULT_TIME, mode = DEFAULT_MODE):
     # mtree expects paths to start with ./ so normalize paths that starts with
     # `/` or relative path (without / and ./)
     if not dest.startswith("."):
@@ -33,6 +33,9 @@ def _mtree_line(dest, type, content = None, uid = DEFAULT_UID, gid = DEFAULT_GID
     ]
     if content:
         spec.append("content=" + content)
+    if link:
+        spec.append("link=" + link)
+
     return " ".join(spec)
 
 def _add_parents(path, uid = DEFAULT_UID, gid = DEFAULT_GID, time = DEFAULT_TIME, mode = DEFAULT_MODE, skip = []):
@@ -94,6 +97,7 @@ def _create_mtree(ctx = None):
     return struct(
         entry = lambda path, type, **kwargs: content.add(_mtree_line(path, type, **kwargs)),
         add_file = lambda path, file, **kwargs: content.add(_mtree_line(path, "file", content = file.path, **kwargs)),
+        add_link = lambda path, src, **kwargs: content.add(_mtree_line(path, "link", link = src, **kwargs)),
         add_dir = lambda path, **kwargs: content.add(_mtree_line(path, "dir", **kwargs)),
         add_parents = lambda path, **kwargs: content.add_all(_add_parents(path, **kwargs), uniquify = True),
         build = lambda **kwargs: _build_tar(ctx, _build_mtree(ctx, content), **kwargs),

--- a/examples/cacerts/BUILD.bazel
+++ b/examples/cacerts/BUILD.bazel
@@ -16,6 +16,7 @@ assert_tar_listing(
 ./etc/ssl/certs time=0.0 mode=755 gid=0 uid=0 type=dir
 ./etc/ssl/certs/ca-certificates.crt time=0.0 mode=555 gid=0 uid=0 type=file size=200313
 ./usr time=0.0 mode=755 gid=0 uid=0 type=dir
+./usr/lib/ssl/cert.pem time=0.0 mode=555 gid=0 uid=0 type=link link=/etc/ssl/certs/ca-certificates.crt
 ./usr/share time=0.0 mode=755 gid=0 uid=0 type=dir
 ./usr/share/doc time=0.0 mode=755 gid=0 uid=0 type=dir
 ./usr/share/doc/ca-certificates time=0.0 mode=755 gid=0 uid=0 type=dir

--- a/examples/debian_snapshot/BUILD.bazel
+++ b/examples/debian_snapshot/BUILD.bazel
@@ -63,6 +63,7 @@ PACKAGES = [
     "@bullseye//dpkg",
     "@bullseye//apt",
     "@bullseye//perl",
+    "@bullseye//openssl",
 ]
 
 # Creates /var/lib/dpkg/status with installed package information.

--- a/examples/debian_snapshot/test_linux_amd64.yaml
+++ b/examples/debian_snapshot/test_linux_amd64.yaml
@@ -25,3 +25,7 @@ commandTests:
     command: "head"
     args: ["-1", "/etc/ssl/certs/ca-certificates.crt"]
     expectedOutput: [-----BEGIN CERTIFICATE-----]
+  - name: "in depth ca-certs check"
+    command: "/usr/bin/openssl"
+    args: ["s_client", "-connect", "www.google.com:443"]
+    expectedOutput: ["Verify return code: 0 .ok."]

--- a/examples/debian_snapshot/test_linux_arm64.yaml
+++ b/examples/debian_snapshot/test_linux_arm64.yaml
@@ -25,3 +25,7 @@ commandTests:
     command: "head"
     args: ["-1", "/etc/ssl/certs/ca-certificates.crt"]
     expectedOutput: [-----BEGIN CERTIFICATE-----]
+  - name: "in depth ca-certs check"
+    command: "/usr/bin/openssl"
+    args: ["s_client", "-connect", "www.google.com:443"]
+    expectedOutput: ["Verify return code: 0 .ok."]


### PR DESCRIPTION

The existing `cacert()` implementation builds the single bundle of certs in
`/etc/ssl/certs/ca-certifates.crt`. This isn't read by default, and results in
a verification error:
```shell
r00t@9c80da3575a7:~# echo | openssl s_client -connect www.google.com:443 2>&1 | grep Verify
Verify return code: 20 (unable to get local issuer certificate)
```

The default path for the single cert bundle is `/usr/lib/ssl/cert.pem`
```shell
r00t@9c80da3575a7:~# ln -sf /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
r00t@9c80da3575a7:~# echo | openssl s_client -connect www.google.com:443 2>&1 | grep Verify
Verify return code: 0 (ok)
```

So ship that symlink as part of `cacert()`