### PR TITLE
fix `dpkg` complaining about missing files list

### DIFF
--- a/apt/defs.bzl
+++ b/apt/defs.bzl
@@ -2,6 +2,9 @@
 
 load("//apt/private:dpkg_status.bzl", _dpkg_status = "dpkg_status")
 load("//apt/private:dpkg_statusd.bzl", _dpkg_statusd = "dpkg_statusd")
+load("//apt/private:dpkg_info.bzl", _dpkg_info = "dpkg_info")
 
 dpkg_status = _dpkg_status
 dpkg_statusd = _dpkg_statusd
+dpkg_info = _dpkg_info
+

--- a/apt/private/BUILD.bazel
+++ b/apt/private/BUILD.bazel
@@ -3,6 +3,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 exports_files([
     "dpkg_statusd.sh",
     "dpkg_status.sh",
+    "dpkg_info.sh",
     "package.BUILD.tmpl",
 ])
 

--- a/apt/private/dpkg_info.bzl
+++ b/apt/private/dpkg_info.bzl
@@ -1,0 +1,59 @@
+"dpkg_info"
+
+# buildifier: disable=bzl-visibility
+load("//distroless/private:tar.bzl", "tar_lib")
+
+_DOC = """TODO: docs"""
+
+def _dpkg_info_impl(ctx):
+    bsdtar = ctx.toolchains[tar_lib.TOOLCHAIN_TYPE]
+
+    ext = tar_lib.common.compression_to_extension[ctx.attr.compression] if ctx.attr.compression else ".tar"
+    output = ctx.actions.declare_file(ctx.attr.name + ext)
+
+    args = ctx.actions.args()
+    args.add(bsdtar.tarinfo.binary)
+    args.add(output)
+    args.add(ctx.file.control)
+    args.add(ctx.file.data)
+    args.add(ctx.attr.package_name)
+    tar_lib.common.add_compression_args(ctx.attr.compression, args)
+
+    ctx.actions.run(
+        executable = ctx.executable._dpkg_info_sh,
+        inputs = [ctx.file.control, ctx.file.data],
+        outputs = [output],
+        tools = bsdtar.default.files,
+        arguments = [args],
+    )
+
+    return [
+        DefaultInfo(files = depset([output])),
+    ]
+
+dpkg_info = rule(
+    doc = _DOC,
+    attrs = {
+        "_dpkg_info_sh": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+            default = ":dpkg_info.sh",
+        ),
+        "package_name": attr.string(mandatory = True),
+        "control": attr.label(
+            allow_single_file = [".tar.zst", ".tar.xz", ".tar.gz", ".tar"],
+            mandatory = True,
+        ),
+        "data": attr.label(
+            allow_single_file = [".tar.zst", ".tar.xz", ".tar.gz", ".tar"],
+            mandatory = True,
+        ),
+        "compression": attr.string(
+            doc = "Compress the archive file with a supported algorithm.",
+            values = tar_lib.common.accepted_compression_types,
+        ),
+    },
+    implementation = _dpkg_info_impl,
+    toolchains = [tar_lib.TOOLCHAIN_TYPE],
+)

--- a/apt/private/dpkg_info.sh
+++ b/apt/private/dpkg_info.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -o pipefail -o errexit -o nounset
+
+readonly bsdtar="$1"
+readonly out="$2"
+readonly control_path="$3"
+readonly data_path="$4"
+readonly package_name="$5"
+shift 5
+
+tmp=$(mktemp -d)
+"$bsdtar" -xf "$control_path" -C "$tmp"
+
+tmp2=$(mktemp -d)
+"$bsdtar" -xf "$data_path" -C "$tmp2"
+
+tmpfile=$(mktemp)
+find "$tmp2" -type f | sed "s|^$tmp2/||" >> "$tmpfile"
+
+# if the package is Multi-Arch: same, we need to append the architecture to the package name
+control_file="$tmp/control"
+package_name_with_arch=$(cat "$control_file" | while read -r line; do
+  multi_arch_same=0
+  arch=""
+  while read -r line; do
+    if [[ "$line" =~ ^Multi-Arch:\ same ]]; then
+      multi_arch_same=1
+    fi
+    if [[ "$line" =~ ^Architecture: ]]; then
+      arch=$(echo "$line" | cut -d' ' -f2)
+    fi
+  done < "$control_file"
+  if [[ $multi_arch_same -eq 1 && -n $arch ]]; then
+    echo "$package_name:$arch"
+  else
+    echo "$package_name"
+  fi
+done | tail -n1)
+
+"$bsdtar" -cf - $@ --format=mtree --options '!gname,!uname,!sha1,!nlink,!time' "@$control_path" | \
+awk -v pkg="$package_name_with_arch" -v tmpfile="$tmpfile" '{
+    if ($1=="#mtree") {
+        print $1; next
+    };
+    # strip leading ./ prefix
+    sub(/^\.?\//, "", $1);
+    if ($1==".") {
+      next
+    }
+    if ($1 ~ /^control/) {
+        $1 = "./var/lib/dpkg/info/" pkg ".list contents=" tmpfile;
+    } else if ($1 ~ /^md5sums/) {
+        $1 = "./var/lib/dpkg/info/" pkg ".md5sums contents=./" $1;
+    } else {
+        $1 = "./var/lib/dpkg/info/" pkg "." $1 " contents=./" $1;
+    }
+    print $0
+}' | "$bsdtar" $@ -cf "$out" -C "$tmp/" @-

--- a/examples/info/BUILD.bazel
+++ b/examples/info/BUILD.bazel
@@ -1,0 +1,30 @@
+# buildifier: disable=bzl-visibility
+load("//apt:defs.bzl", "dpkg_info")
+load("//distroless/tests:asserts.bzl", "assert_tar_listing")
+
+dpkg_info(
+    name = "info",
+    package_name = "bash",
+    control = select({
+        "@platforms//cpu:x86_64": "@noble//bash/amd64:control",
+        "@platforms//cpu:arm64": "@noble//bash/arm64:control",
+    }),
+    data = select({
+        "@platforms//cpu:x86_64": "@noble//bash/amd64:data",
+        "@platforms//cpu:arm64": "@noble//bash/arm64:data",
+    }),
+)
+
+assert_tar_listing(
+    name = "test_info",
+    actual = "info",
+    expected = """\
+#mtree
+./var/lib/dpkg/info/bash.conffiles time=1708597860.0 mode=644 gid=0 uid=0 type=file size=77
+./var/lib/dpkg/info/bash.list time=1723312842.0 mode=644 gid=0 uid=0 type=file size=758
+./var/lib/dpkg/info/bash.md5sums time=1708597860.0 mode=644 gid=0 uid=0 type=file size=1467
+./var/lib/dpkg/info/bash.postinst time=1708597860.0 mode=755 gid=0 uid=0 type=file size=491
+./var/lib/dpkg/info/bash.postrm time=1708597860.0 mode=755 gid=0 uid=0 type=file size=214
+./var/lib/dpkg/info/bash.prerm time=1708597860.0 mode=755 gid=0 uid=0 type=file size=289
+""",
+)


### PR DESCRIPTION
`dpkg` looks into `/var/lib/dpkg/info` and checks for the files list in a file for a package. So, when adding packages through `apt-get install` after container startup, `dpkg` complains `dpkg: warning: files list file for package '<package_name>' missing; assuming package has no files currently installed `. This warning can be ignored, but this tries to solve it by adding required files in the `/var/lib/dpkg/info` directory.