### PR TITLE
Made package index support plaintext

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -614,6 +614,85 @@
       }
     },
     "@@rules_go~//go:extensions.bzl%go_sdk": {
+      "os:linux,arch:amd64": {
+        "bzlTransitiveDigest": "1FAEgzKYvwFeqd0f6LvoXqv46TyKLJMhFoz7n3mpeCY=",
+        "usagesDigest": "864CtSd+x2XUxKD4A3qQ0jTz9t8kXyZV8Mjn+EQeJhQ=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "go_default_sdk": {
+            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
+            "ruleClassName": "go_download_sdk_rule",
+            "attributes": {
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "experiments": [],
+              "patches": [],
+              "patch_strip": 0,
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.21.1",
+              "strip_prefix": "go"
+            }
+          },
+          "go_host_compatible_sdk_label": {
+            "bzlFile": "@@rules_go~//go/private:extensions.bzl",
+            "ruleClassName": "host_compatible_toolchain",
+            "attributes": {
+              "toolchain": "@go_default_sdk//:ROOT"
+            }
+          },
+          "go_toolchains": {
+            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
+            "ruleClassName": "go_multiple_toolchains",
+            "attributes": {
+              "prefixes": [
+                "_0000_go_default_sdk_"
+              ],
+              "geese": [
+                ""
+              ],
+              "goarchs": [
+                ""
+              ],
+              "sdk_repos": [
+                "go_default_sdk"
+              ],
+              "sdk_types": [
+                "remote"
+              ],
+              "sdk_versions": [
+                "1.21.1"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features~",
+            "bazel_features_globals",
+            "bazel_features~~version_extension~bazel_features_globals"
+          ],
+          [
+            "bazel_features~",
+            "bazel_features_version",
+            "bazel_features~~version_extension~bazel_features_version"
+          ],
+          [
+            "rules_go~",
+            "bazel_features",
+            "bazel_features~"
+          ],
+          [
+            "rules_go~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      },
       "os:osx,arch:aarch64": {
         "bzlTransitiveDigest": "1FAEgzKYvwFeqd0f6LvoXqv46TyKLJMhFoz7n3mpeCY=",
         "usagesDigest": "864CtSd+x2XUxKD4A3qQ0jTz9t8kXyZV8Mjn+EQeJhQ=",

--- a/apt/private/deb_import.bzl
+++ b/apt/private/deb_import.bzl
@@ -9,7 +9,10 @@ _RECOMPRESS_CMD = "$(ZSTD_BIN) -f --decompress $< --stdout | $(ZSTD_BIN) - --for
 genrule(
     name = "data",
     srcs = glob(["data.tar.*"]),
-    outs = ["data.tar.gz"],
+    # recompress to a different output name (i.e. not 'data.tar.gz')
+    # because in the case of no extension, we would have data.tar.gz
+    # in both input and output.
+    outs = ["out.tar.gz"], 
     cmd = _RECOMPRESS_CMD,
     toolchains = ["@zstd_toolchains//:resolved_toolchain"],
     visibility = ["//visibility:public"],

--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -65,6 +65,10 @@ PACKAGES = [
     "@bullseye//perl",
 ]
 
+AMD_PACKAGES = PACKAGES + [
+    "@amd_only//bazel",
+]
+
 # Creates /var/lib/dpkg/status with installed package information.
 dpkg_status(
     name = "dpkg_status",
@@ -75,7 +79,7 @@ dpkg_status(
         ],
         "@platforms//cpu:x86_64": [
             "%s/amd64:control" % package
-            for package in PACKAGES
+            for package in AMD_PACKAGES
         ],
     }),
 )
@@ -100,7 +104,7 @@ oci_image(
         ],
         "@platforms//cpu:x86_64": [
             "%s/amd64" % package
-            for package in PACKAGES
+            for package in AMD_PACKAGES
         ],
     }),
 )

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -22,5 +22,13 @@ apt.install(
     manifest = ":bullseye.yaml",
 )
 
-# bazel run @bullseye//:lock
-use_repo(apt, "bullseye", "bullseye_nolock")
+# This is used for testing no extension # package indexes; one example is bazel,
+# but bazel does not support arm, so we need # an apt repo that is _only_ amd.
+apt.install(
+    name = "amd_only",
+    lock = ":amd_only.lock.json",
+    manifest = ":amd_only.yaml",
+)
+
+# bazel run @{bullseye, amd_only}//:lock
+use_repo(apt, "bullseye", "bullseye_nolock", "amd_only")

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -22,8 +22,6 @@ apt.install(
     manifest = ":bullseye.yaml",
 )
 
-# This is used for testing no extension # package indexes; one example is bazel,
-# but bazel does not support arm, so we need # an apt repo that is _only_ amd.
 apt.install(
     name = "amd_only",
     lock = ":amd_only.lock.json",

--- a/e2e/smoke/amd_only.lock.json
+++ b/e2e/smoke/amd_only.lock.json
@@ -1,0 +1,14 @@
+{
+	"packages": [
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "bazel_7.3.1_amd64",
+			"name": "bazel",
+			"sha256": "4b0480abd08fd30e615666d6d8dfe349f0f6764f7e39c036c8a0036bd4d81ce1",
+			"url": "https://storage.googleapis.com/bazel-apt/pool/jdk1.8/b/bazel/bazel_7.3.1_amd64.deb",
+			"version": "7.3.1"
+		}
+	],
+	"version": 1
+}

--- a/e2e/smoke/amd_only.yaml
+++ b/e2e/smoke/amd_only.yaml
@@ -1,0 +1,12 @@
+# To generate the amd_only.lock.json run: bazel run @amd_only//:lock
+version: 1
+
+sources:
+  - channel: stable jdk1.8
+    url: https://storage.googleapis.com/bazel-apt
+
+archs:
+  - "amd64"
+
+packages:
+  - "bazel"

--- a/e2e/smoke/test_linux_amd64.yaml
+++ b/e2e/smoke/test_linux_amd64.yaml
@@ -12,6 +12,7 @@ commandTests:
       - Listing\.\.\.
       - apt/now 2\.2\.4 amd64 \[installed,local\]
       - bash/now 5\.1-2\+deb11u1 amd64 \[installed,local\]
+      - bazel/now 7\.3\.1 amd64 \[installed,local\]
       - coreutils/now 8\.32-4\+b1 amd64 \[installed,local\]
       - dpkg/now 1\.20\.13 amd64 \[installed,local\]
       - libncurses6/now 6\.2\+20201114-2\+deb11u2 amd64 \[installed,local\]


### PR DESCRIPTION
This is useful for something like https://storage.googleapis.com/bazel-apt/, which (edit: used to!) only supports plaintext.


Change-Id: Ic3698c5e281b24a6017c034c164b657d1076a11e