### PR TITLE
fix: decompression fails with multiple apt.install calls

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.3")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.9")
 
 bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
 use_repo(bazel_lib_toolchains, "zstd_toolchains")


### PR DESCRIPTION
This fixes an issue where two calls in the same extension instance fails because bzlmod extensions share working directory per `use_extension` call.

This works;

```
apt = use_extension("@rules_distroless//apt:extensions.bzl", "apt")
apt.install(
    name = "bullseye",
    lock = ":bullseye.lock.json",
    manifest = ":bullseye.yaml",
)

apt2 = use_extension("@rules_distroless//apt:extensions.bzl", "apt")
apt2.install(
    name = "bullseye_nolock",
    lock = ":bullseye.lock.json",
    manifest = ":bullseye.yaml",
)
```

but this fails

```
apt = use_extension("@rules_distroless//apt:extensions.bzl", "apt")
apt.install(
    name = "bullseye",
    lock = ":bullseye.lock.json",
    manifest = ":bullseye.yaml",
)
apt.install(
    name = "bullseye_nolock",
    # lock = ":bullseye.lock.json",
    manifest = ":bullseye.yaml",
)
```

