### PR TITLE
fix: target_compatible_with excluding arm64

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -96,6 +96,34 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "PjIds3feoYE8SGbbIq2SFTZy3zmxeO2tQevJZNDo7iY=",
+        "usagesDigest": "aLmqbvowmHkkBPve05yyDNGN7oh7QE9kBADr3QIZTZs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_config_apple_cc": {
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf",
+            "attributes": {}
+          },
+          "local_config_apple_cc_toolchains": {
+            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
+            "ruleClassName": "_apple_cc_autoconf_toolchains",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "apple_support~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@aspect_bazel_lib~//lib:extensions.bzl%toolchains": {
       "general": {
         "bzlTransitiveDigest": "jl6upvbQ+op05W1a3gE6bja6dc7fvsNfslO0m46Ma3s=",
@@ -563,6 +591,563 @@
         ]
       }
     },
+    "@@buildifier_prebuilt~//:defs.bzl%buildifier_prebuilt_deps_extension": {
+      "general": {
+        "bzlTransitiveDigest": "cnU/K9IY/VeHcxnGaL5eLuX+z8qIjt0yUjs2dZfB3Rc=",
+        "usagesDigest": "dJKWOSZZDy7RHc2XG1O6ezkxcNMSeKBpUqAz2pk8cbY=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "buildozer_darwin_amd64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildozer-darwin-amd64"
+              ],
+              "downloaded_file_path": "buildozer",
+              "executable": true,
+              "sha256": "4014751a4cc5e91a7dc4b64be7b30c565bd9014ae6d1879818dc624562a1d431"
+            }
+          },
+          "buildifier_linux_amd64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildifier-linux-amd64"
+              ],
+              "downloaded_file_path": "buildifier",
+              "executable": true,
+              "sha256": "51bc947dabb7b14ec6fb1224464fbcf7a7cb138f1a10a3b328f00835f72852ce"
+            }
+          },
+          "buildozer_darwin_arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildozer-darwin-arm64"
+              ],
+              "downloaded_file_path": "buildozer",
+              "executable": true,
+              "sha256": "e78bd5357f2356067d4b0d49ec4e4143dd9b1308746afc6ff11b55b952f462d7"
+            }
+          },
+          "buildozer_linux_amd64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildozer-linux-amd64"
+              ],
+              "downloaded_file_path": "buildozer",
+              "executable": true,
+              "sha256": "2aef0f1ef80a0140b8fe6e6a8eb822e14827d8855bfc6681532c7530339ea23b"
+            }
+          },
+          "buildozer_windows_amd64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildozer-windows-amd64.exe"
+              ],
+              "downloaded_file_path": "buildozer.exe",
+              "executable": true,
+              "sha256": "07664d5d08ee099f069cd654070cabf2708efaae9f52dc83921fa400c67a868b"
+            }
+          },
+          "buildozer_linux_arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildozer-linux-arm64"
+              ],
+              "downloaded_file_path": "buildozer",
+              "executable": true,
+              "sha256": "586e27630cbc242e8bd6fe8e24485eca8dcadea6410cc13cbe059202655980ac"
+            }
+          },
+          "buildifier_windows_amd64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildifier-windows-amd64.exe"
+              ],
+              "downloaded_file_path": "buildifier.exe",
+              "executable": true,
+              "sha256": "92bdd284fbc6766fc3e300b434ff9e68ac4d76a06cb29d1bdefe79a102a8d135"
+            }
+          },
+          "buildifier_prebuilt_toolchains": {
+            "bzlFile": "@@buildifier_prebuilt~//:defs.bzl",
+            "ruleClassName": "_buildifier_toolchain_setup",
+            "attributes": {
+              "assets_json": "[{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"darwin\",\"sha256\":\"e2f4a67691c5f55634fbfb3850eb97dd91be0edd059d947b6c83d120682e0216\",\"version\":\"v6.1.2\"},{\"arch\":\"arm64\",\"name\":\"buildifier\",\"platform\":\"darwin\",\"sha256\":\"7549b5f535219ac957aa2a6069d46fbfc9ea3f74abd85fd3d460af4b1a2099a6\",\"version\":\"v6.1.2\"},{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"linux\",\"sha256\":\"51bc947dabb7b14ec6fb1224464fbcf7a7cb138f1a10a3b328f00835f72852ce\",\"version\":\"v6.1.2\"},{\"arch\":\"arm64\",\"name\":\"buildifier\",\"platform\":\"linux\",\"sha256\":\"0ba6e8e3208b5a029164e542ddb5509e618f87b639ffe8cc2f54770022853080\",\"version\":\"v6.1.2\"},{\"arch\":\"amd64\",\"name\":\"buildifier\",\"platform\":\"windows\",\"sha256\":\"92bdd284fbc6766fc3e300b434ff9e68ac4d76a06cb29d1bdefe79a102a8d135\",\"version\":\"v6.1.2\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"darwin\",\"sha256\":\"4014751a4cc5e91a7dc4b64be7b30c565bd9014ae6d1879818dc624562a1d431\",\"version\":\"v6.1.2\"},{\"arch\":\"arm64\",\"name\":\"buildozer\",\"platform\":\"darwin\",\"sha256\":\"e78bd5357f2356067d4b0d49ec4e4143dd9b1308746afc6ff11b55b952f462d7\",\"version\":\"v6.1.2\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"linux\",\"sha256\":\"2aef0f1ef80a0140b8fe6e6a8eb822e14827d8855bfc6681532c7530339ea23b\",\"version\":\"v6.1.2\"},{\"arch\":\"arm64\",\"name\":\"buildozer\",\"platform\":\"linux\",\"sha256\":\"586e27630cbc242e8bd6fe8e24485eca8dcadea6410cc13cbe059202655980ac\",\"version\":\"v6.1.2\"},{\"arch\":\"amd64\",\"name\":\"buildozer\",\"platform\":\"windows\",\"sha256\":\"07664d5d08ee099f069cd654070cabf2708efaae9f52dc83921fa400c67a868b\",\"version\":\"v6.1.2\"}]"
+            }
+          },
+          "buildifier_darwin_amd64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildifier-darwin-amd64"
+              ],
+              "downloaded_file_path": "buildifier",
+              "executable": true,
+              "sha256": "e2f4a67691c5f55634fbfb3850eb97dd91be0edd059d947b6c83d120682e0216"
+            }
+          },
+          "buildifier_darwin_arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildifier-darwin-arm64"
+              ],
+              "downloaded_file_path": "buildifier",
+              "executable": true,
+              "sha256": "7549b5f535219ac957aa2a6069d46fbfc9ea3f74abd85fd3d460af4b1a2099a6"
+            }
+          },
+          "buildifier_linux_arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v6.1.2/buildifier-linux-arm64"
+              ],
+              "downloaded_file_path": "buildifier",
+              "executable": true,
+              "sha256": "0ba6e8e3208b5a029164e542ddb5509e618f87b639ffe8cc2f54770022853080"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "buildifier_prebuilt~",
+            "bazel_skylib",
+            "bazel_skylib~"
+          ],
+          [
+            "buildifier_prebuilt~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@container_structure_test~//:repositories.bzl%extension": {
+      "general": {
+        "bzlTransitiveDigest": "/vl5vOyGN/nxHtUF3SxoDZnTDgDklt4HUpLQD5LE8+k=",
+        "usagesDigest": "YdEtAZuD+ZoX8k+fE/G6hwtEZQPYIYtZ8COmBRHB4Xo=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "structure_test_st_linux_i386": {
+            "bzlFile": "@@container_structure_test~//:repositories.bzl",
+            "ruleClassName": "structure_test_repositories",
+            "attributes": {
+              "platform": "linux_i386"
+            }
+          },
+          "structure_test_st_linux_s390x": {
+            "bzlFile": "@@container_structure_test~//:repositories.bzl",
+            "ruleClassName": "structure_test_repositories",
+            "attributes": {
+              "platform": "linux_s390x"
+            }
+          },
+          "structure_test_st_linux_amd64": {
+            "bzlFile": "@@container_structure_test~//:repositories.bzl",
+            "ruleClassName": "structure_test_repositories",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "structure_test_st_darwin_arm64": {
+            "bzlFile": "@@container_structure_test~//:repositories.bzl",
+            "ruleClassName": "structure_test_repositories",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "structure_test_st_windows_amd64": {
+            "bzlFile": "@@container_structure_test~//:repositories.bzl",
+            "ruleClassName": "structure_test_repositories",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "structure_test_st_darwin_amd64": {
+            "bzlFile": "@@container_structure_test~//:repositories.bzl",
+            "ruleClassName": "structure_test_repositories",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "structure_test_toolchains": {
+            "bzlFile": "@@container_structure_test~//bazel:toolchains_repo.bzl",
+            "ruleClassName": "toolchains_repo",
+            "attributes": {
+              "toolchain_type": "@container_structure_test//bazel:structure_test_toolchain_type",
+              "toolchain": "@structure_test_st_{platform}//:structure_test_toolchain"
+            }
+          },
+          "structure_test_st_linux_arm64": {
+            "bzlFile": "@@container_structure_test~//:repositories.bzl",
+            "ruleClassName": "structure_test_repositories",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@gazelle~//:extensions.bzl%go_deps": {
+      "general": {
+        "bzlTransitiveDigest": "Taobh9Bi1JpF4jHwuw6x9ceWDpHtCjGmS8VXbxLOqH8=",
+        "usagesDigest": "OF7bvO+xWblkUXgQsIPSIr048t6z7ZKSjlR8twO/efg=",
+        "recordedFileInputs": {
+          "@@rules_go~//go.mod": "a7143f329c2a3e0b983ce74a96c0c25b0d0c59d236d75f7e1b069aadd988d55e",
+          "@@gazelle~//go.sum": "7469786f3930030c430969cedae951e6947cb40f4a563dac94a350659c0fedc4",
+          "@@rules_go~//go.sum": "022d36c9ebcc7b5dee1e9b85b3da9c9f3a529ee6f979946d66e4955b8d54614a",
+          "@@gazelle~//go.mod": "9ae159a385b2f244bbe964b9f91dbea6e7bd534e0b22e846655f241c65de2c49"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "org_golang_x_tools_go_vcs": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/tools/go/vcs",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:cOIJqWBl99H1dH5LWizPa+0ImeeJq3t3cJjaeOWUAL4=",
+              "replace": "",
+              "version": "v0.1.0-deprecated"
+            }
+          },
+          "com_github_fsnotify_fsnotify": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "github.com/fsnotify/fsnotify",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=",
+              "replace": "",
+              "version": "v1.7.0"
+            }
+          },
+          "org_golang_x_text": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/text",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=",
+              "replace": "",
+              "version": "v0.3.3"
+            }
+          },
+          "com_github_bmatcuk_doublestar_v4": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "github.com/bmatcuk/doublestar/v4",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=",
+              "replace": "",
+              "version": "v4.6.1"
+            }
+          },
+          "com_github_pmezard_go_difflib": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "github.com/pmezard/go-difflib",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=",
+              "replace": "",
+              "version": "v1.0.0"
+            }
+          },
+          "org_golang_google_protobuf": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "google.golang.org/protobuf",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=",
+              "replace": "",
+              "version": "v1.28.0"
+            }
+          },
+          "org_golang_x_mod": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/mod",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=",
+              "replace": "",
+              "version": "v0.13.0"
+            }
+          },
+          "org_golang_x_tools": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/tools",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=",
+              "replace": "",
+              "version": "v0.13.0"
+            }
+          },
+          "com_github_bazelbuild_buildtools": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "github.com/bazelbuild/buildtools",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:VUHCI4QRifAGYsbVJYqJndLf7YqV12YthB+PLFsEKqo=",
+              "replace": "",
+              "version": "v0.0.0-20231017121127-23aa65d4e117"
+            }
+          },
+          "org_golang_x_net": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/net",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=",
+              "replace": "",
+              "version": "v0.0.0-20210405180319-a5a99cb37ef4"
+            }
+          },
+          "org_golang_google_genproto": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "google.golang.org/genproto",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=",
+              "replace": "",
+              "version": "v0.0.0-20200526211855-cb27e3aa2013"
+            }
+          },
+          "com_github_gogo_protobuf": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "github.com/gogo/protobuf",
+              "build_directives": [
+                "gazelle:proto disable"
+              ],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=",
+              "replace": "",
+              "version": "v1.3.2"
+            }
+          },
+          "com_github_golang_protobuf": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "github.com/golang/protobuf",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=",
+              "replace": "",
+              "version": "v1.5.2"
+            }
+          },
+          "org_golang_x_sync": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/sync",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=",
+              "replace": "",
+              "version": "v0.4.0"
+            }
+          },
+          "com_github_golang_mock": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "github.com/golang/mock",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=",
+              "replace": "",
+              "version": "v1.6.0"
+            }
+          },
+          "bazel_gazelle_go_repository_config": {
+            "bzlFile": "@@gazelle~//internal/bzlmod:go_deps.bzl",
+            "ruleClassName": "_go_repository_config",
+            "attributes": {
+              "importpaths": {
+                "org_golang_x_tools": "golang.org/x/tools",
+                "com_github_bazelbuild_buildtools": "github.com/bazelbuild/buildtools",
+                "@rules_go~": "github.com/bazelbuild/rules_go",
+                "com_github_bmatcuk_doublestar_v4": "github.com/bmatcuk/doublestar/v4",
+                "com_github_fsnotify_fsnotify": "github.com/fsnotify/fsnotify",
+                "com_github_google_go_cmp": "github.com/google/go-cmp",
+                "com_github_pmezard_go_difflib": "github.com/pmezard/go-difflib",
+                "org_golang_x_mod": "golang.org/x/mod",
+                "org_golang_x_sync": "golang.org/x/sync",
+                "org_golang_x_tools_go_vcs": "golang.org/x/tools/go/vcs",
+                "org_golang_x_sys": "golang.org/x/sys",
+                "com_github_gogo_protobuf": "github.com/gogo/protobuf",
+                "com_github_golang_mock": "github.com/golang/mock",
+                "com_github_golang_protobuf": "github.com/golang/protobuf",
+                "org_golang_google_protobuf": "google.golang.org/protobuf",
+                "org_golang_x_net": "golang.org/x/net",
+                "org_golang_x_text": "golang.org/x/text",
+                "org_golang_google_genproto": "google.golang.org/genproto",
+                "org_golang_google_grpc": "google.golang.org/grpc",
+                "@gazelle~": "github.com/bazelbuild/bazel-gazelle"
+              },
+              "module_names": {
+                "@gazelle~": "gazelle",
+                "@rules_go~": "rules_go"
+              },
+              "build_naming_conventions": {}
+            }
+          },
+          "org_golang_google_grpc": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "google.golang.org/grpc",
+              "build_directives": [
+                "gazelle:proto disable"
+              ],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:fPVVDxY9w++VjTZsYvXWqEf9Rqar/e+9zYfxKK+W+YU=",
+              "replace": "",
+              "version": "v1.50.0"
+            }
+          },
+          "org_golang_x_sys": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "golang.org/x/sys",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=",
+              "replace": "",
+              "version": "v0.13.0"
+            }
+          },
+          "com_github_google_go_cmp": {
+            "bzlFile": "@@gazelle~//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "importpath": "github.com/google/go-cmp",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=",
+              "replace": "",
+              "version": "v0.6.0"
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "bazel_gazelle_go_repository_config"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "gazelle~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@gazelle~//internal/bzlmod:non_module_deps.bzl%non_module_deps": {
       "general": {
         "bzlTransitiveDigest": "AjbsH9WZCj0ipLarbbkp25YBRrRhWYvO7OIiTcHyyok=",
@@ -613,7 +1198,182 @@
         ]
       }
     },
+    "@@platforms//host:extension.bzl%host_platform": {
+      "general": {
+        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
+        "usagesDigest": "V1R2Y2oMxKNfx2WCWpSCaUV1WefW1o8HZGm3v1vHgY4=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "host_platform": {
+            "bzlFile": "@@platforms//host:extension.bzl",
+            "ruleClassName": "host_platform_repo",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@rules_go~//go:extensions.bzl%go_sdk": {
+      "os:linux,arch:aarch64": {
+        "bzlTransitiveDigest": "1FAEgzKYvwFeqd0f6LvoXqv46TyKLJMhFoz7n3mpeCY=",
+        "usagesDigest": "864CtSd+x2XUxKD4A3qQ0jTz9t8kXyZV8Mjn+EQeJhQ=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "go_default_sdk": {
+            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
+            "ruleClassName": "go_download_sdk_rule",
+            "attributes": {
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "experiments": [],
+              "patches": [],
+              "patch_strip": 0,
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.21.1",
+              "strip_prefix": "go"
+            }
+          },
+          "go_host_compatible_sdk_label": {
+            "bzlFile": "@@rules_go~//go/private:extensions.bzl",
+            "ruleClassName": "host_compatible_toolchain",
+            "attributes": {
+              "toolchain": "@go_default_sdk//:ROOT"
+            }
+          },
+          "go_toolchains": {
+            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
+            "ruleClassName": "go_multiple_toolchains",
+            "attributes": {
+              "prefixes": [
+                "_0000_go_default_sdk_"
+              ],
+              "geese": [
+                ""
+              ],
+              "goarchs": [
+                ""
+              ],
+              "sdk_repos": [
+                "go_default_sdk"
+              ],
+              "sdk_types": [
+                "remote"
+              ],
+              "sdk_versions": [
+                "1.21.1"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features~",
+            "bazel_features_globals",
+            "bazel_features~~version_extension~bazel_features_globals"
+          ],
+          [
+            "bazel_features~",
+            "bazel_features_version",
+            "bazel_features~~version_extension~bazel_features_version"
+          ],
+          [
+            "rules_go~",
+            "bazel_features",
+            "bazel_features~"
+          ],
+          [
+            "rules_go~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      },
+      "os:linux,arch:amd64": {
+        "bzlTransitiveDigest": "1FAEgzKYvwFeqd0f6LvoXqv46TyKLJMhFoz7n3mpeCY=",
+        "usagesDigest": "864CtSd+x2XUxKD4A3qQ0jTz9t8kXyZV8Mjn+EQeJhQ=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "go_default_sdk": {
+            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
+            "ruleClassName": "go_download_sdk_rule",
+            "attributes": {
+              "goos": "",
+              "goarch": "",
+              "sdks": {},
+              "experiments": [],
+              "patches": [],
+              "patch_strip": 0,
+              "urls": [
+                "https://dl.google.com/go/{}"
+              ],
+              "version": "1.21.1",
+              "strip_prefix": "go"
+            }
+          },
+          "go_host_compatible_sdk_label": {
+            "bzlFile": "@@rules_go~//go/private:extensions.bzl",
+            "ruleClassName": "host_compatible_toolchain",
+            "attributes": {
+              "toolchain": "@go_default_sdk//:ROOT"
+            }
+          },
+          "go_toolchains": {
+            "bzlFile": "@@rules_go~//go/private:sdk.bzl",
+            "ruleClassName": "go_multiple_toolchains",
+            "attributes": {
+              "prefixes": [
+                "_0000_go_default_sdk_"
+              ],
+              "geese": [
+                ""
+              ],
+              "goarchs": [
+                ""
+              ],
+              "sdk_repos": [
+                "go_default_sdk"
+              ],
+              "sdk_types": [
+                "remote"
+              ],
+              "sdk_versions": [
+                "1.21.1"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features~",
+            "bazel_features_globals",
+            "bazel_features~~version_extension~bazel_features_globals"
+          ],
+          [
+            "bazel_features~",
+            "bazel_features_version",
+            "bazel_features~~version_extension~bazel_features_version"
+          ],
+          [
+            "rules_go~",
+            "bazel_features",
+            "bazel_features~"
+          ],
+          [
+            "rules_go~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      },
       "os:osx,arch:aarch64": {
         "bzlTransitiveDigest": "1FAEgzKYvwFeqd0f6LvoXqv46TyKLJMhFoz7n3mpeCY=",
         "usagesDigest": "864CtSd+x2XUxKD4A3qQ0jTz9t8kXyZV8Mjn+EQeJhQ=",
@@ -690,6 +1450,685 @@
             "rules_go~",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_go~//go/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "ByGfNZen1XVBfBvNCl9yi0nJbZErpBpwk6lBI4/r1oo=",
+        "usagesDigest": "/do8Y+NJBDFlPQnWT6iFp1oDtxSM0mUABzn2rLM2hys=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "org_golang_x_tools_go_vcs": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/go/vcs/v0.1.0-deprecated.zip",
+                "https://github.com/golang/tools/archive/refs/tags/go/vcs/v0.1.0-deprecated.zip"
+              ],
+              "sha256": "1b389268d126467105305ae4482df0189cc80a13aaab28d0946192b4ad0737a8",
+              "strip_prefix": "tools-go-vcs-v0.1.0-deprecated/go/vcs",
+              "patches": [
+                "@@rules_go~//third_party:org_golang_x_tools_go_vcs-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "org_golang_x_xerrors": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/xerrors/archive/04be3eba64a22a838cdb17b8dca15a52871c08b4.zip",
+                "https://github.com/golang/xerrors/archive/04be3eba64a22a838cdb17b8dca15a52871c08b4.zip"
+              ],
+              "sha256": "ffad2b06ef2e09d040da2ff08077865e99ab95d4d0451737fc8e33706bb01634",
+              "strip_prefix": "xerrors-04be3eba64a22a838cdb17b8dca15a52871c08b4",
+              "patches": [
+                "@@rules_go~//third_party:org_golang_x_xerrors-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "gogo_special_proto": {
+            "bzlFile": "@@rules_go~//proto:gogo.bzl",
+            "ruleClassName": "gogo_special_proto",
+            "attributes": {}
+          },
+          "org_golang_google_protobuf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "f5d1f6d0e9b836aceb715f1df2dc065083a55b07ecec3b01b5e89d039b14da02",
+              "urls": [
+                "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.31.0.zip",
+                "https://github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.31.0.zip"
+              ],
+              "strip_prefix": "protobuf-go-1.31.0",
+              "patches": [
+                "@@rules_go~//third_party:org_golang_google_protobuf-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "com_github_mwitkow_go_proto_validators": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/mwitkow/go-proto-validators/archive/refs/tags/v0.3.2.zip",
+                "https://github.com/mwitkow/go-proto-validators/archive/refs/tags/v0.3.2.zip"
+              ],
+              "sha256": "d8697f05a2f0eaeb65261b480e1e6035301892d9fc07ed945622f41b12a68142",
+              "strip_prefix": "go-proto-validators-0.3.2"
+            }
+          },
+          "org_golang_x_tools": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/tools/archive/refs/tags/v0.7.0.zip",
+                "https://github.com/golang/tools/archive/refs/tags/v0.7.0.zip"
+              ],
+              "sha256": "9f20a20f29f4008d797a8be882ef82b69cf8f7f2b96dbdfe3814c57d8280fa4b",
+              "strip_prefix": "tools-0.7.0",
+              "patches": [
+                "@@rules_go~//third_party:org_golang_x_tools-deletegopls.patch",
+                "@@rules_go~//third_party:org_golang_x_tools-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "org_golang_google_genproto": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/007df8e322eb3e384d36c0821e2337825c203ca6.zip",
+                "https://github.com/googleapis/go-genproto/archive/007df8e322eb3e384d36c0821e2337825c203ca6.zip"
+              ],
+              "sha256": "e7d0f3faed86258ed4e8e5527a8e98ff00fbd5b1a9b379a99a4aa2f76ce8bbcc",
+              "strip_prefix": "go-genproto-007df8e322eb3e384d36c0821e2337825c203ca6",
+              "patches": [
+                "@@rules_go~//third_party:org_golang_google_genproto-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "bazel_skylib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"
+              ],
+              "sha256": "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+              "strip_prefix": ""
+            }
+          },
+          "com_github_gogo_protobuf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip",
+                "https://github.com/gogo/protobuf/archive/refs/tags/v1.3.2.zip"
+              ],
+              "sha256": "f89f8241af909ce3226562d135c25b28e656ae173337b3e58ede917aa26e1e3c",
+              "strip_prefix": "protobuf-1.3.2",
+              "patches": [
+                "@@rules_go~//third_party:com_github_gogo_protobuf-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "com_github_golang_protobuf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip",
+                "https://github.com/golang/protobuf/archive/refs/tags/v1.5.3.zip"
+              ],
+              "sha256": "2dced4544ae5372281e20f1e48ca76368355a01b31353724718c4d6e3dcbb430",
+              "strip_prefix": "protobuf-1.5.3",
+              "patches": [
+                "@@rules_go~//third_party:com_github_golang_protobuf-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          },
+          "io_bazel_rules_nogo": {
+            "bzlFile": "@@rules_go~//go/private:nogo.bzl",
+            "ruleClassName": "go_register_nogo",
+            "attributes": {
+              "nogo": "@io_bazel_rules_go//:default_nogo"
+            }
+          },
+          "com_github_golang_mock": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip",
+                "https://github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip"
+              ],
+              "patches": [
+                "@@rules_go~//third_party:com_github_golang_mock-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ],
+              "sha256": "5359c78b0c1649cf7beb3b48ff8b1d1aaf0243b22ea4789aba94805280075d8e",
+              "strip_prefix": "mock-1.7.0-rc.1"
+            }
+          },
+          "org_golang_x_sys": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "urls": [
+                "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.12.0.zip",
+                "https://github.com/golang/sys/archive/refs/tags/v0.12.0.zip"
+              ],
+              "sha256": "229b079d23d18f5b1a0c46335020cddc6e5d543da2dae6e45b59d84b5d074e3a",
+              "strip_prefix": "sys-0.12.0",
+              "patches": [
+                "@@rules_go~//third_party:org_golang_x_sys-gazelle.patch"
+              ],
+              "patch_args": [
+                "-p1"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features~",
+            "bazel_features_globals",
+            "bazel_features~~version_extension~bazel_features_globals"
+          ],
+          [
+            "bazel_features~",
+            "bazel_features_version",
+            "bazel_features~~version_extension~bazel_features_version"
+          ],
+          [
+            "rules_go~",
+            "bazel_features",
+            "bazel_features~"
+          ],
+          [
+            "rules_go~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_oci~//oci:extensions.bzl%oci": {
+      "general": {
+        "bzlTransitiveDigest": "6G6tDFJTPCtKyxon8Br4ev91dRdgBbCkorJmAgiIagc=",
+        "usagesDigest": "Pu/P+SVB+Qbdzl3wU3n5aOMsoK6nTX8UJYRkP9qCPpE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "bazel_features_version": {
+            "bzlFile": "@@bazel_features~//private:version_repo.bzl",
+            "ruleClassName": "version_repo",
+            "attributes": {}
+          },
+          "copy_to_directory_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "jq_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "1.7"
+            }
+          },
+          "copy_to_directory_freebsd_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "freebsd_amd64"
+            }
+          },
+          "oci_crane_linux_arm64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "linux_arm64",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "jq_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "1.7"
+            }
+          },
+          "coreutils_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "0.0.26"
+            }
+          },
+          "bsd_tar_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "copy_to_directory_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "oci_regctl_toolchains": {
+            "bzlFile": "@@rules_oci~//oci/private:toolchains_repo.bzl",
+            "ruleClassName": "toolchains_repo",
+            "attributes": {
+              "toolchain_type": "@rules_oci//oci:regctl_toolchain_type",
+              "toolchain": "@oci_regctl_{platform}//:regctl_toolchain"
+            }
+          },
+          "oci_regctl_windows_armv6": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "windows_armv6"
+            }
+          },
+          "oci_crane_linux_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "linux_amd64",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "coreutils_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "version": "0.0.26"
+            }
+          },
+          "coreutils_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "0.0.26"
+            }
+          },
+          "zstd_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "oci_crane_darwin_arm64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "jq_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64",
+              "version": "1.7"
+            }
+          },
+          "oci_regctl_linux_s390x": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "linux_s390x"
+            }
+          },
+          "oci_regctl_darwin_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "oci_crane_linux_i386": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "linux_i386",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_regctl_windows_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "oci_crane_windows_armv6": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "windows_armv6",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_crane_toolchains": {
+            "bzlFile": "@@rules_oci~//oci/private:toolchains_repo.bzl",
+            "ruleClassName": "toolchains_repo",
+            "attributes": {
+              "toolchain_type": "@rules_oci//oci:crane_toolchain_type",
+              "toolchain": "@oci_crane_{platform}//:crane_toolchain"
+            }
+          },
+          "copy_to_directory_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "zstd_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "bsd_tar_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "oci_crane_windows_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "windows_amd64",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "oci_regctl_linux_arm64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "oci_crane_linux_s390x": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "linux_s390x",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "zstd_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "oci_regctl_darwin_arm64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "bsd_tar_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "jq": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_host_alias_repo",
+            "attributes": {}
+          },
+          "oci_crane_darwin_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "darwin_amd64",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "bsd_tar_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "copy_to_directory_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "coreutils_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "0.0.26"
+            }
+          },
+          "bazel_skylib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9f38886a40548c6e96c106b752f242130ee11aaa068a56ba7e56f4511f33e4f2",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz"
+              ]
+            }
+          },
+          "oci_crane_linux_armv6": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "crane_repositories",
+            "attributes": {
+              "platform": "linux_armv6",
+              "crane_version": "v0.18.0"
+            }
+          },
+          "copy_to_directory_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "coreutils_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "coreutils"
+            }
+          },
+          "zstd_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "zstd_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "zstd"
+            }
+          },
+          "jq_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "linux_amd64",
+              "version": "1.7"
+            }
+          },
+          "bsd_tar_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "oci_regctl_linux_amd64": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "bsd_tar_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "tar_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "bsd_tar"
+            }
+          },
+          "jq_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "1.7"
+            }
+          },
+          "oci_regctl_linux_i386": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "linux_i386"
+            }
+          },
+          "jq_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "jq"
+            }
+          },
+          "copy_to_directory_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:copy_to_directory_toolchain.bzl",
+            "ruleClassName": "copy_to_directory_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "copy_to_directory"
+            }
+          },
+          "oci_regctl_linux_armv6": {
+            "bzlFile": "@@rules_oci~//oci:repositories.bzl",
+            "ruleClassName": "regctl_repositories",
+            "attributes": {
+              "platform": "linux_armv6"
+            }
+          },
+          "bazel_features_globals": {
+            "bzlFile": "@@bazel_features~//private:globals_repo.bzl",
+            "ruleClassName": "globals_repo",
+            "attributes": {
+              "globals": {
+                "RunEnvironmentInfo": "5.3.0",
+                "DefaultInfo": "0.0.1",
+                "__TestingOnly_NeverAvailable": "1000000000.0.0"
+              }
+            }
+          },
+          "coreutils_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:coreutils_toolchain.bzl",
+            "ruleClassName": "coreutils_platform_repo",
+            "attributes": {
+              "platform": "windows_amd64",
+              "version": "0.0.26"
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_bazel_lib~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel_features~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_oci~",
+            "aspect_bazel_lib",
+            "aspect_bazel_lib~"
+          ],
+          [
+            "rules_oci~",
+            "bazel_features",
+            "bazel_features~"
+          ],
+          [
+            "rules_oci~",
+            "bazel_skylib",
+            "bazel_skylib~"
           ]
         ]
       }

--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -120,8 +120,10 @@ container_structure_test(
         "@platforms//cpu:x86_64": ["test_linux_amd64.yaml"],
     }),
     image = ":apt",
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
+    target_compatible_with = select({
+        "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],
+        "@platforms//cpu:arm64": ["@platforms//cpu:arm64"],
+    }) + [
         "@platforms//os:linux",
     ],
 )

--- a/examples/debian_shared_dependencies/BUILD.bazel
+++ b/examples/debian_shared_dependencies/BUILD.bazel
@@ -107,8 +107,10 @@ container_structure_test(
         "@platforms//cpu:x86_64": ["test_linux_amd64.yaml"],
     }),
     image = ":apt",
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
+    target_compatible_with = select({
+        "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],
+        "@platforms//cpu:arm64": ["@platforms//cpu:arm64"],
+    }) + [
         "@platforms//os:linux",
     ],
 )

--- a/examples/debian_shared_dependencies/bullseye.lock.json
+++ b/examples/debian_shared_dependencies/bullseye.lock.json
@@ -1,3153 +1,3153 @@
 {
-  "packages": [
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "nginx-core_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "nginx-core",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
-          "name": "zlib1g",
-          "version": "1:1.2.11.dfsg-2+deb11u2"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_amd64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_amd64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_amd64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
-          "name": "libssl1.1",
-          "version": "1.1.1w-0+deb11u1"
-        },
-        {
-          "key": "libpcre3_2-8.39-13_amd64",
-          "name": "libpcre3",
-          "version": "2:8.39-13"
-        },
-        {
-          "key": "iproute2_5.10.0-4_amd64",
-          "name": "iproute2",
-          "version": "5.10.0-4"
-        },
-        {
-          "key": "libcap2-bin_1-2.44-1_amd64",
-          "name": "libcap2-bin",
-          "version": "1:2.44-1"
-        },
-        {
-          "key": "libcap2_1-2.44-1_amd64",
-          "name": "libcap2",
-          "version": "1:2.44-1"
-        },
-        {
-          "key": "libxtables12_1.8.7-1_amd64",
-          "name": "libxtables12",
-          "version": "1.8.7-1"
-        },
-        {
-          "key": "libselinux1_3.1-3_amd64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libmnl0_1.0.4-3_amd64",
-          "name": "libmnl0",
-          "version": "1.0.4-3"
-        },
-        {
-          "key": "libelf1_0.183-1_amd64",
-          "name": "libelf1",
-          "version": "0.183-1"
-        },
-        {
-          "key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
-          "name": "libdb5.3",
-          "version": "5.3.28+dfsg1-0.8"
-        },
-        {
-          "key": "libbsd0_0.11.3-1-p-deb11u1_amd64",
-          "name": "libbsd0",
-          "version": "0.11.3-1+deb11u1"
-        },
-        {
-          "key": "libmd0_1.0.3-3_amd64",
-          "name": "libmd0",
-          "version": "1.0.3-3"
-        },
-        {
-          "key": "libbpf0_1-0.3-2_amd64",
-          "name": "libbpf0",
-          "version": "1:0.3-2"
-        },
-        {
-          "key": "nginx-common_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "nginx-common",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "lsb-base_11.1.0_amd64",
-          "name": "lsb-base",
-          "version": "11.1.0"
-        },
-        {
-          "key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-stream-geoip",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-stream",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libgeoip1_1.6.12-7_amd64",
-          "name": "libgeoip1",
-          "version": "1.6.12-7"
-        },
-        {
-          "key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-mail",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-xslt-filter",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libxslt1.1_1.1.34-4-p-deb11u1_amd64",
-          "name": "libxslt1.1",
-          "version": "1.1.34-4+deb11u1"
-        },
-        {
-          "key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_amd64",
-          "name": "libxml2",
-          "version": "2.9.10+dfsg-6.7+deb11u4"
-        },
-        {
-          "key": "liblzma5_5.2.5-2.1~deb11u1_amd64",
-          "name": "liblzma5",
-          "version": "5.2.5-2.1~deb11u1"
-        },
-        {
-          "key": "libicu67_67.1-7_amd64",
-          "name": "libicu67",
-          "version": "67.1-7"
-        },
-        {
-          "key": "libstdc-p--p-6_10.2.1-6_amd64",
-          "name": "libstdc++6",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libgcrypt20_1.8.7-6_amd64",
-          "name": "libgcrypt20",
-          "version": "1.8.7-6"
-        },
-        {
-          "key": "libgpg-error0_1.38-2_amd64",
-          "name": "libgpg-error0",
-          "version": "1.38-2"
-        },
-        {
-          "key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-image-filter",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libgd3_2.3.0-2_amd64",
-          "name": "libgd3",
-          "version": "2.3.0-2"
-        },
-        {
-          "key": "libxpm4_1-3.5.12-1.1-p-deb11u1_amd64",
-          "name": "libxpm4",
-          "version": "1:3.5.12-1.1+deb11u1"
-        },
-        {
-          "key": "libx11-6_2-1.7.2-1-p-deb11u2_amd64",
-          "name": "libx11-6",
-          "version": "2:1.7.2-1+deb11u2"
-        },
-        {
-          "key": "libx11-data_2-1.7.2-1-p-deb11u2_amd64",
-          "name": "libx11-data",
-          "version": "2:1.7.2-1+deb11u2"
-        },
-        {
-          "key": "libxcb1_1.14-3_amd64",
-          "name": "libxcb1",
-          "version": "1.14-3"
-        },
-        {
-          "key": "libxdmcp6_1-1.1.2-3_amd64",
-          "name": "libxdmcp6",
-          "version": "1:1.1.2-3"
-        },
-        {
-          "key": "libxau6_1-1.0.9-1_amd64",
-          "name": "libxau6",
-          "version": "1:1.0.9-1"
-        },
-        {
-          "key": "libwebp6_0.6.1-2.1-p-deb11u2_amd64",
-          "name": "libwebp6",
-          "version": "0.6.1-2.1+deb11u2"
-        },
-        {
-          "key": "libtiff5_4.2.0-1-p-deb11u5_amd64",
-          "name": "libtiff5",
-          "version": "4.2.0-1+deb11u5"
-        },
-        {
-          "key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
-          "name": "libzstd1",
-          "version": "1.4.8+dfsg-2.1"
-        },
-        {
-          "key": "libjpeg62-turbo_1-2.0.6-4_amd64",
-          "name": "libjpeg62-turbo",
-          "version": "1:2.0.6-4"
-        },
-        {
-          "key": "libjbig0_2.1-3.1-p-b2_amd64",
-          "name": "libjbig0",
-          "version": "2.1-3.1+b2"
-        },
-        {
-          "key": "libdeflate0_1.7-1_amd64",
-          "name": "libdeflate0",
-          "version": "1.7-1"
-        },
-        {
-          "key": "libpng16-16_1.6.37-3_amd64",
-          "name": "libpng16-16",
-          "version": "1.6.37-3"
-        },
-        {
-          "key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_amd64",
-          "name": "libfreetype6",
-          "version": "2.10.4+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libbrotli1_1.0.9-2-p-b2_amd64",
-          "name": "libbrotli1",
-          "version": "1.0.9-2+b2"
-        },
-        {
-          "key": "libfontconfig1_2.13.1-4.2_amd64",
-          "name": "libfontconfig1",
-          "version": "2.13.1-4.2"
-        },
-        {
-          "key": "fontconfig-config_2.13.1-4.2_amd64",
-          "name": "fontconfig-config",
-          "version": "2.13.1-4.2"
-        },
-        {
-          "key": "ucf_3.0043_amd64",
-          "name": "ucf",
-          "version": "3.0043"
-        },
-        {
-          "key": "sensible-utils_0.0.14_amd64",
-          "name": "sensible-utils",
-          "version": "0.0.14"
-        },
-        {
-          "key": "coreutils_8.32-4-p-b1_amd64",
-          "name": "coreutils",
-          "version": "8.32-4+b1"
-        },
-        {
-          "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
-          "name": "libgmp10",
-          "version": "2:6.2.1+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libattr1_1-2.4.48-6_amd64",
-          "name": "libattr1",
-          "version": "1:2.4.48-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_amd64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        },
-        {
-          "key": "debconf_1.5.77_amd64",
-          "name": "debconf",
-          "version": "1.5.77"
-        },
-        {
-          "key": "perl-base_5.32.1-4-p-deb11u3_amd64",
-          "name": "perl-base",
-          "version": "5.32.1-4+deb11u3"
-        },
-        {
-          "key": "dpkg_1.20.13_amd64",
-          "name": "dpkg",
-          "version": "1.20.13"
-        },
-        {
-          "key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
-          "name": "tar",
-          "version": "1.34+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-4_amd64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-4"
-        },
-        {
-          "key": "libuuid1_2.36.1-8-p-deb11u1_amd64",
-          "name": "libuuid1",
-          "version": "2.36.1-8+deb11u1"
-        },
-        {
-          "key": "libexpat1_2.2.10-2-p-deb11u5_amd64",
-          "name": "libexpat1",
-          "version": "2.2.10-2+deb11u5"
-        },
-        {
-          "key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-geoip",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-stream-geoip2",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libmaxminddb0_1.5.2-1_amd64",
-          "name": "libmaxminddb0",
-          "version": "1.5.2-1"
-        },
-        {
-          "key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-upstream-fair",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-subs-filter",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-geoip2",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-echo",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-dav-ext",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-auth-pam",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libpam0g_1.4.0-9-p-deb11u1_amd64",
-          "name": "libpam0g",
-          "version": "1.4.0-9+deb11u1"
-        },
-        {
-          "key": "libaudit1_1-3.0-2_amd64",
-          "name": "libaudit1",
-          "version": "1:3.0-2"
-        },
-        {
-          "key": "libcap-ng0_0.7.9-2.2-p-b1_amd64",
-          "name": "libcap-ng0",
-          "version": "0.7.9-2.2+b1"
-        },
-        {
-          "key": "libaudit-common_1-3.0-2_amd64",
-          "name": "libaudit-common",
-          "version": "1:3.0-2"
-        }
-      ],
-      "key": "nginx-full_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "nginx-full",
-      "sha256": "4049950f648478009faeaf028ab7287240ebd28c27799a5b128a1623290b3e44",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
-          "name": "zlib1g",
-          "version": "1:1.2.11.dfsg-2+deb11u2"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_amd64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_amd64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_amd64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
-          "name": "libssl1.1",
-          "version": "1.1.1w-0+deb11u1"
-        },
-        {
-          "key": "libpcre3_2-8.39-13_amd64",
-          "name": "libpcre3",
-          "version": "2:8.39-13"
-        },
-        {
-          "key": "iproute2_5.10.0-4_amd64",
-          "name": "iproute2",
-          "version": "5.10.0-4"
-        },
-        {
-          "key": "libcap2-bin_1-2.44-1_amd64",
-          "name": "libcap2-bin",
-          "version": "1:2.44-1"
-        },
-        {
-          "key": "libcap2_1-2.44-1_amd64",
-          "name": "libcap2",
-          "version": "1:2.44-1"
-        },
-        {
-          "key": "libxtables12_1.8.7-1_amd64",
-          "name": "libxtables12",
-          "version": "1.8.7-1"
-        },
-        {
-          "key": "libselinux1_3.1-3_amd64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libmnl0_1.0.4-3_amd64",
-          "name": "libmnl0",
-          "version": "1.0.4-3"
-        },
-        {
-          "key": "libelf1_0.183-1_amd64",
-          "name": "libelf1",
-          "version": "0.183-1"
-        },
-        {
-          "key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
-          "name": "libdb5.3",
-          "version": "5.3.28+dfsg1-0.8"
-        },
-        {
-          "key": "libbsd0_0.11.3-1-p-deb11u1_amd64",
-          "name": "libbsd0",
-          "version": "0.11.3-1+deb11u1"
-        },
-        {
-          "key": "libmd0_1.0.3-3_amd64",
-          "name": "libmd0",
-          "version": "1.0.3-3"
-        },
-        {
-          "key": "libbpf0_1-0.3-2_amd64",
-          "name": "libbpf0",
-          "version": "1:0.3-2"
-        },
-        {
-          "key": "nginx-common_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "nginx-common",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "lsb-base_11.1.0_amd64",
-          "name": "lsb-base",
-          "version": "11.1.0"
-        },
-        {
-          "key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-stream-geoip",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-stream",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libgeoip1_1.6.12-7_amd64",
-          "name": "libgeoip1",
-          "version": "1.6.12-7"
-        },
-        {
-          "key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-mail",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-xslt-filter",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libxslt1.1_1.1.34-4-p-deb11u1_amd64",
-          "name": "libxslt1.1",
-          "version": "1.1.34-4+deb11u1"
-        },
-        {
-          "key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_amd64",
-          "name": "libxml2",
-          "version": "2.9.10+dfsg-6.7+deb11u4"
-        },
-        {
-          "key": "liblzma5_5.2.5-2.1~deb11u1_amd64",
-          "name": "liblzma5",
-          "version": "5.2.5-2.1~deb11u1"
-        },
-        {
-          "key": "libicu67_67.1-7_amd64",
-          "name": "libicu67",
-          "version": "67.1-7"
-        },
-        {
-          "key": "libstdc-p--p-6_10.2.1-6_amd64",
-          "name": "libstdc++6",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libgcrypt20_1.8.7-6_amd64",
-          "name": "libgcrypt20",
-          "version": "1.8.7-6"
-        },
-        {
-          "key": "libgpg-error0_1.38-2_amd64",
-          "name": "libgpg-error0",
-          "version": "1.38-2"
-        },
-        {
-          "key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-image-filter",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libgd3_2.3.0-2_amd64",
-          "name": "libgd3",
-          "version": "2.3.0-2"
-        },
-        {
-          "key": "libxpm4_1-3.5.12-1.1-p-deb11u1_amd64",
-          "name": "libxpm4",
-          "version": "1:3.5.12-1.1+deb11u1"
-        },
-        {
-          "key": "libx11-6_2-1.7.2-1-p-deb11u2_amd64",
-          "name": "libx11-6",
-          "version": "2:1.7.2-1+deb11u2"
-        },
-        {
-          "key": "libx11-data_2-1.7.2-1-p-deb11u2_amd64",
-          "name": "libx11-data",
-          "version": "2:1.7.2-1+deb11u2"
-        },
-        {
-          "key": "libxcb1_1.14-3_amd64",
-          "name": "libxcb1",
-          "version": "1.14-3"
-        },
-        {
-          "key": "libxdmcp6_1-1.1.2-3_amd64",
-          "name": "libxdmcp6",
-          "version": "1:1.1.2-3"
-        },
-        {
-          "key": "libxau6_1-1.0.9-1_amd64",
-          "name": "libxau6",
-          "version": "1:1.0.9-1"
-        },
-        {
-          "key": "libwebp6_0.6.1-2.1-p-deb11u2_amd64",
-          "name": "libwebp6",
-          "version": "0.6.1-2.1+deb11u2"
-        },
-        {
-          "key": "libtiff5_4.2.0-1-p-deb11u5_amd64",
-          "name": "libtiff5",
-          "version": "4.2.0-1+deb11u5"
-        },
-        {
-          "key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
-          "name": "libzstd1",
-          "version": "1.4.8+dfsg-2.1"
-        },
-        {
-          "key": "libjpeg62-turbo_1-2.0.6-4_amd64",
-          "name": "libjpeg62-turbo",
-          "version": "1:2.0.6-4"
-        },
-        {
-          "key": "libjbig0_2.1-3.1-p-b2_amd64",
-          "name": "libjbig0",
-          "version": "2.1-3.1+b2"
-        },
-        {
-          "key": "libdeflate0_1.7-1_amd64",
-          "name": "libdeflate0",
-          "version": "1.7-1"
-        },
-        {
-          "key": "libpng16-16_1.6.37-3_amd64",
-          "name": "libpng16-16",
-          "version": "1.6.37-3"
-        },
-        {
-          "key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_amd64",
-          "name": "libfreetype6",
-          "version": "2.10.4+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libbrotli1_1.0.9-2-p-b2_amd64",
-          "name": "libbrotli1",
-          "version": "1.0.9-2+b2"
-        },
-        {
-          "key": "libfontconfig1_2.13.1-4.2_amd64",
-          "name": "libfontconfig1",
-          "version": "2.13.1-4.2"
-        },
-        {
-          "key": "fontconfig-config_2.13.1-4.2_amd64",
-          "name": "fontconfig-config",
-          "version": "2.13.1-4.2"
-        },
-        {
-          "key": "ucf_3.0043_amd64",
-          "name": "ucf",
-          "version": "3.0043"
-        },
-        {
-          "key": "sensible-utils_0.0.14_amd64",
-          "name": "sensible-utils",
-          "version": "0.0.14"
-        },
-        {
-          "key": "coreutils_8.32-4-p-b1_amd64",
-          "name": "coreutils",
-          "version": "8.32-4+b1"
-        },
-        {
-          "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
-          "name": "libgmp10",
-          "version": "2:6.2.1+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libattr1_1-2.4.48-6_amd64",
-          "name": "libattr1",
-          "version": "1:2.4.48-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_amd64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        },
-        {
-          "key": "debconf_1.5.77_amd64",
-          "name": "debconf",
-          "version": "1.5.77"
-        },
-        {
-          "key": "perl-base_5.32.1-4-p-deb11u3_amd64",
-          "name": "perl-base",
-          "version": "5.32.1-4+deb11u3"
-        },
-        {
-          "key": "dpkg_1.20.13_amd64",
-          "name": "dpkg",
-          "version": "1.20.13"
-        },
-        {
-          "key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
-          "name": "tar",
-          "version": "1.34+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-4_amd64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-4"
-        },
-        {
-          "key": "libuuid1_2.36.1-8-p-deb11u1_amd64",
-          "name": "libuuid1",
-          "version": "2.36.1-8+deb11u1"
-        },
-        {
-          "key": "libexpat1_2.2.10-2-p-deb11u5_amd64",
-          "name": "libexpat1",
-          "version": "2.2.10-2+deb11u5"
-        },
-        {
-          "key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_amd64",
-          "name": "libnginx-mod-http-geoip",
-          "version": "1.18.0-6.1+deb11u3"
-        }
-      ],
-      "key": "nginx-core_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "nginx-core",
-      "sha256": "3d36d36ee74a62037159aeae87c51d2535bf7195a0fb325bde90a325034fc152",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
-      "name": "zlib1g",
-      "sha256": "03d2ab2174af76df6f517b854b77460fbdafc3dac0dca979317da67538159a3e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_amd64.deb",
-      "version": "1:1.2.11.dfsg-2+deb11u2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libc6_2.31-13-p-deb11u8_amd64",
-      "name": "libc6",
-      "sha256": "d55d9c9769336f9b8516c20bd8364ce90746fb860ae3dda242f421e711af3d1a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_amd64.deb",
-      "version": "2.31-13+deb11u8"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libcrypt1_1-4.4.18-4_amd64",
-      "name": "libcrypt1",
-      "sha256": "f617952df0c57b4ee039448e3941bccd3f97bfff71e9b0f87ca6dae15cb3f5ef",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb",
-      "version": "1:4.4.18-4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgcc-s1_10.2.1-6_amd64",
-      "name": "libgcc-s1",
-      "sha256": "e478f2709d8474165bb664de42e16950c391f30eaa55bc9b3573281d83a29daf",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "gcc-10-base_10.2.1-6_amd64",
-      "name": "gcc-10-base",
-      "sha256": "be65535e94f95fbf04b104e8ab36790476f063374430f7dfc6c516cbe2d2cd1e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
-      "name": "libssl1.1",
-      "sha256": "aadf8b4b197335645b230c2839b4517aa444fd2e8f434e5438c48a18857988f7",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb",
-      "version": "1.1.1w-0+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libpcre3_2-8.39-13_amd64",
-      "name": "libpcre3",
-      "sha256": "48efcf2348967c211cd9408539edf7ec3fa9d800b33041f6511ccaecc1ffa9d0",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_amd64.deb",
-      "version": "2:8.39-13"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "iproute2_5.10.0-4_amd64",
-      "name": "iproute2",
-      "sha256": "bad652452612c81b8cfdca1411a036a768f5fa3461a04d6662f1ee0807ea3791",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_amd64.deb",
-      "version": "5.10.0-4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libcap2-bin_1-2.44-1_amd64",
-      "name": "libcap2-bin",
-      "sha256": "a5b9717d8455cf8517c4c5f29aa04a4dec973430f0d3c1232f652abb9a4d93cc",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_amd64.deb",
-      "version": "1:2.44-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libcap2_1-2.44-1_amd64",
-      "name": "libcap2",
-      "sha256": "7a3ae3e97d0d403a4c54663c0bb48e9341d98822420a4ab808c6dc8e8474558f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_amd64.deb",
-      "version": "1:2.44-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libxtables12_1.8.7-1_amd64",
-      "name": "libxtables12",
-      "sha256": "9702a4be6f267b58c8fc1cfa0747bbefccb8b9a9af2a3547535533fbf2a7c14d",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_amd64.deb",
-      "version": "1.8.7-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libselinux1_3.1-3_amd64",
-      "name": "libselinux1",
-      "sha256": "339f5ede10500c16dd7192d73169c31c4b27ab12130347275f23044ec8c7d897",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb",
-      "version": "3.1-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
-      "name": "libpcre2-8-0",
-      "sha256": "ee192c8d22624eb9d0a2ae95056bad7fb371e5abc17e23e16b1de3ddb17a1064",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb",
-      "version": "10.36-2+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libmnl0_1.0.4-3_amd64",
-      "name": "libmnl0",
-      "sha256": "4581f42e3373cb72f9ea4e88163b17873afca614a6c6f54637e95aa75983ea7c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_amd64.deb",
-      "version": "1.0.4-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libelf1_0.183-1_amd64",
-      "name": "libelf1",
-      "sha256": "e1ad132d502b255023c222d0cae1d02ca941f6b68fd0e9b908c6004cc326592c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_amd64.deb",
-      "version": "0.183-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
-      "name": "libdb5.3",
-      "sha256": "00b9e63e287f45300d4a4f59b6b88e25918443c932ae3e5845d5761ae193c530",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb",
-      "version": "5.3.28+dfsg1-0.8"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libbsd0_0.11.3-1-p-deb11u1_amd64",
-      "name": "libbsd0",
-      "sha256": "6ec5a08a4bb32c0dc316617f4bbefa8654c472d1cd4412ab8995f3955491f4a8",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_amd64.deb",
-      "version": "0.11.3-1+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libmd0_1.0.3-3_amd64",
-      "name": "libmd0",
-      "sha256": "9e425b3c128b69126d95e61998e1b5ef74e862dd1fc953d91eebcc315aea62ea",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_amd64.deb",
-      "version": "1.0.3-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libbpf0_1-0.3-2_amd64",
-      "name": "libbpf0",
-      "sha256": "21775f2ae3e1221dab6b9cbb7743df54f751b831e89e005a6f3ce951ba3a30b9",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_amd64.deb",
-      "version": "1:0.3-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "nginx-common_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "nginx-common",
-      "sha256": "bfd22beb7bd248db58eee6e6434a7c500f6e98e264219b3832f248696cd58f67",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "lsb-base_11.1.0_amd64",
-      "name": "lsb-base",
-      "sha256": "89ed6332074d827a65305f9a51e591dff20641d61ff5e11f4e1822a9987e96fe",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
-      "version": "11.1.0"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-stream-geoip",
-      "sha256": "b1b22074e8586b9c2fa48fdd460fb43f719e4305a89209cd151102a012af4772",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-stream",
-      "sha256": "1fbc038483013a78f884314a274bafa221000c8d6cddfd76fd217d23bf26b8d0",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgeoip1_1.6.12-7_amd64",
-      "name": "libgeoip1",
-      "sha256": "d4d6076106a6f522144e8071baf6d5fdbd415035f51e081075053ca8223cad51",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_amd64.deb",
-      "version": "1.6.12-7"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-mail",
-      "sha256": "3d401417fc74090544c8cd8586add33cbd2f8d88437072233bca9547922f3384",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-http-xslt-filter",
-      "sha256": "e51af1373b99ce692dfcb11f185ceb4664b6009a50b4d92773af2c74601d2d4a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libxslt1.1_1.1.34-4-p-deb11u1_amd64",
-      "name": "libxslt1.1",
-      "sha256": "e6109d282ad9a330856b88944a953e86329b2c07d8b0f378a2fd0493f27352c8",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_amd64.deb",
-      "version": "1.1.34-4+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_amd64",
-      "name": "libxml2",
-      "sha256": "b29ea9026561ef0019a57b8b192bf08f725976cd1dddd3fc6bcf876840350989",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_amd64.deb",
-      "version": "2.9.10+dfsg-6.7+deb11u4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "liblzma5_5.2.5-2.1~deb11u1_amd64",
-      "name": "liblzma5",
-      "sha256": "1c79a02415ca5ee7234ac60502fb33ee94fa70b02d1c329a6a14178f8329c435",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_amd64.deb",
-      "version": "5.2.5-2.1~deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libicu67_67.1-7_amd64",
-      "name": "libicu67",
-      "sha256": "2bf5c46254f527865bfd6368e1120908755fa57d83634bd7d316c9b3cfd57303",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_amd64.deb",
-      "version": "67.1-7"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libstdc-p--p-6_10.2.1-6_amd64",
-      "name": "libstdc++6",
-      "sha256": "5c155c58935870bf3b4bfe769116841c0d286a74f59eccfd5645693ac23f06b1",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgcrypt20_1.8.7-6_amd64",
-      "name": "libgcrypt20",
-      "sha256": "7a2e0eef8e0c37f03f3a5fcf7102a2e3dc70ba987f696ab71949f9abf36f35ef",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb",
-      "version": "1.8.7-6"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgpg-error0_1.38-2_amd64",
-      "name": "libgpg-error0",
-      "sha256": "16a507fb20cc58b5a524a0dc254a9cb1df02e1ce758a2d8abde0bc4a3c9b7c26",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb",
-      "version": "1.38-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-http-image-filter",
-      "sha256": "811bae64a056aeb4d68329296b0d5f96749a688285977fd2b192f8c81f623304",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgd3_2.3.0-2_amd64",
-      "name": "libgd3",
-      "sha256": "fadaa01272200dcaa476c6b8908e1faa93d6840610beca909099647829f3fdc1",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_amd64.deb",
-      "version": "2.3.0-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libxpm4_1-3.5.12-1.1-p-deb11u1_amd64",
-      "name": "libxpm4",
-      "sha256": "349a5a8cf0de6cb33c199027abfbd6b7a13f5160948e6db066a96080c61e4819",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_amd64.deb",
-      "version": "1:3.5.12-1.1+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libx11-6_2-1.7.2-1-p-deb11u2_amd64",
-      "name": "libx11-6",
-      "sha256": "2b3b959cb10c07be065eb638a8577fe20f282045aaef76425dbd7310d1244b8c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_amd64.deb",
-      "version": "2:1.7.2-1+deb11u2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libx11-data_2-1.7.2-1-p-deb11u2_amd64",
-      "name": "libx11-data",
-      "sha256": "9db24e1e7ed3cd738b503e7df5c1b9b52b1eadcb55019cd63b1409e578565d29",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb",
-      "version": "2:1.7.2-1+deb11u2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libxcb1_1.14-3_amd64",
-      "name": "libxcb1",
-      "sha256": "d5e0f047ed766f45eb7473947b70f9e8fddbe45ef22ecfd92ab712c0671a93ac",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_amd64.deb",
-      "version": "1.14-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libxdmcp6_1-1.1.2-3_amd64",
-      "name": "libxdmcp6",
-      "sha256": "ecb8536f5fb34543b55bb9dc5f5b14c9dbb4150a7bddb3f2287b7cab6e9d25ef",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb",
-      "version": "1:1.1.2-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libxau6_1-1.0.9-1_amd64",
-      "name": "libxau6",
-      "sha256": "679db1c4579ec7c61079adeaae8528adeb2e4bf5465baa6c56233b995d714750",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb",
-      "version": "1:1.0.9-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libwebp6_0.6.1-2.1-p-deb11u2_amd64",
-      "name": "libwebp6",
-      "sha256": "8abc2b1ca77a458bbbcdeb6af5d85316260977370fa2518d017222b3584d9653",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_amd64.deb",
-      "version": "0.6.1-2.1+deb11u2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libtiff5_4.2.0-1-p-deb11u5_amd64",
-      "name": "libtiff5",
-      "sha256": "7a70e9513e2b3c3a3d68f1614189f0be72b57eae2229aa64a3d7c8a3fe0639c9",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_amd64.deb",
-      "version": "4.2.0-1+deb11u5"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
-      "name": "libzstd1",
-      "sha256": "5dcadfbb743bfa1c1c773bff91c018f835e8e8c821d423d3836f3ab84773507b",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_amd64.deb",
-      "version": "1.4.8+dfsg-2.1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libjpeg62-turbo_1-2.0.6-4_amd64",
-      "name": "libjpeg62-turbo",
-      "sha256": "28de780a1605cf501c3a4ebf3e588f5110e814b208548748ab064100c32202ea",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_amd64.deb",
-      "version": "1:2.0.6-4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libjbig0_2.1-3.1-p-b2_amd64",
-      "name": "libjbig0",
-      "sha256": "9646d69eefce505407bf0437ea12fb7c2d47a3fd4434720ba46b642b6dcfd80f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_amd64.deb",
-      "version": "2.1-3.1+b2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libdeflate0_1.7-1_amd64",
-      "name": "libdeflate0",
-      "sha256": "dadaf0d28360f6eb21ad389b2e0f12f8709c9de539b28de9c11d7ec7043dec95",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_amd64.deb",
-      "version": "1.7-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libpng16-16_1.6.37-3_amd64",
-      "name": "libpng16-16",
-      "sha256": "7d5336af395d1f658d0e66d74d0e1f4c632028750e7e04314d1a650e0317f3d6",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_amd64.deb",
-      "version": "1.6.37-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_amd64",
-      "name": "libfreetype6",
-      "sha256": "b21cfdd12adf6cac4af320c2485fb62a8a5edc6f9768bc2288fd686f4fa6dfdf",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_amd64.deb",
-      "version": "2.10.4+dfsg-1+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libbrotli1_1.0.9-2-p-b2_amd64",
-      "name": "libbrotli1",
-      "sha256": "65ca7d8b03e9dac09c5d544a89dd52d1aeb74f6a19583d32e4ff5f0c77624c24",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_amd64.deb",
-      "version": "1.0.9-2+b2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libfontconfig1_2.13.1-4.2_amd64",
-      "name": "libfontconfig1",
-      "sha256": "b92861827627a76e74d6f447a5577d039ef2f95da18af1f29aa98fb96baea4c1",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_amd64.deb",
-      "version": "2.13.1-4.2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "fontconfig-config_2.13.1-4.2_amd64",
-      "name": "fontconfig-config",
-      "sha256": "48afb6ad7d15e6104a343b789f73697301ad8bff77b69927bc998f5a409d8e90",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
-      "version": "2.13.1-4.2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "ucf_3.0043_amd64",
-      "name": "ucf",
-      "sha256": "ebef6bcd777b5c0cc2699926f2159db08433aed07c50cb321fd828b28c5e8d53",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
-      "version": "3.0043"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "sensible-utils_0.0.14_amd64",
-      "name": "sensible-utils",
-      "sha256": "b9a447dc4ec8714196b037e20a2209e62cd669f5450222952f259bda4416b71f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
-      "version": "0.0.14"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "libselinux1_3.1-3_amd64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_amd64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_amd64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_amd64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
-          "name": "libgmp10",
-          "version": "2:6.2.1+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libattr1_1-2.4.48-6_amd64",
-          "name": "libattr1",
-          "version": "1:2.4.48-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_amd64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        }
-      ],
-      "key": "coreutils_8.32-4-p-b1_amd64",
-      "name": "coreutils",
-      "sha256": "3558a412ab51eee4b60641327cb145bb91415f127769823b68f9335585b308d4",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4+b1_amd64.deb",
-      "version": "8.32-4+b1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
-      "name": "libgmp10",
-      "sha256": "fc117ccb084a98d25021f7e01e4dfedd414fa2118fdd1e27d2d801d7248aebbc",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb",
-      "version": "2:6.2.1+dfsg-1+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libattr1_1-2.4.48-6_amd64",
-      "name": "libattr1",
-      "sha256": "af3c3562eb2802481a2b9558df1b389f3c6d9b1bf3b4219e000e05131372ebaf",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_amd64.deb",
-      "version": "1:2.4.48-6"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libacl1_2.2.53-10_amd64",
-      "name": "libacl1",
-      "sha256": "aa18d721be8aea50fbdb32cd9a319cb18a3f111ea6ad17399aa4ba9324c8e26a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb",
-      "version": "2.2.53-10"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "debconf_1.5.77_amd64",
-      "name": "debconf",
-      "sha256": "d9ee4dff77aaad12674eed3ccefdcccd332424c9e2ac2ac00a37a1e06c84ab70",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
-      "version": "1.5.77"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "perl-base_5.32.1-4-p-deb11u3_amd64",
-      "name": "perl-base",
-      "sha256": "94c6299552866aadc58acb8ec5111a74b17bcb453f6e2f45ea5f7c4f42580d13",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_amd64.deb",
-      "version": "5.32.1-4+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "dpkg_1.20.13_amd64",
-      "name": "dpkg",
-      "sha256": "eb2b7ba3a3c4e905a380045a2d1cd219d2d45755aba5966d6c804b79400beb05",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb",
-      "version": "1.20.13"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
-      "name": "tar",
-      "sha256": "41c9c31f67a76b3532036f09ceac1f40a9224f1680395d120a8b24eae60dd54a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_amd64.deb",
-      "version": "1.34+dfsg-1+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libbz2-1.0_1.0.8-4_amd64",
-      "name": "libbz2-1.0",
-      "sha256": "16e27c3ebd97981e70db3733f899963362748f178a62644df69d1f247e741379",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb",
-      "version": "1.0.8-4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libuuid1_2.36.1-8-p-deb11u1_amd64",
-      "name": "libuuid1",
-      "sha256": "31250af4dd3b7d1519326a9a6764d1466a93d8f498cf6545058761ebc38b2823",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_amd64.deb",
-      "version": "2.36.1-8+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libexpat1_2.2.10-2-p-deb11u5_amd64",
-      "name": "libexpat1",
-      "sha256": "5744040c4735bcdd51238aebfa3e402b857244897f1007f61154982ebe5abbd7",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_amd64.deb",
-      "version": "2.2.10-2+deb11u5"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-http-geoip",
-      "sha256": "639ceb3e17c3d5a3033757d86a57f3fa786be27ef51fd1618c8a84e9d55ef974",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-stream-geoip2",
-      "sha256": "20abf8d42ceebe21dcf76c9c4952b9b9a5d8c140affade21c8aebb22d38469d9",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libmaxminddb0_1.5.2-1_amd64",
-      "name": "libmaxminddb0",
-      "sha256": "9779e86a61b8315d119939f3226472f17d707dce0673eff7b961a478e519e351",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_amd64.deb",
-      "version": "1.5.2-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-http-upstream-fair",
-      "sha256": "9650cbb1808fd4d63703b70d5d4599c34e4781c85f5e2b2b47f0abc934397f28",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-http-subs-filter",
-      "sha256": "fbfc00d65a6305911a7f025eb331912dadb6de7cdc5e65e5d94f2e65d70a5596",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-http-geoip2",
-      "sha256": "de912c363bb1864148379f0784c8031194a3749ae930a5fd0eb1bc2df63d7957",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-http-echo",
-      "sha256": "a5be1358d4fb799fdd5941377dea2c45cd013e2c4130dfce98f4af94aead1ec3",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-http-dav-ext",
-      "sha256": "48458923ac10ed4ad432237583b617702e8ca6b88da330989711aa734f7e06ee",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_amd64",
-      "name": "libnginx-mod-http-auth-pam",
-      "sha256": "08f23455c05eee95e8c0bf96d1a52e6a1ddcf509dd1b4dec97c778ff2c596c92",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_amd64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libpam0g_1.4.0-9-p-deb11u1_amd64",
-      "name": "libpam0g",
-      "sha256": "496771218fb585bb716fdae6ef8824dbfb5d544b4fa2f3cd4d0e4d7158ae2220",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_amd64.deb",
-      "version": "1.4.0-9+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libaudit1_1-3.0-2_amd64",
-      "name": "libaudit1",
-      "sha256": "e3aa1383e387dc077a1176f7f3cbfdbc084bcc270a8938f598d5cb119773b268",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_amd64.deb",
-      "version": "1:3.0-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libcap-ng0_0.7.9-2.2-p-b1_amd64",
-      "name": "libcap-ng0",
-      "sha256": "d34e29769b8ef23e9b9920814afb7905b8ee749db0814e6a8d937ccc4f309830",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_amd64.deb",
-      "version": "0.7.9-2.2+b1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libaudit-common_1-3.0-2_amd64",
-      "name": "libaudit-common",
-      "sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
-      "version": "1:3.0-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "tzdata_2024a-0-p-deb11u1_amd64",
-      "name": "tzdata",
-      "sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
-      "version": "2024a-0+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "debianutils_4.11.2_amd64",
-          "name": "debianutils",
-          "version": "4.11.2"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_amd64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_amd64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_amd64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "base-files_11.1-p-deb11u9_amd64",
-          "name": "base-files",
-          "version": "11.1+deb11u9"
-        },
-        {
-          "key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
-          "name": "libtinfo6",
-          "version": "6.2+20201114-2+deb11u2"
-        }
-      ],
-      "key": "bash_5.1-2-p-deb11u1_amd64",
-      "name": "bash",
-      "sha256": "f702ef058e762d7208a9c83f6f6bbf02645533bfd615c54e8cdcce842cd57377",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_amd64.deb",
-      "version": "5.1-2+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "debianutils_4.11.2_amd64",
-      "name": "debianutils",
-      "sha256": "83d21669c5957e3eaee20096a7d8c596bd07f57f1e95dc74f192b3fb7bb2e6a9",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_amd64.deb",
-      "version": "4.11.2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "base-files_11.1-p-deb11u9_amd64",
-      "name": "base-files",
-      "sha256": "1ff08cf6e1b97af1e37cda830f3658f9af43a906abb80a21951c81aea02ce230",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_amd64.deb",
-      "version": "11.1+deb11u9"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
-      "name": "libtinfo6",
-      "sha256": "96ed58b8fd656521e08549c763cd18da6cff1b7801a3a22f29678701a95d7e7b",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_amd64.deb",
-      "version": "6.2+20201114-2+deb11u2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "nginx-core_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "nginx-core",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
-          "name": "zlib1g",
-          "version": "1:1.2.11.dfsg-2+deb11u2"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_arm64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_arm64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_arm64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
-          "name": "libssl1.1",
-          "version": "1.1.1w-0+deb11u1"
-        },
-        {
-          "key": "libpcre3_2-8.39-13_arm64",
-          "name": "libpcre3",
-          "version": "2:8.39-13"
-        },
-        {
-          "key": "iproute2_5.10.0-4_arm64",
-          "name": "iproute2",
-          "version": "5.10.0-4"
-        },
-        {
-          "key": "libcap2-bin_1-2.44-1_arm64",
-          "name": "libcap2-bin",
-          "version": "1:2.44-1"
-        },
-        {
-          "key": "libcap2_1-2.44-1_arm64",
-          "name": "libcap2",
-          "version": "1:2.44-1"
-        },
-        {
-          "key": "libxtables12_1.8.7-1_arm64",
-          "name": "libxtables12",
-          "version": "1.8.7-1"
-        },
-        {
-          "key": "libselinux1_3.1-3_arm64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libmnl0_1.0.4-3_arm64",
-          "name": "libmnl0",
-          "version": "1.0.4-3"
-        },
-        {
-          "key": "libelf1_0.183-1_arm64",
-          "name": "libelf1",
-          "version": "0.183-1"
-        },
-        {
-          "key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
-          "name": "libdb5.3",
-          "version": "5.3.28+dfsg1-0.8"
-        },
-        {
-          "key": "libbsd0_0.11.3-1-p-deb11u1_arm64",
-          "name": "libbsd0",
-          "version": "0.11.3-1+deb11u1"
-        },
-        {
-          "key": "libmd0_1.0.3-3_arm64",
-          "name": "libmd0",
-          "version": "1.0.3-3"
-        },
-        {
-          "key": "libbpf0_1-0.3-2_arm64",
-          "name": "libbpf0",
-          "version": "1:0.3-2"
-        },
-        {
-          "key": "nginx-common_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "nginx-common",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "lsb-base_11.1.0_arm64",
-          "name": "lsb-base",
-          "version": "11.1.0"
-        },
-        {
-          "key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-stream-geoip",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-stream",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libgeoip1_1.6.12-7_arm64",
-          "name": "libgeoip1",
-          "version": "1.6.12-7"
-        },
-        {
-          "key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-mail",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-xslt-filter",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libxslt1.1_1.1.34-4-p-deb11u1_arm64",
-          "name": "libxslt1.1",
-          "version": "1.1.34-4+deb11u1"
-        },
-        {
-          "key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_arm64",
-          "name": "libxml2",
-          "version": "2.9.10+dfsg-6.7+deb11u4"
-        },
-        {
-          "key": "liblzma5_5.2.5-2.1~deb11u1_arm64",
-          "name": "liblzma5",
-          "version": "5.2.5-2.1~deb11u1"
-        },
-        {
-          "key": "libicu67_67.1-7_arm64",
-          "name": "libicu67",
-          "version": "67.1-7"
-        },
-        {
-          "key": "libstdc-p--p-6_10.2.1-6_arm64",
-          "name": "libstdc++6",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libgcrypt20_1.8.7-6_arm64",
-          "name": "libgcrypt20",
-          "version": "1.8.7-6"
-        },
-        {
-          "key": "libgpg-error0_1.38-2_arm64",
-          "name": "libgpg-error0",
-          "version": "1.38-2"
-        },
-        {
-          "key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-image-filter",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libgd3_2.3.0-2_arm64",
-          "name": "libgd3",
-          "version": "2.3.0-2"
-        },
-        {
-          "key": "libxpm4_1-3.5.12-1.1-p-deb11u1_arm64",
-          "name": "libxpm4",
-          "version": "1:3.5.12-1.1+deb11u1"
-        },
-        {
-          "key": "libx11-6_2-1.7.2-1-p-deb11u2_arm64",
-          "name": "libx11-6",
-          "version": "2:1.7.2-1+deb11u2"
-        },
-        {
-          "key": "libx11-data_2-1.7.2-1-p-deb11u2_arm64",
-          "name": "libx11-data",
-          "version": "2:1.7.2-1+deb11u2"
-        },
-        {
-          "key": "libxcb1_1.14-3_arm64",
-          "name": "libxcb1",
-          "version": "1.14-3"
-        },
-        {
-          "key": "libxdmcp6_1-1.1.2-3_arm64",
-          "name": "libxdmcp6",
-          "version": "1:1.1.2-3"
-        },
-        {
-          "key": "libxau6_1-1.0.9-1_arm64",
-          "name": "libxau6",
-          "version": "1:1.0.9-1"
-        },
-        {
-          "key": "libwebp6_0.6.1-2.1-p-deb11u2_arm64",
-          "name": "libwebp6",
-          "version": "0.6.1-2.1+deb11u2"
-        },
-        {
-          "key": "libtiff5_4.2.0-1-p-deb11u5_arm64",
-          "name": "libtiff5",
-          "version": "4.2.0-1+deb11u5"
-        },
-        {
-          "key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
-          "name": "libzstd1",
-          "version": "1.4.8+dfsg-2.1"
-        },
-        {
-          "key": "libjpeg62-turbo_1-2.0.6-4_arm64",
-          "name": "libjpeg62-turbo",
-          "version": "1:2.0.6-4"
-        },
-        {
-          "key": "libjbig0_2.1-3.1-p-b2_arm64",
-          "name": "libjbig0",
-          "version": "2.1-3.1+b2"
-        },
-        {
-          "key": "libdeflate0_1.7-1_arm64",
-          "name": "libdeflate0",
-          "version": "1.7-1"
-        },
-        {
-          "key": "libpng16-16_1.6.37-3_arm64",
-          "name": "libpng16-16",
-          "version": "1.6.37-3"
-        },
-        {
-          "key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_arm64",
-          "name": "libfreetype6",
-          "version": "2.10.4+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libbrotli1_1.0.9-2-p-b2_arm64",
-          "name": "libbrotli1",
-          "version": "1.0.9-2+b2"
-        },
-        {
-          "key": "libfontconfig1_2.13.1-4.2_arm64",
-          "name": "libfontconfig1",
-          "version": "2.13.1-4.2"
-        },
-        {
-          "key": "fontconfig-config_2.13.1-4.2_arm64",
-          "name": "fontconfig-config",
-          "version": "2.13.1-4.2"
-        },
-        {
-          "key": "ucf_3.0043_arm64",
-          "name": "ucf",
-          "version": "3.0043"
-        },
-        {
-          "key": "sensible-utils_0.0.14_arm64",
-          "name": "sensible-utils",
-          "version": "0.0.14"
-        },
-        {
-          "key": "coreutils_8.32-4_arm64",
-          "name": "coreutils",
-          "version": "8.32-4"
-        },
-        {
-          "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
-          "name": "libgmp10",
-          "version": "2:6.2.1+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libattr1_1-2.4.48-6_arm64",
-          "name": "libattr1",
-          "version": "1:2.4.48-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_arm64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        },
-        {
-          "key": "debconf_1.5.77_arm64",
-          "name": "debconf",
-          "version": "1.5.77"
-        },
-        {
-          "key": "perl-base_5.32.1-4-p-deb11u3_arm64",
-          "name": "perl-base",
-          "version": "5.32.1-4+deb11u3"
-        },
-        {
-          "key": "dpkg_1.20.13_arm64",
-          "name": "dpkg",
-          "version": "1.20.13"
-        },
-        {
-          "key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
-          "name": "tar",
-          "version": "1.34+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-4_arm64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-4"
-        },
-        {
-          "key": "libuuid1_2.36.1-8-p-deb11u1_arm64",
-          "name": "libuuid1",
-          "version": "2.36.1-8+deb11u1"
-        },
-        {
-          "key": "libexpat1_2.2.10-2-p-deb11u5_arm64",
-          "name": "libexpat1",
-          "version": "2.2.10-2+deb11u5"
-        },
-        {
-          "key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-geoip",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-stream-geoip2",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libmaxminddb0_1.5.2-1_arm64",
-          "name": "libmaxminddb0",
-          "version": "1.5.2-1"
-        },
-        {
-          "key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-upstream-fair",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-subs-filter",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-geoip2",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-echo",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-dav-ext",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-auth-pam",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libpam0g_1.4.0-9-p-deb11u1_arm64",
-          "name": "libpam0g",
-          "version": "1.4.0-9+deb11u1"
-        },
-        {
-          "key": "libaudit1_1-3.0-2_arm64",
-          "name": "libaudit1",
-          "version": "1:3.0-2"
-        },
-        {
-          "key": "libcap-ng0_0.7.9-2.2-p-b1_arm64",
-          "name": "libcap-ng0",
-          "version": "0.7.9-2.2+b1"
-        },
-        {
-          "key": "libaudit-common_1-3.0-2_arm64",
-          "name": "libaudit-common",
-          "version": "1:3.0-2"
-        }
-      ],
-      "key": "nginx-full_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "nginx-full",
-      "sha256": "4049950f648478009faeaf028ab7287240ebd28c27799a5b128a1623290b3e44",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
-          "name": "zlib1g",
-          "version": "1:1.2.11.dfsg-2+deb11u2"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_arm64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_arm64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_arm64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
-          "name": "libssl1.1",
-          "version": "1.1.1w-0+deb11u1"
-        },
-        {
-          "key": "libpcre3_2-8.39-13_arm64",
-          "name": "libpcre3",
-          "version": "2:8.39-13"
-        },
-        {
-          "key": "iproute2_5.10.0-4_arm64",
-          "name": "iproute2",
-          "version": "5.10.0-4"
-        },
-        {
-          "key": "libcap2-bin_1-2.44-1_arm64",
-          "name": "libcap2-bin",
-          "version": "1:2.44-1"
-        },
-        {
-          "key": "libcap2_1-2.44-1_arm64",
-          "name": "libcap2",
-          "version": "1:2.44-1"
-        },
-        {
-          "key": "libxtables12_1.8.7-1_arm64",
-          "name": "libxtables12",
-          "version": "1.8.7-1"
-        },
-        {
-          "key": "libselinux1_3.1-3_arm64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libmnl0_1.0.4-3_arm64",
-          "name": "libmnl0",
-          "version": "1.0.4-3"
-        },
-        {
-          "key": "libelf1_0.183-1_arm64",
-          "name": "libelf1",
-          "version": "0.183-1"
-        },
-        {
-          "key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
-          "name": "libdb5.3",
-          "version": "5.3.28+dfsg1-0.8"
-        },
-        {
-          "key": "libbsd0_0.11.3-1-p-deb11u1_arm64",
-          "name": "libbsd0",
-          "version": "0.11.3-1+deb11u1"
-        },
-        {
-          "key": "libmd0_1.0.3-3_arm64",
-          "name": "libmd0",
-          "version": "1.0.3-3"
-        },
-        {
-          "key": "libbpf0_1-0.3-2_arm64",
-          "name": "libbpf0",
-          "version": "1:0.3-2"
-        },
-        {
-          "key": "nginx-common_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "nginx-common",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "lsb-base_11.1.0_arm64",
-          "name": "lsb-base",
-          "version": "11.1.0"
-        },
-        {
-          "key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-stream-geoip",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-stream",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libgeoip1_1.6.12-7_arm64",
-          "name": "libgeoip1",
-          "version": "1.6.12-7"
-        },
-        {
-          "key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-mail",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-xslt-filter",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libxslt1.1_1.1.34-4-p-deb11u1_arm64",
-          "name": "libxslt1.1",
-          "version": "1.1.34-4+deb11u1"
-        },
-        {
-          "key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_arm64",
-          "name": "libxml2",
-          "version": "2.9.10+dfsg-6.7+deb11u4"
-        },
-        {
-          "key": "liblzma5_5.2.5-2.1~deb11u1_arm64",
-          "name": "liblzma5",
-          "version": "5.2.5-2.1~deb11u1"
-        },
-        {
-          "key": "libicu67_67.1-7_arm64",
-          "name": "libicu67",
-          "version": "67.1-7"
-        },
-        {
-          "key": "libstdc-p--p-6_10.2.1-6_arm64",
-          "name": "libstdc++6",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libgcrypt20_1.8.7-6_arm64",
-          "name": "libgcrypt20",
-          "version": "1.8.7-6"
-        },
-        {
-          "key": "libgpg-error0_1.38-2_arm64",
-          "name": "libgpg-error0",
-          "version": "1.38-2"
-        },
-        {
-          "key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-image-filter",
-          "version": "1.18.0-6.1+deb11u3"
-        },
-        {
-          "key": "libgd3_2.3.0-2_arm64",
-          "name": "libgd3",
-          "version": "2.3.0-2"
-        },
-        {
-          "key": "libxpm4_1-3.5.12-1.1-p-deb11u1_arm64",
-          "name": "libxpm4",
-          "version": "1:3.5.12-1.1+deb11u1"
-        },
-        {
-          "key": "libx11-6_2-1.7.2-1-p-deb11u2_arm64",
-          "name": "libx11-6",
-          "version": "2:1.7.2-1+deb11u2"
-        },
-        {
-          "key": "libx11-data_2-1.7.2-1-p-deb11u2_arm64",
-          "name": "libx11-data",
-          "version": "2:1.7.2-1+deb11u2"
-        },
-        {
-          "key": "libxcb1_1.14-3_arm64",
-          "name": "libxcb1",
-          "version": "1.14-3"
-        },
-        {
-          "key": "libxdmcp6_1-1.1.2-3_arm64",
-          "name": "libxdmcp6",
-          "version": "1:1.1.2-3"
-        },
-        {
-          "key": "libxau6_1-1.0.9-1_arm64",
-          "name": "libxau6",
-          "version": "1:1.0.9-1"
-        },
-        {
-          "key": "libwebp6_0.6.1-2.1-p-deb11u2_arm64",
-          "name": "libwebp6",
-          "version": "0.6.1-2.1+deb11u2"
-        },
-        {
-          "key": "libtiff5_4.2.0-1-p-deb11u5_arm64",
-          "name": "libtiff5",
-          "version": "4.2.0-1+deb11u5"
-        },
-        {
-          "key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
-          "name": "libzstd1",
-          "version": "1.4.8+dfsg-2.1"
-        },
-        {
-          "key": "libjpeg62-turbo_1-2.0.6-4_arm64",
-          "name": "libjpeg62-turbo",
-          "version": "1:2.0.6-4"
-        },
-        {
-          "key": "libjbig0_2.1-3.1-p-b2_arm64",
-          "name": "libjbig0",
-          "version": "2.1-3.1+b2"
-        },
-        {
-          "key": "libdeflate0_1.7-1_arm64",
-          "name": "libdeflate0",
-          "version": "1.7-1"
-        },
-        {
-          "key": "libpng16-16_1.6.37-3_arm64",
-          "name": "libpng16-16",
-          "version": "1.6.37-3"
-        },
-        {
-          "key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_arm64",
-          "name": "libfreetype6",
-          "version": "2.10.4+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libbrotli1_1.0.9-2-p-b2_arm64",
-          "name": "libbrotli1",
-          "version": "1.0.9-2+b2"
-        },
-        {
-          "key": "libfontconfig1_2.13.1-4.2_arm64",
-          "name": "libfontconfig1",
-          "version": "2.13.1-4.2"
-        },
-        {
-          "key": "fontconfig-config_2.13.1-4.2_arm64",
-          "name": "fontconfig-config",
-          "version": "2.13.1-4.2"
-        },
-        {
-          "key": "ucf_3.0043_arm64",
-          "name": "ucf",
-          "version": "3.0043"
-        },
-        {
-          "key": "sensible-utils_0.0.14_arm64",
-          "name": "sensible-utils",
-          "version": "0.0.14"
-        },
-        {
-          "key": "coreutils_8.32-4_arm64",
-          "name": "coreutils",
-          "version": "8.32-4"
-        },
-        {
-          "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
-          "name": "libgmp10",
-          "version": "2:6.2.1+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libattr1_1-2.4.48-6_arm64",
-          "name": "libattr1",
-          "version": "1:2.4.48-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_arm64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        },
-        {
-          "key": "debconf_1.5.77_arm64",
-          "name": "debconf",
-          "version": "1.5.77"
-        },
-        {
-          "key": "perl-base_5.32.1-4-p-deb11u3_arm64",
-          "name": "perl-base",
-          "version": "5.32.1-4+deb11u3"
-        },
-        {
-          "key": "dpkg_1.20.13_arm64",
-          "name": "dpkg",
-          "version": "1.20.13"
-        },
-        {
-          "key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
-          "name": "tar",
-          "version": "1.34+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-4_arm64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-4"
-        },
-        {
-          "key": "libuuid1_2.36.1-8-p-deb11u1_arm64",
-          "name": "libuuid1",
-          "version": "2.36.1-8+deb11u1"
-        },
-        {
-          "key": "libexpat1_2.2.10-2-p-deb11u5_arm64",
-          "name": "libexpat1",
-          "version": "2.2.10-2+deb11u5"
-        },
-        {
-          "key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_arm64",
-          "name": "libnginx-mod-http-geoip",
-          "version": "1.18.0-6.1+deb11u3"
-        }
-      ],
-      "key": "nginx-core_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "nginx-core",
-      "sha256": "932d9d78df093f037caf9a32af5f3a9f42f113ccc87ca59946f983753a9b83b8",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
-      "name": "zlib1g",
-      "sha256": "e3963985d1a020d67ffd4180e6f9c4b5c600b515f0c9d8fda513d7a0e48e63a1",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_arm64.deb",
-      "version": "1:1.2.11.dfsg-2+deb11u2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libc6_2.31-13-p-deb11u8_arm64",
-      "name": "libc6",
-      "sha256": "6eb629090615ebda5dcac2365a7358c035add00b89c2724c2e9e13ccd5bd9f7c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_arm64.deb",
-      "version": "2.31-13+deb11u8"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libcrypt1_1-4.4.18-4_arm64",
-      "name": "libcrypt1",
-      "sha256": "22b586b29e840dabebf0bf227d233376628b87954915d064bc142ae85d1b7979",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_arm64.deb",
-      "version": "1:4.4.18-4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgcc-s1_10.2.1-6_arm64",
-      "name": "libgcc-s1",
-      "sha256": "e2fcdb378d3c1ad1bcb64d4fb6b37aab44011152beca12a4944f435a2582df1f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_arm64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "gcc-10-base_10.2.1-6_arm64",
-      "name": "gcc-10-base",
-      "sha256": "7d782bece7b4a36bed045a7e17d17244cb8f7e4732466091b01412ebf215defb",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_arm64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
-      "name": "libssl1.1",
-      "sha256": "fe7a7d313c87e46e62e614a07137e4a476a79fc9e5aab7b23e8235211280fee3",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_arm64.deb",
-      "version": "1.1.1w-0+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libpcre3_2-8.39-13_arm64",
-      "name": "libpcre3",
-      "sha256": "21cac4064a41dbc354295c437f37bf623f9004513a97a6fa030248566aa986e9",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_arm64.deb",
-      "version": "2:8.39-13"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "iproute2_5.10.0-4_arm64",
-      "name": "iproute2",
-      "sha256": "92d6c7ca67fca91257a3734d94417a3300c4240d8f6934c6b742c001814b4e31",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_arm64.deb",
-      "version": "5.10.0-4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libcap2-bin_1-2.44-1_arm64",
-      "name": "libcap2-bin",
-      "sha256": "37915f4cc73cfaef7862043f2bdad062d1b1639df04c511665f1f9321c84d0db",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_arm64.deb",
-      "version": "1:2.44-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libcap2_1-2.44-1_arm64",
-      "name": "libcap2",
-      "sha256": "7c5729a1cfd14876685217c5f0545301e7ff1b839262fb487d6a778e8cd8c05a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_arm64.deb",
-      "version": "1:2.44-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libxtables12_1.8.7-1_arm64",
-      "name": "libxtables12",
-      "sha256": "fa07088a313d8dae7a8cba0780117e80ead683ac549fd9986a52a3280232272a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_arm64.deb",
-      "version": "1.8.7-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libselinux1_3.1-3_arm64",
-      "name": "libselinux1",
-      "sha256": "da98279a47dabaa46a83514142f5c691c6a71fa7e582661a3a3db6887ad3e9d1",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_arm64.deb",
-      "version": "3.1-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
-      "name": "libpcre2-8-0",
-      "sha256": "27a4362a4793cb67a8ae571bd8c3f7e8654dc2e56d99088391b87af1793cca9c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_arm64.deb",
-      "version": "10.36-2+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libmnl0_1.0.4-3_arm64",
-      "name": "libmnl0",
-      "sha256": "d63aafb6f2c07db8fcb135b00ff915baf72ef8a3397e773c9c24d67950c6a46c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_arm64.deb",
-      "version": "1.0.4-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libelf1_0.183-1_arm64",
-      "name": "libelf1",
-      "sha256": "12e14110cd66b3bf0564e3b184985b3e91c9cd76e909531a7f7bd2cb9b35a1f3",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_arm64.deb",
-      "version": "0.183-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
-      "name": "libdb5.3",
-      "sha256": "cf9aa3eae9cfc4c84f93e32f3d11e2707146e4d9707712909e3c61530b50353e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_arm64.deb",
-      "version": "5.3.28+dfsg1-0.8"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libbsd0_0.11.3-1-p-deb11u1_arm64",
-      "name": "libbsd0",
-      "sha256": "614d36d41b670955a75526865bd321703f2accb6e0c07ee4c283fbba12e494df",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_arm64.deb",
-      "version": "0.11.3-1+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libmd0_1.0.3-3_arm64",
-      "name": "libmd0",
-      "sha256": "3c490cdcce9d25e702e6587b6166cd8e7303fce8343642d9d5d99695282a9e5c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_arm64.deb",
-      "version": "1.0.3-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libbpf0_1-0.3-2_arm64",
-      "name": "libbpf0",
-      "sha256": "1ef325a3bd9e43970cd8e7f9f44b13e36bc935ac496e56d96f715aa69ae7281b",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_arm64.deb",
-      "version": "1:0.3-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "nginx-common_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "nginx-common",
-      "sha256": "bfd22beb7bd248db58eee6e6434a7c500f6e98e264219b3832f248696cd58f67",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "lsb-base_11.1.0_arm64",
-      "name": "lsb-base",
-      "sha256": "89ed6332074d827a65305f9a51e591dff20641d61ff5e11f4e1822a9987e96fe",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
-      "version": "11.1.0"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-stream-geoip",
-      "sha256": "140963ecb81a3ea933e96fd7c89d01c4ffdb12509e3869d769d7b21ca5d690bf",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-stream",
-      "sha256": "88d083135df9c2c1e2401f174b4e48dde2d92cca7fc8ef661f9d26f00b395a75",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgeoip1_1.6.12-7_arm64",
-      "name": "libgeoip1",
-      "sha256": "17225fb2ed7ce9a090c39d90acc2696e5582805a2a1f391e0a8278bb6a2d0178",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_arm64.deb",
-      "version": "1.6.12-7"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-mail",
-      "sha256": "f8fa0d620dcdea21669b5fd9f503528d53b94117a9c31ac36dc318db0fbac315",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-http-xslt-filter",
-      "sha256": "5d9bb33231c8589a07063a73bb6b3061bc92fae79e5731e96b5b398f1fafee29",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libxslt1.1_1.1.34-4-p-deb11u1_arm64",
-      "name": "libxslt1.1",
-      "sha256": "2505ed3d8e6b049349ecfeff1cb6923eca43403d252e8ddd308a6a644b97eec7",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_arm64.deb",
-      "version": "1.1.34-4+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_arm64",
-      "name": "libxml2",
-      "sha256": "ccd9f449fa88827258bd51eeb8d5f6f33719df290f157c2b0be3c527a6ee45aa",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_arm64.deb",
-      "version": "2.9.10+dfsg-6.7+deb11u4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "liblzma5_5.2.5-2.1~deb11u1_arm64",
-      "name": "liblzma5",
-      "sha256": "d865bba41952c707b3fa3ae8cab4d4bd337ee92991d2aead66c925bf7cc48846",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_arm64.deb",
-      "version": "5.2.5-2.1~deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libicu67_67.1-7_arm64",
-      "name": "libicu67",
-      "sha256": "776303db230b275d8a17dfe8f0012bf61093dfc910f0d51f175be36707686efe",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_arm64.deb",
-      "version": "67.1-7"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libstdc-p--p-6_10.2.1-6_arm64",
-      "name": "libstdc++6",
-      "sha256": "7869aa540cc46e9f3d4267d5bde2af0e5b429a820c1d6f1a4cfccfe788c31890",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_arm64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgcrypt20_1.8.7-6_arm64",
-      "name": "libgcrypt20",
-      "sha256": "61ec779149f20923b30adad7bdf4732957e88a5b6a26d94b2210dfe79409959b",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_arm64.deb",
-      "version": "1.8.7-6"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgpg-error0_1.38-2_arm64",
-      "name": "libgpg-error0",
-      "sha256": "d1116f4281d6db35279799a21051e0d0e2600d110d7ee2b95b3cca6bec28067c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_arm64.deb",
-      "version": "1.38-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-http-image-filter",
-      "sha256": "d972b39dcca41c42f7c797fcc4472d81b64e99978845b2309e18e6d5937e384e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgd3_2.3.0-2_arm64",
-      "name": "libgd3",
-      "sha256": "1e6d6af0c90fe62193b3e51e45f69d075b86d7bde3fb4fd30b60da763aeca43f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_arm64.deb",
-      "version": "2.3.0-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libxpm4_1-3.5.12-1.1-p-deb11u1_arm64",
-      "name": "libxpm4",
-      "sha256": "83ba23ecaaf3f7b700f1ec2c1e349b5a63f3c8cdceb43cc78eb353e16051427d",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_arm64.deb",
-      "version": "1:3.5.12-1.1+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libx11-6_2-1.7.2-1-p-deb11u2_arm64",
-      "name": "libx11-6",
-      "sha256": "1ddb1a4d3dbdaeac8fd8d0009a27e6453b15d97362fdd1d3efb1d5f577364f30",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_arm64.deb",
-      "version": "2:1.7.2-1+deb11u2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libx11-data_2-1.7.2-1-p-deb11u2_arm64",
-      "name": "libx11-data",
-      "sha256": "9db24e1e7ed3cd738b503e7df5c1b9b52b1eadcb55019cd63b1409e578565d29",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb",
-      "version": "2:1.7.2-1+deb11u2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libxcb1_1.14-3_arm64",
-      "name": "libxcb1",
-      "sha256": "48f82b65c93adb7af7757961fdd2730928316459f008d767b7104a56bc20a8f1",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_arm64.deb",
-      "version": "1.14-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libxdmcp6_1-1.1.2-3_arm64",
-      "name": "libxdmcp6",
-      "sha256": "e92569ac33247261aa09adfadc34ced3994ac301cf8b58de415a2d5dbf15ccfc",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb",
-      "version": "1:1.1.2-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libxau6_1-1.0.9-1_arm64",
-      "name": "libxau6",
-      "sha256": "36c2bf400641a80521093771dc2562c903df4065f9eb03add50d90564337ea6c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb",
-      "version": "1:1.0.9-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libwebp6_0.6.1-2.1-p-deb11u2_arm64",
-      "name": "libwebp6",
-      "sha256": "edeb260e528fecae77457a63a468e55837a98079fdd7f1e20e9813c358f8c755",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_arm64.deb",
-      "version": "0.6.1-2.1+deb11u2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libtiff5_4.2.0-1-p-deb11u5_arm64",
-      "name": "libtiff5",
-      "sha256": "6896296ef6193ff77434c5d1d09dd9a333633f7a208ab1cc7de3b286d2d45824",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_arm64.deb",
-      "version": "4.2.0-1+deb11u5"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
-      "name": "libzstd1",
-      "sha256": "dd01659c6c122f983a3369a04ede63539f666585d52a03f8aa2c27b307e547e0",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_arm64.deb",
-      "version": "1.4.8+dfsg-2.1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libjpeg62-turbo_1-2.0.6-4_arm64",
-      "name": "libjpeg62-turbo",
-      "sha256": "8903394de23dc6ead5abfc80972c8fd44300c9903ad4589d0df926e71977d881",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_arm64.deb",
-      "version": "1:2.0.6-4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libjbig0_2.1-3.1-p-b2_arm64",
-      "name": "libjbig0",
-      "sha256": "b71b3e62e162f64cb24466bf7c6e40b05ce2a67ca7fed26d267d498f2896d549",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_arm64.deb",
-      "version": "2.1-3.1+b2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libdeflate0_1.7-1_arm64",
-      "name": "libdeflate0",
-      "sha256": "a1adc22600ea5e44e8ea715972ac2af7994cc7ff4d94bba8e8b01abb9ddbdfd0",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_arm64.deb",
-      "version": "1.7-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libpng16-16_1.6.37-3_arm64",
-      "name": "libpng16-16",
-      "sha256": "f5f61274aa5f71b9e44b077bd7b9fa9cd5ff71d8b8295f47dc1b2d45378aa73e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_arm64.deb",
-      "version": "1.6.37-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_arm64",
-      "name": "libfreetype6",
-      "sha256": "b25f1c148498dd2b49dc30da0a2b2537a7bd0cb34afb8ea681dd145053c9a3f8",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_arm64.deb",
-      "version": "2.10.4+dfsg-1+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libbrotli1_1.0.9-2-p-b2_arm64",
-      "name": "libbrotli1",
-      "sha256": "52ca7f90de6cb6576a0a5cf5712fc4ae7344b79c44b8a1548087fd5d92bf1f64",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_arm64.deb",
-      "version": "1.0.9-2+b2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libfontconfig1_2.13.1-4.2_arm64",
-      "name": "libfontconfig1",
-      "sha256": "18b13ef8a46e9d79ba6a6ba2db0c86e42583277b5d47f6942f3223e349c22641",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_arm64.deb",
-      "version": "2.13.1-4.2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "fontconfig-config_2.13.1-4.2_arm64",
-      "name": "fontconfig-config",
-      "sha256": "48afb6ad7d15e6104a343b789f73697301ad8bff77b69927bc998f5a409d8e90",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
-      "version": "2.13.1-4.2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "ucf_3.0043_arm64",
-      "name": "ucf",
-      "sha256": "ebef6bcd777b5c0cc2699926f2159db08433aed07c50cb321fd828b28c5e8d53",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
-      "version": "3.0043"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "sensible-utils_0.0.14_arm64",
-      "name": "sensible-utils",
-      "sha256": "b9a447dc4ec8714196b037e20a2209e62cd669f5450222952f259bda4416b71f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
-      "version": "0.0.14"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "libselinux1_3.1-3_arm64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_arm64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_arm64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_arm64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
-          "name": "libgmp10",
-          "version": "2:6.2.1+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libattr1_1-2.4.48-6_arm64",
-          "name": "libattr1",
-          "version": "1:2.4.48-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_arm64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        }
-      ],
-      "key": "coreutils_8.32-4_arm64",
-      "name": "coreutils",
-      "sha256": "6210c84d6ff84b867dc430f661f22f536e1704c27bdb79de38e26f75b853d9c0",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4_arm64.deb",
-      "version": "8.32-4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
-      "name": "libgmp10",
-      "sha256": "d52619b6ff8829aa5424dfe3189dd05f22118211e69273e9576030584ffcce80",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_arm64.deb",
-      "version": "2:6.2.1+dfsg-1+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libattr1_1-2.4.48-6_arm64",
-      "name": "libattr1",
-      "sha256": "cb9b59be719a6fdbaabaa60e22aa6158b2de7a68c88ccd7c3fb7f41a25fb43d0",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_arm64.deb",
-      "version": "1:2.4.48-6"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libacl1_2.2.53-10_arm64",
-      "name": "libacl1",
-      "sha256": "f164c48192cb47746101de6c59afa3f97777c8fc821e5a30bb890df1f4cb4cfd",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_arm64.deb",
-      "version": "2.2.53-10"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "debconf_1.5.77_arm64",
-      "name": "debconf",
-      "sha256": "d9ee4dff77aaad12674eed3ccefdcccd332424c9e2ac2ac00a37a1e06c84ab70",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
-      "version": "1.5.77"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "perl-base_5.32.1-4-p-deb11u3_arm64",
-      "name": "perl-base",
-      "sha256": "53e09d9594692c462f33d4e9394bff60f95fe74b70402772dc7396a5829b76e5",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_arm64.deb",
-      "version": "5.32.1-4+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "dpkg_1.20.13_arm64",
-      "name": "dpkg",
-      "sha256": "87b0bce7361d94cc15caf27709fa8a70de44f9dd742cf0d69d25796a03d24853",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_arm64.deb",
-      "version": "1.20.13"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
-      "name": "tar",
-      "sha256": "0f94aac4e6d25e07ed23b7fc3ed06e69074c95276d82caae7fc7b207fd714e39",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_arm64.deb",
-      "version": "1.34+dfsg-1+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libbz2-1.0_1.0.8-4_arm64",
-      "name": "libbz2-1.0",
-      "sha256": "da340e8470e96445c56966f74e48a9a91dee0fa5c89876e88a4575cc17d17a97",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_arm64.deb",
-      "version": "1.0.8-4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libuuid1_2.36.1-8-p-deb11u1_arm64",
-      "name": "libuuid1",
-      "sha256": "3d677da6a22e9cac519fed5a2ed5b20a4217f51ca420fce57434b5e813c26e03",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_arm64.deb",
-      "version": "2.36.1-8+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libexpat1_2.2.10-2-p-deb11u5_arm64",
-      "name": "libexpat1",
-      "sha256": "8d20bfd061845bda0321d01accd6f8386ead5b1d7250a585d12b8d5fb1408ffa",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_arm64.deb",
-      "version": "2.2.10-2+deb11u5"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-http-geoip",
-      "sha256": "7b1d105339402426108d4d10fa733f24f2340c9b6482d10917c194d13f66072f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-stream-geoip2",
-      "sha256": "da0e67b4cc318b7bb338bec7476c260fecd6cc06ecfad4c7f9acb22a4a74d07b",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libmaxminddb0_1.5.2-1_arm64",
-      "name": "libmaxminddb0",
-      "sha256": "05504845f0fab5c54075e462b99b326a224ceaefaccda864f641f1bf6d99914d",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_arm64.deb",
-      "version": "1.5.2-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-http-upstream-fair",
-      "sha256": "7be1dfa763e9158ccdea168b1103f5b6b16b3a0c95c3996076c7f4a20aa35bca",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-http-subs-filter",
-      "sha256": "22354006f199cc3e8e51aac00ca649dd169ca91c2e565a4734f18f3741b061ef",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-http-geoip2",
-      "sha256": "1ae5c1491a8f43ff3a0269270d1f954441cf6fb160b3f83bb2f10ae7b47eb0ce",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-http-echo",
-      "sha256": "ef014f5f294e744e465a9075722c1d7cb3423392b2bd029d60e0d952fd90fde7",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-http-dav-ext",
-      "sha256": "8c65130c9d18a28eadfb657bbe818de567ed6625147e868c3bbd739189f8a991",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_arm64",
-      "name": "libnginx-mod-http-auth-pam",
-      "sha256": "4e6e906608ef1960c2514f371445bf3a32ea72b7098cae38cedac4b5c10abf05",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_arm64.deb",
-      "version": "1.18.0-6.1+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libpam0g_1.4.0-9-p-deb11u1_arm64",
-      "name": "libpam0g",
-      "sha256": "4905e523ce38e80b79f13f0227fca519f6833eb116dd9c58cbbecb39c0e01e3d",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_arm64.deb",
-      "version": "1.4.0-9+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libaudit1_1-3.0-2_arm64",
-      "name": "libaudit1",
-      "sha256": "c93da146715dcd0c71759629c04afb01a41c879d91b2f5330adc74365db03763",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_arm64.deb",
-      "version": "1:3.0-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libcap-ng0_0.7.9-2.2-p-b1_arm64",
-      "name": "libcap-ng0",
-      "sha256": "b7b14e0b7747872f04691efe6c126de5ed0bf1dc200f51b93039cc2f4a65a96a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_arm64.deb",
-      "version": "0.7.9-2.2+b1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libaudit-common_1-3.0-2_arm64",
-      "name": "libaudit-common",
-      "sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
-      "version": "1:3.0-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "tzdata_2024a-0-p-deb11u1_arm64",
-      "name": "tzdata",
-      "sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
-      "version": "2024a-0+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "debianutils_4.11.2_arm64",
-          "name": "debianutils",
-          "version": "4.11.2"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_arm64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_arm64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_arm64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "base-files_11.1-p-deb11u9_arm64",
-          "name": "base-files",
-          "version": "11.1+deb11u9"
-        },
-        {
-          "key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
-          "name": "libtinfo6",
-          "version": "6.2+20201114-2+deb11u2"
-        }
-      ],
-      "key": "bash_5.1-2-p-deb11u1_arm64",
-      "name": "bash",
-      "sha256": "d7c7af5d86f43a885069408a89788f67f248e8124c682bb73936f33874e0611b",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb",
-      "version": "5.1-2+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "debianutils_4.11.2_arm64",
-      "name": "debianutils",
-      "sha256": "6543b2b1a61b4b7b4b55b4bd25162309d7d23d14d3303649aee84ad314c30e02",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_arm64.deb",
-      "version": "4.11.2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "base-files_11.1-p-deb11u9_arm64",
-      "name": "base-files",
-      "sha256": "c40dc4d5c6b82f5cfe75efa1a12bd09b9d5b9b8446ea045a991896a1ead8b02c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_arm64.deb",
-      "version": "11.1+deb11u9"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
-      "name": "libtinfo6",
-      "sha256": "58027c991756930a2abb2f87a829393d3fdbfb76f4eca9795ef38ea2b0510e27",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb",
-      "version": "6.2+20201114-2+deb11u2"
-    }
-  ],
-  "version": 1
+	"packages": [
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "nginx-core_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "nginx-core",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2+deb11u2"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_amd64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_amd64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_amd64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
+					"name": "libssl1.1",
+					"version": "1.1.1w-0+deb11u1"
+				},
+				{
+					"key": "libpcre3_2-8.39-13_amd64",
+					"name": "libpcre3",
+					"version": "2:8.39-13"
+				},
+				{
+					"key": "iproute2_5.10.0-4_amd64",
+					"name": "iproute2",
+					"version": "5.10.0-4"
+				},
+				{
+					"key": "libcap2-bin_1-2.44-1_amd64",
+					"name": "libcap2-bin",
+					"version": "1:2.44-1"
+				},
+				{
+					"key": "libcap2_1-2.44-1_amd64",
+					"name": "libcap2",
+					"version": "1:2.44-1"
+				},
+				{
+					"key": "libxtables12_1.8.7-1_amd64",
+					"name": "libxtables12",
+					"version": "1.8.7-1"
+				},
+				{
+					"key": "libselinux1_3.1-3_amd64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libmnl0_1.0.4-3_amd64",
+					"name": "libmnl0",
+					"version": "1.0.4-3"
+				},
+				{
+					"key": "libelf1_0.183-1_amd64",
+					"name": "libelf1",
+					"version": "0.183-1"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.8"
+				},
+				{
+					"key": "libbsd0_0.11.3-1-p-deb11u1_amd64",
+					"name": "libbsd0",
+					"version": "0.11.3-1+deb11u1"
+				},
+				{
+					"key": "libmd0_1.0.3-3_amd64",
+					"name": "libmd0",
+					"version": "1.0.3-3"
+				},
+				{
+					"key": "libbpf0_1-0.3-2_amd64",
+					"name": "libbpf0",
+					"version": "1:0.3-2"
+				},
+				{
+					"key": "nginx-common_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "nginx-common",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "lsb-base_11.1.0_amd64",
+					"name": "lsb-base",
+					"version": "11.1.0"
+				},
+				{
+					"key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-stream-geoip",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-stream",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libgeoip1_1.6.12-7_amd64",
+					"name": "libgeoip1",
+					"version": "1.6.12-7"
+				},
+				{
+					"key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-mail",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-xslt-filter",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libxslt1.1_1.1.34-4-p-deb11u1_amd64",
+					"name": "libxslt1.1",
+					"version": "1.1.34-4+deb11u1"
+				},
+				{
+					"key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_amd64",
+					"name": "libxml2",
+					"version": "2.9.10+dfsg-6.7+deb11u4"
+				},
+				{
+					"key": "liblzma5_5.2.5-2.1_deb11u1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2.1~deb11u1"
+				},
+				{
+					"key": "libicu67_67.1-7_amd64",
+					"name": "libicu67",
+					"version": "67.1-7"
+				},
+				{
+					"key": "libstdc-p--p-6_10.2.1-6_amd64",
+					"name": "libstdc++6",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libgcrypt20_1.8.7-6_amd64",
+					"name": "libgcrypt20",
+					"version": "1.8.7-6"
+				},
+				{
+					"key": "libgpg-error0_1.38-2_amd64",
+					"name": "libgpg-error0",
+					"version": "1.38-2"
+				},
+				{
+					"key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-image-filter",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libgd3_2.3.0-2_amd64",
+					"name": "libgd3",
+					"version": "2.3.0-2"
+				},
+				{
+					"key": "libxpm4_1-3.5.12-1.1-p-deb11u1_amd64",
+					"name": "libxpm4",
+					"version": "1:3.5.12-1.1+deb11u1"
+				},
+				{
+					"key": "libx11-6_2-1.7.2-1-p-deb11u2_amd64",
+					"name": "libx11-6",
+					"version": "2:1.7.2-1+deb11u2"
+				},
+				{
+					"key": "libx11-data_2-1.7.2-1-p-deb11u2_amd64",
+					"name": "libx11-data",
+					"version": "2:1.7.2-1+deb11u2"
+				},
+				{
+					"key": "libxcb1_1.14-3_amd64",
+					"name": "libxcb1",
+					"version": "1.14-3"
+				},
+				{
+					"key": "libxdmcp6_1-1.1.2-3_amd64",
+					"name": "libxdmcp6",
+					"version": "1:1.1.2-3"
+				},
+				{
+					"key": "libxau6_1-1.0.9-1_amd64",
+					"name": "libxau6",
+					"version": "1:1.0.9-1"
+				},
+				{
+					"key": "libwebp6_0.6.1-2.1-p-deb11u2_amd64",
+					"name": "libwebp6",
+					"version": "0.6.1-2.1+deb11u2"
+				},
+				{
+					"key": "libtiff5_4.2.0-1-p-deb11u5_amd64",
+					"name": "libtiff5",
+					"version": "4.2.0-1+deb11u5"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-2.1"
+				},
+				{
+					"key": "libjpeg62-turbo_1-2.0.6-4_amd64",
+					"name": "libjpeg62-turbo",
+					"version": "1:2.0.6-4"
+				},
+				{
+					"key": "libjbig0_2.1-3.1-p-b2_amd64",
+					"name": "libjbig0",
+					"version": "2.1-3.1+b2"
+				},
+				{
+					"key": "libdeflate0_1.7-1_amd64",
+					"name": "libdeflate0",
+					"version": "1.7-1"
+				},
+				{
+					"key": "libpng16-16_1.6.37-3_amd64",
+					"name": "libpng16-16",
+					"version": "1.6.37-3"
+				},
+				{
+					"key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_amd64",
+					"name": "libfreetype6",
+					"version": "2.10.4+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libbrotli1_1.0.9-2-p-b2_amd64",
+					"name": "libbrotli1",
+					"version": "1.0.9-2+b2"
+				},
+				{
+					"key": "libfontconfig1_2.13.1-4.2_amd64",
+					"name": "libfontconfig1",
+					"version": "2.13.1-4.2"
+				},
+				{
+					"key": "fontconfig-config_2.13.1-4.2_amd64",
+					"name": "fontconfig-config",
+					"version": "2.13.1-4.2"
+				},
+				{
+					"key": "ucf_3.0043_amd64",
+					"name": "ucf",
+					"version": "3.0043"
+				},
+				{
+					"key": "sensible-utils_0.0.14_amd64",
+					"name": "sensible-utils",
+					"version": "0.0.14"
+				},
+				{
+					"key": "coreutils_8.32-4-p-b1_amd64",
+					"name": "coreutils",
+					"version": "8.32-4+b1"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libattr1_1-2.4.48-6_amd64",
+					"name": "libattr1",
+					"version": "1:2.4.48-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_amd64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				},
+				{
+					"key": "debconf_1.5.77_amd64",
+					"name": "debconf",
+					"version": "1.5.77"
+				},
+				{
+					"key": "perl-base_5.32.1-4-p-deb11u3_amd64",
+					"name": "perl-base",
+					"version": "5.32.1-4+deb11u3"
+				},
+				{
+					"key": "dpkg_1.20.13_amd64",
+					"name": "dpkg",
+					"version": "1.20.13"
+				},
+				{
+					"key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
+					"name": "tar",
+					"version": "1.34+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-4_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-4"
+				},
+				{
+					"key": "libuuid1_2.36.1-8-p-deb11u1_amd64",
+					"name": "libuuid1",
+					"version": "2.36.1-8+deb11u1"
+				},
+				{
+					"key": "libexpat1_2.2.10-2-p-deb11u5_amd64",
+					"name": "libexpat1",
+					"version": "2.2.10-2+deb11u5"
+				},
+				{
+					"key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-geoip",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-stream-geoip2",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libmaxminddb0_1.5.2-1_amd64",
+					"name": "libmaxminddb0",
+					"version": "1.5.2-1"
+				},
+				{
+					"key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-upstream-fair",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-subs-filter",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-geoip2",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-echo",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-dav-ext",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-auth-pam",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libpam0g_1.4.0-9-p-deb11u1_amd64",
+					"name": "libpam0g",
+					"version": "1.4.0-9+deb11u1"
+				},
+				{
+					"key": "libaudit1_1-3.0-2_amd64",
+					"name": "libaudit1",
+					"version": "1:3.0-2"
+				},
+				{
+					"key": "libcap-ng0_0.7.9-2.2-p-b1_amd64",
+					"name": "libcap-ng0",
+					"version": "0.7.9-2.2+b1"
+				},
+				{
+					"key": "libaudit-common_1-3.0-2_amd64",
+					"name": "libaudit-common",
+					"version": "1:3.0-2"
+				}
+			],
+			"key": "nginx-full_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "nginx-full",
+			"sha256": "4049950f648478009faeaf028ab7287240ebd28c27799a5b128a1623290b3e44",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2+deb11u2"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_amd64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_amd64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_amd64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
+					"name": "libssl1.1",
+					"version": "1.1.1w-0+deb11u1"
+				},
+				{
+					"key": "libpcre3_2-8.39-13_amd64",
+					"name": "libpcre3",
+					"version": "2:8.39-13"
+				},
+				{
+					"key": "iproute2_5.10.0-4_amd64",
+					"name": "iproute2",
+					"version": "5.10.0-4"
+				},
+				{
+					"key": "libcap2-bin_1-2.44-1_amd64",
+					"name": "libcap2-bin",
+					"version": "1:2.44-1"
+				},
+				{
+					"key": "libcap2_1-2.44-1_amd64",
+					"name": "libcap2",
+					"version": "1:2.44-1"
+				},
+				{
+					"key": "libxtables12_1.8.7-1_amd64",
+					"name": "libxtables12",
+					"version": "1.8.7-1"
+				},
+				{
+					"key": "libselinux1_3.1-3_amd64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libmnl0_1.0.4-3_amd64",
+					"name": "libmnl0",
+					"version": "1.0.4-3"
+				},
+				{
+					"key": "libelf1_0.183-1_amd64",
+					"name": "libelf1",
+					"version": "0.183-1"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.8"
+				},
+				{
+					"key": "libbsd0_0.11.3-1-p-deb11u1_amd64",
+					"name": "libbsd0",
+					"version": "0.11.3-1+deb11u1"
+				},
+				{
+					"key": "libmd0_1.0.3-3_amd64",
+					"name": "libmd0",
+					"version": "1.0.3-3"
+				},
+				{
+					"key": "libbpf0_1-0.3-2_amd64",
+					"name": "libbpf0",
+					"version": "1:0.3-2"
+				},
+				{
+					"key": "nginx-common_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "nginx-common",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "lsb-base_11.1.0_amd64",
+					"name": "lsb-base",
+					"version": "11.1.0"
+				},
+				{
+					"key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-stream-geoip",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-stream",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libgeoip1_1.6.12-7_amd64",
+					"name": "libgeoip1",
+					"version": "1.6.12-7"
+				},
+				{
+					"key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-mail",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-xslt-filter",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libxslt1.1_1.1.34-4-p-deb11u1_amd64",
+					"name": "libxslt1.1",
+					"version": "1.1.34-4+deb11u1"
+				},
+				{
+					"key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_amd64",
+					"name": "libxml2",
+					"version": "2.9.10+dfsg-6.7+deb11u4"
+				},
+				{
+					"key": "liblzma5_5.2.5-2.1_deb11u1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2.1~deb11u1"
+				},
+				{
+					"key": "libicu67_67.1-7_amd64",
+					"name": "libicu67",
+					"version": "67.1-7"
+				},
+				{
+					"key": "libstdc-p--p-6_10.2.1-6_amd64",
+					"name": "libstdc++6",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libgcrypt20_1.8.7-6_amd64",
+					"name": "libgcrypt20",
+					"version": "1.8.7-6"
+				},
+				{
+					"key": "libgpg-error0_1.38-2_amd64",
+					"name": "libgpg-error0",
+					"version": "1.38-2"
+				},
+				{
+					"key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-image-filter",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libgd3_2.3.0-2_amd64",
+					"name": "libgd3",
+					"version": "2.3.0-2"
+				},
+				{
+					"key": "libxpm4_1-3.5.12-1.1-p-deb11u1_amd64",
+					"name": "libxpm4",
+					"version": "1:3.5.12-1.1+deb11u1"
+				},
+				{
+					"key": "libx11-6_2-1.7.2-1-p-deb11u2_amd64",
+					"name": "libx11-6",
+					"version": "2:1.7.2-1+deb11u2"
+				},
+				{
+					"key": "libx11-data_2-1.7.2-1-p-deb11u2_amd64",
+					"name": "libx11-data",
+					"version": "2:1.7.2-1+deb11u2"
+				},
+				{
+					"key": "libxcb1_1.14-3_amd64",
+					"name": "libxcb1",
+					"version": "1.14-3"
+				},
+				{
+					"key": "libxdmcp6_1-1.1.2-3_amd64",
+					"name": "libxdmcp6",
+					"version": "1:1.1.2-3"
+				},
+				{
+					"key": "libxau6_1-1.0.9-1_amd64",
+					"name": "libxau6",
+					"version": "1:1.0.9-1"
+				},
+				{
+					"key": "libwebp6_0.6.1-2.1-p-deb11u2_amd64",
+					"name": "libwebp6",
+					"version": "0.6.1-2.1+deb11u2"
+				},
+				{
+					"key": "libtiff5_4.2.0-1-p-deb11u5_amd64",
+					"name": "libtiff5",
+					"version": "4.2.0-1+deb11u5"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-2.1"
+				},
+				{
+					"key": "libjpeg62-turbo_1-2.0.6-4_amd64",
+					"name": "libjpeg62-turbo",
+					"version": "1:2.0.6-4"
+				},
+				{
+					"key": "libjbig0_2.1-3.1-p-b2_amd64",
+					"name": "libjbig0",
+					"version": "2.1-3.1+b2"
+				},
+				{
+					"key": "libdeflate0_1.7-1_amd64",
+					"name": "libdeflate0",
+					"version": "1.7-1"
+				},
+				{
+					"key": "libpng16-16_1.6.37-3_amd64",
+					"name": "libpng16-16",
+					"version": "1.6.37-3"
+				},
+				{
+					"key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_amd64",
+					"name": "libfreetype6",
+					"version": "2.10.4+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libbrotli1_1.0.9-2-p-b2_amd64",
+					"name": "libbrotli1",
+					"version": "1.0.9-2+b2"
+				},
+				{
+					"key": "libfontconfig1_2.13.1-4.2_amd64",
+					"name": "libfontconfig1",
+					"version": "2.13.1-4.2"
+				},
+				{
+					"key": "fontconfig-config_2.13.1-4.2_amd64",
+					"name": "fontconfig-config",
+					"version": "2.13.1-4.2"
+				},
+				{
+					"key": "ucf_3.0043_amd64",
+					"name": "ucf",
+					"version": "3.0043"
+				},
+				{
+					"key": "sensible-utils_0.0.14_amd64",
+					"name": "sensible-utils",
+					"version": "0.0.14"
+				},
+				{
+					"key": "coreutils_8.32-4-p-b1_amd64",
+					"name": "coreutils",
+					"version": "8.32-4+b1"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libattr1_1-2.4.48-6_amd64",
+					"name": "libattr1",
+					"version": "1:2.4.48-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_amd64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				},
+				{
+					"key": "debconf_1.5.77_amd64",
+					"name": "debconf",
+					"version": "1.5.77"
+				},
+				{
+					"key": "perl-base_5.32.1-4-p-deb11u3_amd64",
+					"name": "perl-base",
+					"version": "5.32.1-4+deb11u3"
+				},
+				{
+					"key": "dpkg_1.20.13_amd64",
+					"name": "dpkg",
+					"version": "1.20.13"
+				},
+				{
+					"key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
+					"name": "tar",
+					"version": "1.34+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-4_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-4"
+				},
+				{
+					"key": "libuuid1_2.36.1-8-p-deb11u1_amd64",
+					"name": "libuuid1",
+					"version": "2.36.1-8+deb11u1"
+				},
+				{
+					"key": "libexpat1_2.2.10-2-p-deb11u5_amd64",
+					"name": "libexpat1",
+					"version": "2.2.10-2+deb11u5"
+				},
+				{
+					"key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_amd64",
+					"name": "libnginx-mod-http-geoip",
+					"version": "1.18.0-6.1+deb11u3"
+				}
+			],
+			"key": "nginx-core_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "nginx-core",
+			"sha256": "3d36d36ee74a62037159aeae87c51d2535bf7195a0fb325bde90a325034fc152",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
+			"name": "zlib1g",
+			"sha256": "03d2ab2174af76df6f517b854b77460fbdafc3dac0dca979317da67538159a3e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_amd64.deb",
+			"version": "1:1.2.11.dfsg-2+deb11u2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libc6_2.31-13-p-deb11u8_amd64",
+			"name": "libc6",
+			"sha256": "d55d9c9769336f9b8516c20bd8364ce90746fb860ae3dda242f421e711af3d1a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_amd64.deb",
+			"version": "2.31-13+deb11u8"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.18-4_amd64",
+			"name": "libcrypt1",
+			"sha256": "f617952df0c57b4ee039448e3941bccd3f97bfff71e9b0f87ca6dae15cb3f5ef",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb",
+			"version": "1:4.4.18-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcc-s1_10.2.1-6_amd64",
+			"name": "libgcc-s1",
+			"sha256": "e478f2709d8474165bb664de42e16950c391f30eaa55bc9b3573281d83a29daf",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-10-base_10.2.1-6_amd64",
+			"name": "gcc-10-base",
+			"sha256": "be65535e94f95fbf04b104e8ab36790476f063374430f7dfc6c516cbe2d2cd1e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
+			"name": "libssl1.1",
+			"sha256": "aadf8b4b197335645b230c2839b4517aa444fd2e8f434e5438c48a18857988f7",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb",
+			"version": "1.1.1w-0+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpcre3_2-8.39-13_amd64",
+			"name": "libpcre3",
+			"sha256": "48efcf2348967c211cd9408539edf7ec3fa9d800b33041f6511ccaecc1ffa9d0",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_amd64.deb",
+			"version": "2:8.39-13"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "iproute2_5.10.0-4_amd64",
+			"name": "iproute2",
+			"sha256": "bad652452612c81b8cfdca1411a036a768f5fa3461a04d6662f1ee0807ea3791",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_amd64.deb",
+			"version": "5.10.0-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcap2-bin_1-2.44-1_amd64",
+			"name": "libcap2-bin",
+			"sha256": "a5b9717d8455cf8517c4c5f29aa04a4dec973430f0d3c1232f652abb9a4d93cc",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_amd64.deb",
+			"version": "1:2.44-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcap2_1-2.44-1_amd64",
+			"name": "libcap2",
+			"sha256": "7a3ae3e97d0d403a4c54663c0bb48e9341d98822420a4ab808c6dc8e8474558f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_amd64.deb",
+			"version": "1:2.44-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxtables12_1.8.7-1_amd64",
+			"name": "libxtables12",
+			"sha256": "9702a4be6f267b58c8fc1cfa0747bbefccb8b9a9af2a3547535533fbf2a7c14d",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_amd64.deb",
+			"version": "1.8.7-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libselinux1_3.1-3_amd64",
+			"name": "libselinux1",
+			"sha256": "339f5ede10500c16dd7192d73169c31c4b27ab12130347275f23044ec8c7d897",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb",
+			"version": "3.1-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
+			"name": "libpcre2-8-0",
+			"sha256": "ee192c8d22624eb9d0a2ae95056bad7fb371e5abc17e23e16b1de3ddb17a1064",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb",
+			"version": "10.36-2+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmnl0_1.0.4-3_amd64",
+			"name": "libmnl0",
+			"sha256": "4581f42e3373cb72f9ea4e88163b17873afca614a6c6f54637e95aa75983ea7c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_amd64.deb",
+			"version": "1.0.4-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libelf1_0.183-1_amd64",
+			"name": "libelf1",
+			"sha256": "e1ad132d502b255023c222d0cae1d02ca941f6b68fd0e9b908c6004cc326592c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_amd64.deb",
+			"version": "0.183-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
+			"name": "libdb5.3",
+			"sha256": "00b9e63e287f45300d4a4f59b6b88e25918443c932ae3e5845d5761ae193c530",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb",
+			"version": "5.3.28+dfsg1-0.8"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbsd0_0.11.3-1-p-deb11u1_amd64",
+			"name": "libbsd0",
+			"sha256": "6ec5a08a4bb32c0dc316617f4bbefa8654c472d1cd4412ab8995f3955491f4a8",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_amd64.deb",
+			"version": "0.11.3-1+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmd0_1.0.3-3_amd64",
+			"name": "libmd0",
+			"sha256": "9e425b3c128b69126d95e61998e1b5ef74e862dd1fc953d91eebcc315aea62ea",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_amd64.deb",
+			"version": "1.0.3-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbpf0_1-0.3-2_amd64",
+			"name": "libbpf0",
+			"sha256": "21775f2ae3e1221dab6b9cbb7743df54f751b831e89e005a6f3ce951ba3a30b9",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_amd64.deb",
+			"version": "1:0.3-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "nginx-common_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "nginx-common",
+			"sha256": "bfd22beb7bd248db58eee6e6434a7c500f6e98e264219b3832f248696cd58f67",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "lsb-base_11.1.0_amd64",
+			"name": "lsb-base",
+			"sha256": "89ed6332074d827a65305f9a51e591dff20641d61ff5e11f4e1822a9987e96fe",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
+			"version": "11.1.0"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-stream-geoip",
+			"sha256": "b1b22074e8586b9c2fa48fdd460fb43f719e4305a89209cd151102a012af4772",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-stream",
+			"sha256": "1fbc038483013a78f884314a274bafa221000c8d6cddfd76fd217d23bf26b8d0",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgeoip1_1.6.12-7_amd64",
+			"name": "libgeoip1",
+			"sha256": "d4d6076106a6f522144e8071baf6d5fdbd415035f51e081075053ca8223cad51",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_amd64.deb",
+			"version": "1.6.12-7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-mail",
+			"sha256": "3d401417fc74090544c8cd8586add33cbd2f8d88437072233bca9547922f3384",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-http-xslt-filter",
+			"sha256": "e51af1373b99ce692dfcb11f185ceb4664b6009a50b4d92773af2c74601d2d4a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxslt1.1_1.1.34-4-p-deb11u1_amd64",
+			"name": "libxslt1.1",
+			"sha256": "e6109d282ad9a330856b88944a953e86329b2c07d8b0f378a2fd0493f27352c8",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_amd64.deb",
+			"version": "1.1.34-4+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_amd64",
+			"name": "libxml2",
+			"sha256": "b29ea9026561ef0019a57b8b192bf08f725976cd1dddd3fc6bcf876840350989",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_amd64.deb",
+			"version": "2.9.10+dfsg-6.7+deb11u4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblzma5_5.2.5-2.1_deb11u1_amd64",
+			"name": "liblzma5",
+			"sha256": "1c79a02415ca5ee7234ac60502fb33ee94fa70b02d1c329a6a14178f8329c435",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_amd64.deb",
+			"version": "5.2.5-2.1~deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libicu67_67.1-7_amd64",
+			"name": "libicu67",
+			"sha256": "2bf5c46254f527865bfd6368e1120908755fa57d83634bd7d316c9b3cfd57303",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_amd64.deb",
+			"version": "67.1-7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libstdc-p--p-6_10.2.1-6_amd64",
+			"name": "libstdc++6",
+			"sha256": "5c155c58935870bf3b4bfe769116841c0d286a74f59eccfd5645693ac23f06b1",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcrypt20_1.8.7-6_amd64",
+			"name": "libgcrypt20",
+			"sha256": "7a2e0eef8e0c37f03f3a5fcf7102a2e3dc70ba987f696ab71949f9abf36f35ef",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb",
+			"version": "1.8.7-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgpg-error0_1.38-2_amd64",
+			"name": "libgpg-error0",
+			"sha256": "16a507fb20cc58b5a524a0dc254a9cb1df02e1ce758a2d8abde0bc4a3c9b7c26",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb",
+			"version": "1.38-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-http-image-filter",
+			"sha256": "811bae64a056aeb4d68329296b0d5f96749a688285977fd2b192f8c81f623304",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgd3_2.3.0-2_amd64",
+			"name": "libgd3",
+			"sha256": "fadaa01272200dcaa476c6b8908e1faa93d6840610beca909099647829f3fdc1",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_amd64.deb",
+			"version": "2.3.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxpm4_1-3.5.12-1.1-p-deb11u1_amd64",
+			"name": "libxpm4",
+			"sha256": "349a5a8cf0de6cb33c199027abfbd6b7a13f5160948e6db066a96080c61e4819",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_amd64.deb",
+			"version": "1:3.5.12-1.1+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libx11-6_2-1.7.2-1-p-deb11u2_amd64",
+			"name": "libx11-6",
+			"sha256": "2b3b959cb10c07be065eb638a8577fe20f282045aaef76425dbd7310d1244b8c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_amd64.deb",
+			"version": "2:1.7.2-1+deb11u2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libx11-data_2-1.7.2-1-p-deb11u2_amd64",
+			"name": "libx11-data",
+			"sha256": "9db24e1e7ed3cd738b503e7df5c1b9b52b1eadcb55019cd63b1409e578565d29",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb",
+			"version": "2:1.7.2-1+deb11u2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxcb1_1.14-3_amd64",
+			"name": "libxcb1",
+			"sha256": "d5e0f047ed766f45eb7473947b70f9e8fddbe45ef22ecfd92ab712c0671a93ac",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_amd64.deb",
+			"version": "1.14-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxdmcp6_1-1.1.2-3_amd64",
+			"name": "libxdmcp6",
+			"sha256": "ecb8536f5fb34543b55bb9dc5f5b14c9dbb4150a7bddb3f2287b7cab6e9d25ef",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb",
+			"version": "1:1.1.2-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxau6_1-1.0.9-1_amd64",
+			"name": "libxau6",
+			"sha256": "679db1c4579ec7c61079adeaae8528adeb2e4bf5465baa6c56233b995d714750",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb",
+			"version": "1:1.0.9-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libwebp6_0.6.1-2.1-p-deb11u2_amd64",
+			"name": "libwebp6",
+			"sha256": "8abc2b1ca77a458bbbcdeb6af5d85316260977370fa2518d017222b3584d9653",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_amd64.deb",
+			"version": "0.6.1-2.1+deb11u2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtiff5_4.2.0-1-p-deb11u5_amd64",
+			"name": "libtiff5",
+			"sha256": "7a70e9513e2b3c3a3d68f1614189f0be72b57eae2229aa64a3d7c8a3fe0639c9",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_amd64.deb",
+			"version": "4.2.0-1+deb11u5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
+			"name": "libzstd1",
+			"sha256": "5dcadfbb743bfa1c1c773bff91c018f835e8e8c821d423d3836f3ab84773507b",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_amd64.deb",
+			"version": "1.4.8+dfsg-2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libjpeg62-turbo_1-2.0.6-4_amd64",
+			"name": "libjpeg62-turbo",
+			"sha256": "28de780a1605cf501c3a4ebf3e588f5110e814b208548748ab064100c32202ea",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_amd64.deb",
+			"version": "1:2.0.6-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libjbig0_2.1-3.1-p-b2_amd64",
+			"name": "libjbig0",
+			"sha256": "9646d69eefce505407bf0437ea12fb7c2d47a3fd4434720ba46b642b6dcfd80f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_amd64.deb",
+			"version": "2.1-3.1+b2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libdeflate0_1.7-1_amd64",
+			"name": "libdeflate0",
+			"sha256": "dadaf0d28360f6eb21ad389b2e0f12f8709c9de539b28de9c11d7ec7043dec95",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_amd64.deb",
+			"version": "1.7-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpng16-16_1.6.37-3_amd64",
+			"name": "libpng16-16",
+			"sha256": "7d5336af395d1f658d0e66d74d0e1f4c632028750e7e04314d1a650e0317f3d6",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_amd64.deb",
+			"version": "1.6.37-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_amd64",
+			"name": "libfreetype6",
+			"sha256": "b21cfdd12adf6cac4af320c2485fb62a8a5edc6f9768bc2288fd686f4fa6dfdf",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_amd64.deb",
+			"version": "2.10.4+dfsg-1+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbrotli1_1.0.9-2-p-b2_amd64",
+			"name": "libbrotli1",
+			"sha256": "65ca7d8b03e9dac09c5d544a89dd52d1aeb74f6a19583d32e4ff5f0c77624c24",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_amd64.deb",
+			"version": "1.0.9-2+b2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libfontconfig1_2.13.1-4.2_amd64",
+			"name": "libfontconfig1",
+			"sha256": "b92861827627a76e74d6f447a5577d039ef2f95da18af1f29aa98fb96baea4c1",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_amd64.deb",
+			"version": "2.13.1-4.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "fontconfig-config_2.13.1-4.2_amd64",
+			"name": "fontconfig-config",
+			"sha256": "48afb6ad7d15e6104a343b789f73697301ad8bff77b69927bc998f5a409d8e90",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
+			"version": "2.13.1-4.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "ucf_3.0043_amd64",
+			"name": "ucf",
+			"sha256": "ebef6bcd777b5c0cc2699926f2159db08433aed07c50cb321fd828b28c5e8d53",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
+			"version": "3.0043"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "sensible-utils_0.0.14_amd64",
+			"name": "sensible-utils",
+			"sha256": "b9a447dc4ec8714196b037e20a2209e62cd669f5450222952f259bda4416b71f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
+			"version": "0.0.14"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libselinux1_3.1-3_amd64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_amd64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_amd64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_amd64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libattr1_1-2.4.48-6_amd64",
+					"name": "libattr1",
+					"version": "1:2.4.48-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_amd64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				}
+			],
+			"key": "coreutils_8.32-4-p-b1_amd64",
+			"name": "coreutils",
+			"sha256": "3558a412ab51eee4b60641327cb145bb91415f127769823b68f9335585b308d4",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4+b1_amd64.deb",
+			"version": "8.32-4+b1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
+			"name": "libgmp10",
+			"sha256": "fc117ccb084a98d25021f7e01e4dfedd414fa2118fdd1e27d2d801d7248aebbc",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb",
+			"version": "2:6.2.1+dfsg-1+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libattr1_1-2.4.48-6_amd64",
+			"name": "libattr1",
+			"sha256": "af3c3562eb2802481a2b9558df1b389f3c6d9b1bf3b4219e000e05131372ebaf",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_amd64.deb",
+			"version": "1:2.4.48-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libacl1_2.2.53-10_amd64",
+			"name": "libacl1",
+			"sha256": "aa18d721be8aea50fbdb32cd9a319cb18a3f111ea6ad17399aa4ba9324c8e26a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb",
+			"version": "2.2.53-10"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "debconf_1.5.77_amd64",
+			"name": "debconf",
+			"sha256": "d9ee4dff77aaad12674eed3ccefdcccd332424c9e2ac2ac00a37a1e06c84ab70",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
+			"version": "1.5.77"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "perl-base_5.32.1-4-p-deb11u3_amd64",
+			"name": "perl-base",
+			"sha256": "94c6299552866aadc58acb8ec5111a74b17bcb453f6e2f45ea5f7c4f42580d13",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_amd64.deb",
+			"version": "5.32.1-4+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "dpkg_1.20.13_amd64",
+			"name": "dpkg",
+			"sha256": "eb2b7ba3a3c4e905a380045a2d1cd219d2d45755aba5966d6c804b79400beb05",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb",
+			"version": "1.20.13"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
+			"name": "tar",
+			"sha256": "41c9c31f67a76b3532036f09ceac1f40a9224f1680395d120a8b24eae60dd54a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_amd64.deb",
+			"version": "1.34+dfsg-1+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbz2-1.0_1.0.8-4_amd64",
+			"name": "libbz2-1.0",
+			"sha256": "16e27c3ebd97981e70db3733f899963362748f178a62644df69d1f247e741379",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb",
+			"version": "1.0.8-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libuuid1_2.36.1-8-p-deb11u1_amd64",
+			"name": "libuuid1",
+			"sha256": "31250af4dd3b7d1519326a9a6764d1466a93d8f498cf6545058761ebc38b2823",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_amd64.deb",
+			"version": "2.36.1-8+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libexpat1_2.2.10-2-p-deb11u5_amd64",
+			"name": "libexpat1",
+			"sha256": "5744040c4735bcdd51238aebfa3e402b857244897f1007f61154982ebe5abbd7",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_amd64.deb",
+			"version": "2.2.10-2+deb11u5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-http-geoip",
+			"sha256": "639ceb3e17c3d5a3033757d86a57f3fa786be27ef51fd1618c8a84e9d55ef974",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-stream-geoip2",
+			"sha256": "20abf8d42ceebe21dcf76c9c4952b9b9a5d8c140affade21c8aebb22d38469d9",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmaxminddb0_1.5.2-1_amd64",
+			"name": "libmaxminddb0",
+			"sha256": "9779e86a61b8315d119939f3226472f17d707dce0673eff7b961a478e519e351",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_amd64.deb",
+			"version": "1.5.2-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-http-upstream-fair",
+			"sha256": "9650cbb1808fd4d63703b70d5d4599c34e4781c85f5e2b2b47f0abc934397f28",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-http-subs-filter",
+			"sha256": "fbfc00d65a6305911a7f025eb331912dadb6de7cdc5e65e5d94f2e65d70a5596",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-http-geoip2",
+			"sha256": "de912c363bb1864148379f0784c8031194a3749ae930a5fd0eb1bc2df63d7957",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-http-echo",
+			"sha256": "a5be1358d4fb799fdd5941377dea2c45cd013e2c4130dfce98f4af94aead1ec3",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-http-dav-ext",
+			"sha256": "48458923ac10ed4ad432237583b617702e8ca6b88da330989711aa734f7e06ee",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_amd64",
+			"name": "libnginx-mod-http-auth-pam",
+			"sha256": "08f23455c05eee95e8c0bf96d1a52e6a1ddcf509dd1b4dec97c778ff2c596c92",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_amd64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpam0g_1.4.0-9-p-deb11u1_amd64",
+			"name": "libpam0g",
+			"sha256": "496771218fb585bb716fdae6ef8824dbfb5d544b4fa2f3cd4d0e4d7158ae2220",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_amd64.deb",
+			"version": "1.4.0-9+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libaudit1_1-3.0-2_amd64",
+			"name": "libaudit1",
+			"sha256": "e3aa1383e387dc077a1176f7f3cbfdbc084bcc270a8938f598d5cb119773b268",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_amd64.deb",
+			"version": "1:3.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcap-ng0_0.7.9-2.2-p-b1_amd64",
+			"name": "libcap-ng0",
+			"sha256": "d34e29769b8ef23e9b9920814afb7905b8ee749db0814e6a8d937ccc4f309830",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_amd64.deb",
+			"version": "0.7.9-2.2+b1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libaudit-common_1-3.0-2_amd64",
+			"name": "libaudit-common",
+			"sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+			"version": "1:3.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tzdata_2024a-0-p-deb11u1_amd64",
+			"name": "tzdata",
+			"sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+			"version": "2024a-0+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "debianutils_4.11.2_amd64",
+					"name": "debianutils",
+					"version": "4.11.2"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_amd64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_amd64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_amd64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "base-files_11.1-p-deb11u9_amd64",
+					"name": "base-files",
+					"version": "11.1+deb11u9"
+				},
+				{
+					"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
+					"name": "libtinfo6",
+					"version": "6.2+20201114-2+deb11u2"
+				}
+			],
+			"key": "bash_5.1-2-p-deb11u1_amd64",
+			"name": "bash",
+			"sha256": "f702ef058e762d7208a9c83f6f6bbf02645533bfd615c54e8cdcce842cd57377",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_amd64.deb",
+			"version": "5.1-2+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "debianutils_4.11.2_amd64",
+			"name": "debianutils",
+			"sha256": "83d21669c5957e3eaee20096a7d8c596bd07f57f1e95dc74f192b3fb7bb2e6a9",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_amd64.deb",
+			"version": "4.11.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "base-files_11.1-p-deb11u9_amd64",
+			"name": "base-files",
+			"sha256": "1ff08cf6e1b97af1e37cda830f3658f9af43a906abb80a21951c81aea02ce230",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_amd64.deb",
+			"version": "11.1+deb11u9"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
+			"name": "libtinfo6",
+			"sha256": "96ed58b8fd656521e08549c763cd18da6cff1b7801a3a22f29678701a95d7e7b",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_amd64.deb",
+			"version": "6.2+20201114-2+deb11u2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "nginx-core_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "nginx-core",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2+deb11u2"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_arm64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_arm64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_arm64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
+					"name": "libssl1.1",
+					"version": "1.1.1w-0+deb11u1"
+				},
+				{
+					"key": "libpcre3_2-8.39-13_arm64",
+					"name": "libpcre3",
+					"version": "2:8.39-13"
+				},
+				{
+					"key": "iproute2_5.10.0-4_arm64",
+					"name": "iproute2",
+					"version": "5.10.0-4"
+				},
+				{
+					"key": "libcap2-bin_1-2.44-1_arm64",
+					"name": "libcap2-bin",
+					"version": "1:2.44-1"
+				},
+				{
+					"key": "libcap2_1-2.44-1_arm64",
+					"name": "libcap2",
+					"version": "1:2.44-1"
+				},
+				{
+					"key": "libxtables12_1.8.7-1_arm64",
+					"name": "libxtables12",
+					"version": "1.8.7-1"
+				},
+				{
+					"key": "libselinux1_3.1-3_arm64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libmnl0_1.0.4-3_arm64",
+					"name": "libmnl0",
+					"version": "1.0.4-3"
+				},
+				{
+					"key": "libelf1_0.183-1_arm64",
+					"name": "libelf1",
+					"version": "0.183-1"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.8"
+				},
+				{
+					"key": "libbsd0_0.11.3-1-p-deb11u1_arm64",
+					"name": "libbsd0",
+					"version": "0.11.3-1+deb11u1"
+				},
+				{
+					"key": "libmd0_1.0.3-3_arm64",
+					"name": "libmd0",
+					"version": "1.0.3-3"
+				},
+				{
+					"key": "libbpf0_1-0.3-2_arm64",
+					"name": "libbpf0",
+					"version": "1:0.3-2"
+				},
+				{
+					"key": "nginx-common_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "nginx-common",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "lsb-base_11.1.0_arm64",
+					"name": "lsb-base",
+					"version": "11.1.0"
+				},
+				{
+					"key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-stream-geoip",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-stream",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libgeoip1_1.6.12-7_arm64",
+					"name": "libgeoip1",
+					"version": "1.6.12-7"
+				},
+				{
+					"key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-mail",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-xslt-filter",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libxslt1.1_1.1.34-4-p-deb11u1_arm64",
+					"name": "libxslt1.1",
+					"version": "1.1.34-4+deb11u1"
+				},
+				{
+					"key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_arm64",
+					"name": "libxml2",
+					"version": "2.9.10+dfsg-6.7+deb11u4"
+				},
+				{
+					"key": "liblzma5_5.2.5-2.1_deb11u1_arm64",
+					"name": "liblzma5",
+					"version": "5.2.5-2.1~deb11u1"
+				},
+				{
+					"key": "libicu67_67.1-7_arm64",
+					"name": "libicu67",
+					"version": "67.1-7"
+				},
+				{
+					"key": "libstdc-p--p-6_10.2.1-6_arm64",
+					"name": "libstdc++6",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libgcrypt20_1.8.7-6_arm64",
+					"name": "libgcrypt20",
+					"version": "1.8.7-6"
+				},
+				{
+					"key": "libgpg-error0_1.38-2_arm64",
+					"name": "libgpg-error0",
+					"version": "1.38-2"
+				},
+				{
+					"key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-image-filter",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libgd3_2.3.0-2_arm64",
+					"name": "libgd3",
+					"version": "2.3.0-2"
+				},
+				{
+					"key": "libxpm4_1-3.5.12-1.1-p-deb11u1_arm64",
+					"name": "libxpm4",
+					"version": "1:3.5.12-1.1+deb11u1"
+				},
+				{
+					"key": "libx11-6_2-1.7.2-1-p-deb11u2_arm64",
+					"name": "libx11-6",
+					"version": "2:1.7.2-1+deb11u2"
+				},
+				{
+					"key": "libx11-data_2-1.7.2-1-p-deb11u2_arm64",
+					"name": "libx11-data",
+					"version": "2:1.7.2-1+deb11u2"
+				},
+				{
+					"key": "libxcb1_1.14-3_arm64",
+					"name": "libxcb1",
+					"version": "1.14-3"
+				},
+				{
+					"key": "libxdmcp6_1-1.1.2-3_arm64",
+					"name": "libxdmcp6",
+					"version": "1:1.1.2-3"
+				},
+				{
+					"key": "libxau6_1-1.0.9-1_arm64",
+					"name": "libxau6",
+					"version": "1:1.0.9-1"
+				},
+				{
+					"key": "libwebp6_0.6.1-2.1-p-deb11u2_arm64",
+					"name": "libwebp6",
+					"version": "0.6.1-2.1+deb11u2"
+				},
+				{
+					"key": "libtiff5_4.2.0-1-p-deb11u5_arm64",
+					"name": "libtiff5",
+					"version": "4.2.0-1+deb11u5"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-2.1"
+				},
+				{
+					"key": "libjpeg62-turbo_1-2.0.6-4_arm64",
+					"name": "libjpeg62-turbo",
+					"version": "1:2.0.6-4"
+				},
+				{
+					"key": "libjbig0_2.1-3.1-p-b2_arm64",
+					"name": "libjbig0",
+					"version": "2.1-3.1+b2"
+				},
+				{
+					"key": "libdeflate0_1.7-1_arm64",
+					"name": "libdeflate0",
+					"version": "1.7-1"
+				},
+				{
+					"key": "libpng16-16_1.6.37-3_arm64",
+					"name": "libpng16-16",
+					"version": "1.6.37-3"
+				},
+				{
+					"key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_arm64",
+					"name": "libfreetype6",
+					"version": "2.10.4+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libbrotli1_1.0.9-2-p-b2_arm64",
+					"name": "libbrotli1",
+					"version": "1.0.9-2+b2"
+				},
+				{
+					"key": "libfontconfig1_2.13.1-4.2_arm64",
+					"name": "libfontconfig1",
+					"version": "2.13.1-4.2"
+				},
+				{
+					"key": "fontconfig-config_2.13.1-4.2_arm64",
+					"name": "fontconfig-config",
+					"version": "2.13.1-4.2"
+				},
+				{
+					"key": "ucf_3.0043_arm64",
+					"name": "ucf",
+					"version": "3.0043"
+				},
+				{
+					"key": "sensible-utils_0.0.14_arm64",
+					"name": "sensible-utils",
+					"version": "0.0.14"
+				},
+				{
+					"key": "coreutils_8.32-4_arm64",
+					"name": "coreutils",
+					"version": "8.32-4"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libattr1_1-2.4.48-6_arm64",
+					"name": "libattr1",
+					"version": "1:2.4.48-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_arm64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				},
+				{
+					"key": "debconf_1.5.77_arm64",
+					"name": "debconf",
+					"version": "1.5.77"
+				},
+				{
+					"key": "perl-base_5.32.1-4-p-deb11u3_arm64",
+					"name": "perl-base",
+					"version": "5.32.1-4+deb11u3"
+				},
+				{
+					"key": "dpkg_1.20.13_arm64",
+					"name": "dpkg",
+					"version": "1.20.13"
+				},
+				{
+					"key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
+					"name": "tar",
+					"version": "1.34+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-4_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-4"
+				},
+				{
+					"key": "libuuid1_2.36.1-8-p-deb11u1_arm64",
+					"name": "libuuid1",
+					"version": "2.36.1-8+deb11u1"
+				},
+				{
+					"key": "libexpat1_2.2.10-2-p-deb11u5_arm64",
+					"name": "libexpat1",
+					"version": "2.2.10-2+deb11u5"
+				},
+				{
+					"key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-geoip",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-stream-geoip2",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libmaxminddb0_1.5.2-1_arm64",
+					"name": "libmaxminddb0",
+					"version": "1.5.2-1"
+				},
+				{
+					"key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-upstream-fair",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-subs-filter",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-geoip2",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-echo",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-dav-ext",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-auth-pam",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libpam0g_1.4.0-9-p-deb11u1_arm64",
+					"name": "libpam0g",
+					"version": "1.4.0-9+deb11u1"
+				},
+				{
+					"key": "libaudit1_1-3.0-2_arm64",
+					"name": "libaudit1",
+					"version": "1:3.0-2"
+				},
+				{
+					"key": "libcap-ng0_0.7.9-2.2-p-b1_arm64",
+					"name": "libcap-ng0",
+					"version": "0.7.9-2.2+b1"
+				},
+				{
+					"key": "libaudit-common_1-3.0-2_arm64",
+					"name": "libaudit-common",
+					"version": "1:3.0-2"
+				}
+			],
+			"key": "nginx-full_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "nginx-full",
+			"sha256": "4049950f648478009faeaf028ab7287240ebd28c27799a5b128a1623290b3e44",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2+deb11u2"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_arm64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_arm64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_arm64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
+					"name": "libssl1.1",
+					"version": "1.1.1w-0+deb11u1"
+				},
+				{
+					"key": "libpcre3_2-8.39-13_arm64",
+					"name": "libpcre3",
+					"version": "2:8.39-13"
+				},
+				{
+					"key": "iproute2_5.10.0-4_arm64",
+					"name": "iproute2",
+					"version": "5.10.0-4"
+				},
+				{
+					"key": "libcap2-bin_1-2.44-1_arm64",
+					"name": "libcap2-bin",
+					"version": "1:2.44-1"
+				},
+				{
+					"key": "libcap2_1-2.44-1_arm64",
+					"name": "libcap2",
+					"version": "1:2.44-1"
+				},
+				{
+					"key": "libxtables12_1.8.7-1_arm64",
+					"name": "libxtables12",
+					"version": "1.8.7-1"
+				},
+				{
+					"key": "libselinux1_3.1-3_arm64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libmnl0_1.0.4-3_arm64",
+					"name": "libmnl0",
+					"version": "1.0.4-3"
+				},
+				{
+					"key": "libelf1_0.183-1_arm64",
+					"name": "libelf1",
+					"version": "0.183-1"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.8"
+				},
+				{
+					"key": "libbsd0_0.11.3-1-p-deb11u1_arm64",
+					"name": "libbsd0",
+					"version": "0.11.3-1+deb11u1"
+				},
+				{
+					"key": "libmd0_1.0.3-3_arm64",
+					"name": "libmd0",
+					"version": "1.0.3-3"
+				},
+				{
+					"key": "libbpf0_1-0.3-2_arm64",
+					"name": "libbpf0",
+					"version": "1:0.3-2"
+				},
+				{
+					"key": "nginx-common_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "nginx-common",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "lsb-base_11.1.0_arm64",
+					"name": "lsb-base",
+					"version": "11.1.0"
+				},
+				{
+					"key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-stream-geoip",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-stream",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libgeoip1_1.6.12-7_arm64",
+					"name": "libgeoip1",
+					"version": "1.6.12-7"
+				},
+				{
+					"key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-mail",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-xslt-filter",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libxslt1.1_1.1.34-4-p-deb11u1_arm64",
+					"name": "libxslt1.1",
+					"version": "1.1.34-4+deb11u1"
+				},
+				{
+					"key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_arm64",
+					"name": "libxml2",
+					"version": "2.9.10+dfsg-6.7+deb11u4"
+				},
+				{
+					"key": "liblzma5_5.2.5-2.1_deb11u1_arm64",
+					"name": "liblzma5",
+					"version": "5.2.5-2.1~deb11u1"
+				},
+				{
+					"key": "libicu67_67.1-7_arm64",
+					"name": "libicu67",
+					"version": "67.1-7"
+				},
+				{
+					"key": "libstdc-p--p-6_10.2.1-6_arm64",
+					"name": "libstdc++6",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libgcrypt20_1.8.7-6_arm64",
+					"name": "libgcrypt20",
+					"version": "1.8.7-6"
+				},
+				{
+					"key": "libgpg-error0_1.38-2_arm64",
+					"name": "libgpg-error0",
+					"version": "1.38-2"
+				},
+				{
+					"key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-image-filter",
+					"version": "1.18.0-6.1+deb11u3"
+				},
+				{
+					"key": "libgd3_2.3.0-2_arm64",
+					"name": "libgd3",
+					"version": "2.3.0-2"
+				},
+				{
+					"key": "libxpm4_1-3.5.12-1.1-p-deb11u1_arm64",
+					"name": "libxpm4",
+					"version": "1:3.5.12-1.1+deb11u1"
+				},
+				{
+					"key": "libx11-6_2-1.7.2-1-p-deb11u2_arm64",
+					"name": "libx11-6",
+					"version": "2:1.7.2-1+deb11u2"
+				},
+				{
+					"key": "libx11-data_2-1.7.2-1-p-deb11u2_arm64",
+					"name": "libx11-data",
+					"version": "2:1.7.2-1+deb11u2"
+				},
+				{
+					"key": "libxcb1_1.14-3_arm64",
+					"name": "libxcb1",
+					"version": "1.14-3"
+				},
+				{
+					"key": "libxdmcp6_1-1.1.2-3_arm64",
+					"name": "libxdmcp6",
+					"version": "1:1.1.2-3"
+				},
+				{
+					"key": "libxau6_1-1.0.9-1_arm64",
+					"name": "libxau6",
+					"version": "1:1.0.9-1"
+				},
+				{
+					"key": "libwebp6_0.6.1-2.1-p-deb11u2_arm64",
+					"name": "libwebp6",
+					"version": "0.6.1-2.1+deb11u2"
+				},
+				{
+					"key": "libtiff5_4.2.0-1-p-deb11u5_arm64",
+					"name": "libtiff5",
+					"version": "4.2.0-1+deb11u5"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-2.1"
+				},
+				{
+					"key": "libjpeg62-turbo_1-2.0.6-4_arm64",
+					"name": "libjpeg62-turbo",
+					"version": "1:2.0.6-4"
+				},
+				{
+					"key": "libjbig0_2.1-3.1-p-b2_arm64",
+					"name": "libjbig0",
+					"version": "2.1-3.1+b2"
+				},
+				{
+					"key": "libdeflate0_1.7-1_arm64",
+					"name": "libdeflate0",
+					"version": "1.7-1"
+				},
+				{
+					"key": "libpng16-16_1.6.37-3_arm64",
+					"name": "libpng16-16",
+					"version": "1.6.37-3"
+				},
+				{
+					"key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_arm64",
+					"name": "libfreetype6",
+					"version": "2.10.4+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libbrotli1_1.0.9-2-p-b2_arm64",
+					"name": "libbrotli1",
+					"version": "1.0.9-2+b2"
+				},
+				{
+					"key": "libfontconfig1_2.13.1-4.2_arm64",
+					"name": "libfontconfig1",
+					"version": "2.13.1-4.2"
+				},
+				{
+					"key": "fontconfig-config_2.13.1-4.2_arm64",
+					"name": "fontconfig-config",
+					"version": "2.13.1-4.2"
+				},
+				{
+					"key": "ucf_3.0043_arm64",
+					"name": "ucf",
+					"version": "3.0043"
+				},
+				{
+					"key": "sensible-utils_0.0.14_arm64",
+					"name": "sensible-utils",
+					"version": "0.0.14"
+				},
+				{
+					"key": "coreutils_8.32-4_arm64",
+					"name": "coreutils",
+					"version": "8.32-4"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libattr1_1-2.4.48-6_arm64",
+					"name": "libattr1",
+					"version": "1:2.4.48-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_arm64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				},
+				{
+					"key": "debconf_1.5.77_arm64",
+					"name": "debconf",
+					"version": "1.5.77"
+				},
+				{
+					"key": "perl-base_5.32.1-4-p-deb11u3_arm64",
+					"name": "perl-base",
+					"version": "5.32.1-4+deb11u3"
+				},
+				{
+					"key": "dpkg_1.20.13_arm64",
+					"name": "dpkg",
+					"version": "1.20.13"
+				},
+				{
+					"key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
+					"name": "tar",
+					"version": "1.34+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-4_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-4"
+				},
+				{
+					"key": "libuuid1_2.36.1-8-p-deb11u1_arm64",
+					"name": "libuuid1",
+					"version": "2.36.1-8+deb11u1"
+				},
+				{
+					"key": "libexpat1_2.2.10-2-p-deb11u5_arm64",
+					"name": "libexpat1",
+					"version": "2.2.10-2+deb11u5"
+				},
+				{
+					"key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_arm64",
+					"name": "libnginx-mod-http-geoip",
+					"version": "1.18.0-6.1+deb11u3"
+				}
+			],
+			"key": "nginx-core_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "nginx-core",
+			"sha256": "932d9d78df093f037caf9a32af5f3a9f42f113ccc87ca59946f983753a9b83b8",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
+			"name": "zlib1g",
+			"sha256": "e3963985d1a020d67ffd4180e6f9c4b5c600b515f0c9d8fda513d7a0e48e63a1",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_arm64.deb",
+			"version": "1:1.2.11.dfsg-2+deb11u2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libc6_2.31-13-p-deb11u8_arm64",
+			"name": "libc6",
+			"sha256": "6eb629090615ebda5dcac2365a7358c035add00b89c2724c2e9e13ccd5bd9f7c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_arm64.deb",
+			"version": "2.31-13+deb11u8"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.18-4_arm64",
+			"name": "libcrypt1",
+			"sha256": "22b586b29e840dabebf0bf227d233376628b87954915d064bc142ae85d1b7979",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_arm64.deb",
+			"version": "1:4.4.18-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcc-s1_10.2.1-6_arm64",
+			"name": "libgcc-s1",
+			"sha256": "e2fcdb378d3c1ad1bcb64d4fb6b37aab44011152beca12a4944f435a2582df1f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_arm64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc-10-base_10.2.1-6_arm64",
+			"name": "gcc-10-base",
+			"sha256": "7d782bece7b4a36bed045a7e17d17244cb8f7e4732466091b01412ebf215defb",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_arm64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
+			"name": "libssl1.1",
+			"sha256": "fe7a7d313c87e46e62e614a07137e4a476a79fc9e5aab7b23e8235211280fee3",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_arm64.deb",
+			"version": "1.1.1w-0+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpcre3_2-8.39-13_arm64",
+			"name": "libpcre3",
+			"sha256": "21cac4064a41dbc354295c437f37bf623f9004513a97a6fa030248566aa986e9",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_arm64.deb",
+			"version": "2:8.39-13"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "iproute2_5.10.0-4_arm64",
+			"name": "iproute2",
+			"sha256": "92d6c7ca67fca91257a3734d94417a3300c4240d8f6934c6b742c001814b4e31",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_arm64.deb",
+			"version": "5.10.0-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcap2-bin_1-2.44-1_arm64",
+			"name": "libcap2-bin",
+			"sha256": "37915f4cc73cfaef7862043f2bdad062d1b1639df04c511665f1f9321c84d0db",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_arm64.deb",
+			"version": "1:2.44-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcap2_1-2.44-1_arm64",
+			"name": "libcap2",
+			"sha256": "7c5729a1cfd14876685217c5f0545301e7ff1b839262fb487d6a778e8cd8c05a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_arm64.deb",
+			"version": "1:2.44-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libxtables12_1.8.7-1_arm64",
+			"name": "libxtables12",
+			"sha256": "fa07088a313d8dae7a8cba0780117e80ead683ac549fd9986a52a3280232272a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_arm64.deb",
+			"version": "1.8.7-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libselinux1_3.1-3_arm64",
+			"name": "libselinux1",
+			"sha256": "da98279a47dabaa46a83514142f5c691c6a71fa7e582661a3a3db6887ad3e9d1",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_arm64.deb",
+			"version": "3.1-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
+			"name": "libpcre2-8-0",
+			"sha256": "27a4362a4793cb67a8ae571bd8c3f7e8654dc2e56d99088391b87af1793cca9c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_arm64.deb",
+			"version": "10.36-2+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libmnl0_1.0.4-3_arm64",
+			"name": "libmnl0",
+			"sha256": "d63aafb6f2c07db8fcb135b00ff915baf72ef8a3397e773c9c24d67950c6a46c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_arm64.deb",
+			"version": "1.0.4-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libelf1_0.183-1_arm64",
+			"name": "libelf1",
+			"sha256": "12e14110cd66b3bf0564e3b184985b3e91c9cd76e909531a7f7bd2cb9b35a1f3",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_arm64.deb",
+			"version": "0.183-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
+			"name": "libdb5.3",
+			"sha256": "cf9aa3eae9cfc4c84f93e32f3d11e2707146e4d9707712909e3c61530b50353e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_arm64.deb",
+			"version": "5.3.28+dfsg1-0.8"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libbsd0_0.11.3-1-p-deb11u1_arm64",
+			"name": "libbsd0",
+			"sha256": "614d36d41b670955a75526865bd321703f2accb6e0c07ee4c283fbba12e494df",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_arm64.deb",
+			"version": "0.11.3-1+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libmd0_1.0.3-3_arm64",
+			"name": "libmd0",
+			"sha256": "3c490cdcce9d25e702e6587b6166cd8e7303fce8343642d9d5d99695282a9e5c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_arm64.deb",
+			"version": "1.0.3-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libbpf0_1-0.3-2_arm64",
+			"name": "libbpf0",
+			"sha256": "1ef325a3bd9e43970cd8e7f9f44b13e36bc935ac496e56d96f715aa69ae7281b",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_arm64.deb",
+			"version": "1:0.3-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "nginx-common_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "nginx-common",
+			"sha256": "bfd22beb7bd248db58eee6e6434a7c500f6e98e264219b3832f248696cd58f67",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "lsb-base_11.1.0_arm64",
+			"name": "lsb-base",
+			"sha256": "89ed6332074d827a65305f9a51e591dff20641d61ff5e11f4e1822a9987e96fe",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
+			"version": "11.1.0"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-stream-geoip",
+			"sha256": "140963ecb81a3ea933e96fd7c89d01c4ffdb12509e3869d769d7b21ca5d690bf",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-stream",
+			"sha256": "88d083135df9c2c1e2401f174b4e48dde2d92cca7fc8ef661f9d26f00b395a75",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgeoip1_1.6.12-7_arm64",
+			"name": "libgeoip1",
+			"sha256": "17225fb2ed7ce9a090c39d90acc2696e5582805a2a1f391e0a8278bb6a2d0178",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_arm64.deb",
+			"version": "1.6.12-7"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-mail",
+			"sha256": "f8fa0d620dcdea21669b5fd9f503528d53b94117a9c31ac36dc318db0fbac315",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-http-xslt-filter",
+			"sha256": "5d9bb33231c8589a07063a73bb6b3061bc92fae79e5731e96b5b398f1fafee29",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libxslt1.1_1.1.34-4-p-deb11u1_arm64",
+			"name": "libxslt1.1",
+			"sha256": "2505ed3d8e6b049349ecfeff1cb6923eca43403d252e8ddd308a6a644b97eec7",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_arm64.deb",
+			"version": "1.1.34-4+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_arm64",
+			"name": "libxml2",
+			"sha256": "ccd9f449fa88827258bd51eeb8d5f6f33719df290f157c2b0be3c527a6ee45aa",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_arm64.deb",
+			"version": "2.9.10+dfsg-6.7+deb11u4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "liblzma5_5.2.5-2.1_deb11u1_arm64",
+			"name": "liblzma5",
+			"sha256": "d865bba41952c707b3fa3ae8cab4d4bd337ee92991d2aead66c925bf7cc48846",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_arm64.deb",
+			"version": "5.2.5-2.1~deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libicu67_67.1-7_arm64",
+			"name": "libicu67",
+			"sha256": "776303db230b275d8a17dfe8f0012bf61093dfc910f0d51f175be36707686efe",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_arm64.deb",
+			"version": "67.1-7"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libstdc-p--p-6_10.2.1-6_arm64",
+			"name": "libstdc++6",
+			"sha256": "7869aa540cc46e9f3d4267d5bde2af0e5b429a820c1d6f1a4cfccfe788c31890",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_arm64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcrypt20_1.8.7-6_arm64",
+			"name": "libgcrypt20",
+			"sha256": "61ec779149f20923b30adad7bdf4732957e88a5b6a26d94b2210dfe79409959b",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_arm64.deb",
+			"version": "1.8.7-6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgpg-error0_1.38-2_arm64",
+			"name": "libgpg-error0",
+			"sha256": "d1116f4281d6db35279799a21051e0d0e2600d110d7ee2b95b3cca6bec28067c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_arm64.deb",
+			"version": "1.38-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-http-image-filter",
+			"sha256": "d972b39dcca41c42f7c797fcc4472d81b64e99978845b2309e18e6d5937e384e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgd3_2.3.0-2_arm64",
+			"name": "libgd3",
+			"sha256": "1e6d6af0c90fe62193b3e51e45f69d075b86d7bde3fb4fd30b60da763aeca43f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_arm64.deb",
+			"version": "2.3.0-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libxpm4_1-3.5.12-1.1-p-deb11u1_arm64",
+			"name": "libxpm4",
+			"sha256": "83ba23ecaaf3f7b700f1ec2c1e349b5a63f3c8cdceb43cc78eb353e16051427d",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_arm64.deb",
+			"version": "1:3.5.12-1.1+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libx11-6_2-1.7.2-1-p-deb11u2_arm64",
+			"name": "libx11-6",
+			"sha256": "1ddb1a4d3dbdaeac8fd8d0009a27e6453b15d97362fdd1d3efb1d5f577364f30",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_arm64.deb",
+			"version": "2:1.7.2-1+deb11u2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libx11-data_2-1.7.2-1-p-deb11u2_arm64",
+			"name": "libx11-data",
+			"sha256": "9db24e1e7ed3cd738b503e7df5c1b9b52b1eadcb55019cd63b1409e578565d29",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb",
+			"version": "2:1.7.2-1+deb11u2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libxcb1_1.14-3_arm64",
+			"name": "libxcb1",
+			"sha256": "48f82b65c93adb7af7757961fdd2730928316459f008d767b7104a56bc20a8f1",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_arm64.deb",
+			"version": "1.14-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libxdmcp6_1-1.1.2-3_arm64",
+			"name": "libxdmcp6",
+			"sha256": "e92569ac33247261aa09adfadc34ced3994ac301cf8b58de415a2d5dbf15ccfc",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb",
+			"version": "1:1.1.2-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libxau6_1-1.0.9-1_arm64",
+			"name": "libxau6",
+			"sha256": "36c2bf400641a80521093771dc2562c903df4065f9eb03add50d90564337ea6c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb",
+			"version": "1:1.0.9-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libwebp6_0.6.1-2.1-p-deb11u2_arm64",
+			"name": "libwebp6",
+			"sha256": "edeb260e528fecae77457a63a468e55837a98079fdd7f1e20e9813c358f8c755",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_arm64.deb",
+			"version": "0.6.1-2.1+deb11u2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtiff5_4.2.0-1-p-deb11u5_arm64",
+			"name": "libtiff5",
+			"sha256": "6896296ef6193ff77434c5d1d09dd9a333633f7a208ab1cc7de3b286d2d45824",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_arm64.deb",
+			"version": "4.2.0-1+deb11u5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
+			"name": "libzstd1",
+			"sha256": "dd01659c6c122f983a3369a04ede63539f666585d52a03f8aa2c27b307e547e0",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_arm64.deb",
+			"version": "1.4.8+dfsg-2.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libjpeg62-turbo_1-2.0.6-4_arm64",
+			"name": "libjpeg62-turbo",
+			"sha256": "8903394de23dc6ead5abfc80972c8fd44300c9903ad4589d0df926e71977d881",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_arm64.deb",
+			"version": "1:2.0.6-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libjbig0_2.1-3.1-p-b2_arm64",
+			"name": "libjbig0",
+			"sha256": "b71b3e62e162f64cb24466bf7c6e40b05ce2a67ca7fed26d267d498f2896d549",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_arm64.deb",
+			"version": "2.1-3.1+b2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libdeflate0_1.7-1_arm64",
+			"name": "libdeflate0",
+			"sha256": "a1adc22600ea5e44e8ea715972ac2af7994cc7ff4d94bba8e8b01abb9ddbdfd0",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_arm64.deb",
+			"version": "1.7-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpng16-16_1.6.37-3_arm64",
+			"name": "libpng16-16",
+			"sha256": "f5f61274aa5f71b9e44b077bd7b9fa9cd5ff71d8b8295f47dc1b2d45378aa73e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_arm64.deb",
+			"version": "1.6.37-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_arm64",
+			"name": "libfreetype6",
+			"sha256": "b25f1c148498dd2b49dc30da0a2b2537a7bd0cb34afb8ea681dd145053c9a3f8",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_arm64.deb",
+			"version": "2.10.4+dfsg-1+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libbrotli1_1.0.9-2-p-b2_arm64",
+			"name": "libbrotli1",
+			"sha256": "52ca7f90de6cb6576a0a5cf5712fc4ae7344b79c44b8a1548087fd5d92bf1f64",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_arm64.deb",
+			"version": "1.0.9-2+b2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libfontconfig1_2.13.1-4.2_arm64",
+			"name": "libfontconfig1",
+			"sha256": "18b13ef8a46e9d79ba6a6ba2db0c86e42583277b5d47f6942f3223e349c22641",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_arm64.deb",
+			"version": "2.13.1-4.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "fontconfig-config_2.13.1-4.2_arm64",
+			"name": "fontconfig-config",
+			"sha256": "48afb6ad7d15e6104a343b789f73697301ad8bff77b69927bc998f5a409d8e90",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
+			"version": "2.13.1-4.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "ucf_3.0043_arm64",
+			"name": "ucf",
+			"sha256": "ebef6bcd777b5c0cc2699926f2159db08433aed07c50cb321fd828b28c5e8d53",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
+			"version": "3.0043"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "sensible-utils_0.0.14_arm64",
+			"name": "sensible-utils",
+			"sha256": "b9a447dc4ec8714196b037e20a2209e62cd669f5450222952f259bda4416b71f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
+			"version": "0.0.14"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libselinux1_3.1-3_arm64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_arm64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_arm64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_arm64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libattr1_1-2.4.48-6_arm64",
+					"name": "libattr1",
+					"version": "1:2.4.48-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_arm64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				}
+			],
+			"key": "coreutils_8.32-4_arm64",
+			"name": "coreutils",
+			"sha256": "6210c84d6ff84b867dc430f661f22f536e1704c27bdb79de38e26f75b853d9c0",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4_arm64.deb",
+			"version": "8.32-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
+			"name": "libgmp10",
+			"sha256": "d52619b6ff8829aa5424dfe3189dd05f22118211e69273e9576030584ffcce80",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_arm64.deb",
+			"version": "2:6.2.1+dfsg-1+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libattr1_1-2.4.48-6_arm64",
+			"name": "libattr1",
+			"sha256": "cb9b59be719a6fdbaabaa60e22aa6158b2de7a68c88ccd7c3fb7f41a25fb43d0",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_arm64.deb",
+			"version": "1:2.4.48-6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libacl1_2.2.53-10_arm64",
+			"name": "libacl1",
+			"sha256": "f164c48192cb47746101de6c59afa3f97777c8fc821e5a30bb890df1f4cb4cfd",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_arm64.deb",
+			"version": "2.2.53-10"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "debconf_1.5.77_arm64",
+			"name": "debconf",
+			"sha256": "d9ee4dff77aaad12674eed3ccefdcccd332424c9e2ac2ac00a37a1e06c84ab70",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
+			"version": "1.5.77"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "perl-base_5.32.1-4-p-deb11u3_arm64",
+			"name": "perl-base",
+			"sha256": "53e09d9594692c462f33d4e9394bff60f95fe74b70402772dc7396a5829b76e5",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_arm64.deb",
+			"version": "5.32.1-4+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "dpkg_1.20.13_arm64",
+			"name": "dpkg",
+			"sha256": "87b0bce7361d94cc15caf27709fa8a70de44f9dd742cf0d69d25796a03d24853",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_arm64.deb",
+			"version": "1.20.13"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
+			"name": "tar",
+			"sha256": "0f94aac4e6d25e07ed23b7fc3ed06e69074c95276d82caae7fc7b207fd714e39",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_arm64.deb",
+			"version": "1.34+dfsg-1+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libbz2-1.0_1.0.8-4_arm64",
+			"name": "libbz2-1.0",
+			"sha256": "da340e8470e96445c56966f74e48a9a91dee0fa5c89876e88a4575cc17d17a97",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_arm64.deb",
+			"version": "1.0.8-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libuuid1_2.36.1-8-p-deb11u1_arm64",
+			"name": "libuuid1",
+			"sha256": "3d677da6a22e9cac519fed5a2ed5b20a4217f51ca420fce57434b5e813c26e03",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_arm64.deb",
+			"version": "2.36.1-8+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libexpat1_2.2.10-2-p-deb11u5_arm64",
+			"name": "libexpat1",
+			"sha256": "8d20bfd061845bda0321d01accd6f8386ead5b1d7250a585d12b8d5fb1408ffa",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_arm64.deb",
+			"version": "2.2.10-2+deb11u5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-http-geoip",
+			"sha256": "7b1d105339402426108d4d10fa733f24f2340c9b6482d10917c194d13f66072f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-stream-geoip2",
+			"sha256": "da0e67b4cc318b7bb338bec7476c260fecd6cc06ecfad4c7f9acb22a4a74d07b",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libmaxminddb0_1.5.2-1_arm64",
+			"name": "libmaxminddb0",
+			"sha256": "05504845f0fab5c54075e462b99b326a224ceaefaccda864f641f1bf6d99914d",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_arm64.deb",
+			"version": "1.5.2-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-http-upstream-fair",
+			"sha256": "7be1dfa763e9158ccdea168b1103f5b6b16b3a0c95c3996076c7f4a20aa35bca",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-http-subs-filter",
+			"sha256": "22354006f199cc3e8e51aac00ca649dd169ca91c2e565a4734f18f3741b061ef",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-http-geoip2",
+			"sha256": "1ae5c1491a8f43ff3a0269270d1f954441cf6fb160b3f83bb2f10ae7b47eb0ce",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-http-echo",
+			"sha256": "ef014f5f294e744e465a9075722c1d7cb3423392b2bd029d60e0d952fd90fde7",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-http-dav-ext",
+			"sha256": "8c65130c9d18a28eadfb657bbe818de567ed6625147e868c3bbd739189f8a991",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_arm64",
+			"name": "libnginx-mod-http-auth-pam",
+			"sha256": "4e6e906608ef1960c2514f371445bf3a32ea72b7098cae38cedac4b5c10abf05",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_arm64.deb",
+			"version": "1.18.0-6.1+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpam0g_1.4.0-9-p-deb11u1_arm64",
+			"name": "libpam0g",
+			"sha256": "4905e523ce38e80b79f13f0227fca519f6833eb116dd9c58cbbecb39c0e01e3d",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_arm64.deb",
+			"version": "1.4.0-9+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libaudit1_1-3.0-2_arm64",
+			"name": "libaudit1",
+			"sha256": "c93da146715dcd0c71759629c04afb01a41c879d91b2f5330adc74365db03763",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_arm64.deb",
+			"version": "1:3.0-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcap-ng0_0.7.9-2.2-p-b1_arm64",
+			"name": "libcap-ng0",
+			"sha256": "b7b14e0b7747872f04691efe6c126de5ed0bf1dc200f51b93039cc2f4a65a96a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_arm64.deb",
+			"version": "0.7.9-2.2+b1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libaudit-common_1-3.0-2_arm64",
+			"name": "libaudit-common",
+			"sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+			"version": "1:3.0-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "tzdata_2024a-0-p-deb11u1_arm64",
+			"name": "tzdata",
+			"sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+			"version": "2024a-0+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "debianutils_4.11.2_arm64",
+					"name": "debianutils",
+					"version": "4.11.2"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_arm64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_arm64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_arm64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "base-files_11.1-p-deb11u9_arm64",
+					"name": "base-files",
+					"version": "11.1+deb11u9"
+				},
+				{
+					"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
+					"name": "libtinfo6",
+					"version": "6.2+20201114-2+deb11u2"
+				}
+			],
+			"key": "bash_5.1-2-p-deb11u1_arm64",
+			"name": "bash",
+			"sha256": "d7c7af5d86f43a885069408a89788f67f248e8124c682bb73936f33874e0611b",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb",
+			"version": "5.1-2+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "debianutils_4.11.2_arm64",
+			"name": "debianutils",
+			"sha256": "6543b2b1a61b4b7b4b55b4bd25162309d7d23d14d3303649aee84ad314c30e02",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_arm64.deb",
+			"version": "4.11.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "base-files_11.1-p-deb11u9_arm64",
+			"name": "base-files",
+			"sha256": "c40dc4d5c6b82f5cfe75efa1a12bd09b9d5b9b8446ea045a991896a1ead8b02c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_arm64.deb",
+			"version": "11.1+deb11u9"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
+			"name": "libtinfo6",
+			"sha256": "58027c991756930a2abb2f87a829393d3fdbfb76f4eca9795ef38ea2b0510e27",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb",
+			"version": "6.2+20201114-2+deb11u2"
+		}
+	],
+	"version": 1
 }

--- a/examples/debian_snapshot/BUILD.bazel
+++ b/examples/debian_snapshot/BUILD.bazel
@@ -121,8 +121,10 @@ container_structure_test(
         "@platforms//cpu:x86_64": ["test_linux_amd64.yaml"],
     }),
     image = ":apt",
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
+    target_compatible_with = select({
+        "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],
+        "@platforms//cpu:arm64": ["@platforms//cpu:arm64"],
+    }) + [
         "@platforms//os:linux",
     ],
 )

--- a/examples/debian_snapshot/bullseye.lock.json
+++ b/examples/debian_snapshot/bullseye.lock.json
@@ -1,2385 +1,2385 @@
 {
-  "packages": [
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "ncurses-base_6.2-p-20201114-2-p-deb11u2_amd64",
-      "name": "ncurses-base",
-      "sha256": "a55a5f94299448279da6a6c2031a9816dc768cd300668ff82ecfc6480bbfc83d",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
-      "version": "6.2+20201114-2+deb11u2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "libc6_2.31-13-p-deb11u8_amd64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_amd64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_amd64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
-          "name": "libtinfo6",
-          "version": "6.2+20201114-2+deb11u2"
-        }
-      ],
-      "key": "libncurses6_6.2-p-20201114-2-p-deb11u2_amd64",
-      "name": "libncurses6",
-      "sha256": "5b75c540d26d0525f231d39e5cf27ea7919d57305ba7101ea430c975369095eb",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_amd64.deb",
-      "version": "6.2+20201114-2+deb11u2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libc6_2.31-13-p-deb11u8_amd64",
-      "name": "libc6",
-      "sha256": "d55d9c9769336f9b8516c20bd8364ce90746fb860ae3dda242f421e711af3d1a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_amd64.deb",
-      "version": "2.31-13+deb11u8"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libcrypt1_1-4.4.18-4_amd64",
-      "name": "libcrypt1",
-      "sha256": "f617952df0c57b4ee039448e3941bccd3f97bfff71e9b0f87ca6dae15cb3f5ef",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb",
-      "version": "1:4.4.18-4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgcc-s1_10.2.1-6_amd64",
-      "name": "libgcc-s1",
-      "sha256": "e478f2709d8474165bb664de42e16950c391f30eaa55bc9b3573281d83a29daf",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "gcc-10-base_10.2.1-6_amd64",
-      "name": "gcc-10-base",
-      "sha256": "be65535e94f95fbf04b104e8ab36790476f063374430f7dfc6c516cbe2d2cd1e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
-      "name": "libtinfo6",
-      "sha256": "96ed58b8fd656521e08549c763cd18da6cff1b7801a3a22f29678701a95d7e7b",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_amd64.deb",
-      "version": "6.2+20201114-2+deb11u2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "tzdata_2024a-0-p-deb11u1_amd64",
-      "name": "tzdata",
-      "sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
-      "version": "2024a-0+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "debianutils_4.11.2_amd64",
-          "name": "debianutils",
-          "version": "4.11.2"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_amd64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_amd64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_amd64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "base-files_11.1-p-deb11u9_amd64",
-          "name": "base-files",
-          "version": "11.1+deb11u9"
-        },
-        {
-          "key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
-          "name": "libtinfo6",
-          "version": "6.2+20201114-2+deb11u2"
-        }
-      ],
-      "key": "bash_5.1-2-p-deb11u1_amd64",
-      "name": "bash",
-      "sha256": "f702ef058e762d7208a9c83f6f6bbf02645533bfd615c54e8cdcce842cd57377",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_amd64.deb",
-      "version": "5.1-2+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "debianutils_4.11.2_amd64",
-      "name": "debianutils",
-      "sha256": "83d21669c5957e3eaee20096a7d8c596bd07f57f1e95dc74f192b3fb7bb2e6a9",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_amd64.deb",
-      "version": "4.11.2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "base-files_11.1-p-deb11u9_amd64",
-      "name": "base-files",
-      "sha256": "1ff08cf6e1b97af1e37cda830f3658f9af43a906abb80a21951c81aea02ce230",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_amd64.deb",
-      "version": "11.1+deb11u9"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "libselinux1_3.1-3_amd64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_amd64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_amd64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_amd64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
-          "name": "libgmp10",
-          "version": "2:6.2.1+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libattr1_1-2.4.48-6_amd64",
-          "name": "libattr1",
-          "version": "1:2.4.48-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_amd64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        }
-      ],
-      "key": "coreutils_8.32-4-p-b1_amd64",
-      "name": "coreutils",
-      "sha256": "3558a412ab51eee4b60641327cb145bb91415f127769823b68f9335585b308d4",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4+b1_amd64.deb",
-      "version": "8.32-4+b1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libselinux1_3.1-3_amd64",
-      "name": "libselinux1",
-      "sha256": "339f5ede10500c16dd7192d73169c31c4b27ab12130347275f23044ec8c7d897",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb",
-      "version": "3.1-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
-      "name": "libpcre2-8-0",
-      "sha256": "ee192c8d22624eb9d0a2ae95056bad7fb371e5abc17e23e16b1de3ddb17a1064",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb",
-      "version": "10.36-2+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
-      "name": "libgmp10",
-      "sha256": "fc117ccb084a98d25021f7e01e4dfedd414fa2118fdd1e27d2d801d7248aebbc",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb",
-      "version": "2:6.2.1+dfsg-1+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libattr1_1-2.4.48-6_amd64",
-      "name": "libattr1",
-      "sha256": "af3c3562eb2802481a2b9558df1b389f3c6d9b1bf3b4219e000e05131372ebaf",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_amd64.deb",
-      "version": "1:2.4.48-6"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libacl1_2.2.53-10_amd64",
-      "name": "libacl1",
-      "sha256": "aa18d721be8aea50fbdb32cd9a319cb18a3f111ea6ad17399aa4ba9324c8e26a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb",
-      "version": "2.2.53-10"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
-          "name": "tar",
-          "version": "1.34+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libselinux1_3.1-3_amd64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_amd64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_amd64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_amd64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_amd64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        },
-        {
-          "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
-          "name": "zlib1g",
-          "version": "1:1.2.11.dfsg-2+deb11u2"
-        },
-        {
-          "key": "liblzma5_5.2.5-2.1~deb11u1_amd64",
-          "name": "liblzma5",
-          "version": "5.2.5-2.1~deb11u1"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-4_amd64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-4"
-        }
-      ],
-      "key": "dpkg_1.20.13_amd64",
-      "name": "dpkg",
-      "sha256": "eb2b7ba3a3c4e905a380045a2d1cd219d2d45755aba5966d6c804b79400beb05",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb",
-      "version": "1.20.13"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
-      "name": "tar",
-      "sha256": "41c9c31f67a76b3532036f09ceac1f40a9224f1680395d120a8b24eae60dd54a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_amd64.deb",
-      "version": "1.34+dfsg-1+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
-      "name": "zlib1g",
-      "sha256": "03d2ab2174af76df6f517b854b77460fbdafc3dac0dca979317da67538159a3e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_amd64.deb",
-      "version": "1:1.2.11.dfsg-2+deb11u2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "liblzma5_5.2.5-2.1~deb11u1_amd64",
-      "name": "liblzma5",
-      "sha256": "1c79a02415ca5ee7234ac60502fb33ee94fa70b02d1c329a6a14178f8329c435",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_amd64.deb",
-      "version": "5.2.5-2.1~deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libbz2-1.0_1.0.8-4_amd64",
-      "name": "libbz2-1.0",
-      "sha256": "16e27c3ebd97981e70db3733f899963362748f178a62644df69d1f247e741379",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb",
-      "version": "1.0.8-4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "libsystemd0_247.3-7-p-deb11u4_amd64",
-          "name": "libsystemd0",
-          "version": "247.3-7+deb11u4"
-        },
-        {
-          "key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
-          "name": "libzstd1",
-          "version": "1.4.8+dfsg-2.1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_amd64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_amd64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_amd64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "liblzma5_5.2.5-2.1~deb11u1_amd64",
-          "name": "liblzma5",
-          "version": "5.2.5-2.1~deb11u1"
-        },
-        {
-          "key": "liblz4-1_1.9.3-2_amd64",
-          "name": "liblz4-1",
-          "version": "1.9.3-2"
-        },
-        {
-          "key": "libgcrypt20_1.8.7-6_amd64",
-          "name": "libgcrypt20",
-          "version": "1.8.7-6"
-        },
-        {
-          "key": "libgpg-error0_1.38-2_amd64",
-          "name": "libgpg-error0",
-          "version": "1.38-2"
-        },
-        {
-          "key": "libstdc-p--p-6_10.2.1-6_amd64",
-          "name": "libstdc++6",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libseccomp2_2.5.1-1-p-deb11u1_amd64",
-          "name": "libseccomp2",
-          "version": "2.5.1-1+deb11u1"
-        },
-        {
-          "key": "libgnutls30_3.7.1-5-p-deb11u4_amd64",
-          "name": "libgnutls30",
-          "version": "3.7.1-5+deb11u4"
-        },
-        {
-          "key": "libunistring2_0.9.10-4_amd64",
-          "name": "libunistring2",
-          "version": "0.9.10-4"
-        },
-        {
-          "key": "libtasn1-6_4.16.0-2-p-deb11u1_amd64",
-          "name": "libtasn1-6",
-          "version": "4.16.0-2+deb11u1"
-        },
-        {
-          "key": "libp11-kit0_0.23.22-1_amd64",
-          "name": "libp11-kit0",
-          "version": "0.23.22-1"
-        },
-        {
-          "key": "libffi7_3.3-6_amd64",
-          "name": "libffi7",
-          "version": "3.3-6"
-        },
-        {
-          "key": "libnettle8_3.7.3-1_amd64",
-          "name": "libnettle8",
-          "version": "3.7.3-1"
-        },
-        {
-          "key": "libidn2-0_2.3.0-5_amd64",
-          "name": "libidn2-0",
-          "version": "2.3.0-5"
-        },
-        {
-          "key": "libhogweed6_3.7.3-1_amd64",
-          "name": "libhogweed6",
-          "version": "3.7.3-1"
-        },
-        {
-          "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
-          "name": "libgmp10",
-          "version": "2:6.2.1+dfsg-1+deb11u1"
-        },
-        {
-          "key": "debian-archive-keyring_2021.1.1-p-deb11u1_amd64",
-          "name": "debian-archive-keyring",
-          "version": "2021.1.1+deb11u1"
-        },
-        {
-          "key": "libapt-pkg6.0_2.2.4_amd64",
-          "name": "libapt-pkg6.0",
-          "version": "2.2.4"
-        },
-        {
-          "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
-          "name": "zlib1g",
-          "version": "1:1.2.11.dfsg-2+deb11u2"
-        },
-        {
-          "key": "libxxhash0_0.8.0-2_amd64",
-          "name": "libxxhash0",
-          "version": "0.8.0-2"
-        },
-        {
-          "key": "libudev1_247.3-7-p-deb11u4_amd64",
-          "name": "libudev1",
-          "version": "247.3-7+deb11u4"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-4_amd64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-4"
-        },
-        {
-          "key": "adduser_3.118-p-deb11u1_amd64",
-          "name": "adduser",
-          "version": "3.118+deb11u1"
-        },
-        {
-          "key": "passwd_1-4.8.1-1_amd64",
-          "name": "passwd",
-          "version": "1:4.8.1-1"
-        },
-        {
-          "key": "libpam-modules_1.4.0-9-p-deb11u1_amd64",
-          "name": "libpam-modules",
-          "version": "1.4.0-9+deb11u1"
-        },
-        {
-          "key": "libpam-modules-bin_1.4.0-9-p-deb11u1_amd64",
-          "name": "libpam-modules-bin",
-          "version": "1.4.0-9+deb11u1"
-        },
-        {
-          "key": "libselinux1_3.1-3_amd64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libpam0g_1.4.0-9-p-deb11u1_amd64",
-          "name": "libpam0g",
-          "version": "1.4.0-9+deb11u1"
-        },
-        {
-          "key": "libaudit1_1-3.0-2_amd64",
-          "name": "libaudit1",
-          "version": "1:3.0-2"
-        },
-        {
-          "key": "libcap-ng0_0.7.9-2.2-p-b1_amd64",
-          "name": "libcap-ng0",
-          "version": "0.7.9-2.2+b1"
-        },
-        {
-          "key": "libaudit-common_1-3.0-2_amd64",
-          "name": "libaudit-common",
-          "version": "1:3.0-2"
-        },
-        {
-          "key": "libtirpc3_1.3.1-1-p-deb11u1_amd64",
-          "name": "libtirpc3",
-          "version": "1.3.1-1+deb11u1"
-        },
-        {
-          "key": "libtirpc-common_1.3.1-1-p-deb11u1_amd64",
-          "name": "libtirpc-common",
-          "version": "1.3.1-1+deb11u1"
-        },
-        {
-          "key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_amd64",
-          "name": "libgssapi-krb5-2",
-          "version": "1.18.3-6+deb11u4"
-        },
-        {
-          "key": "libkrb5support0_1.18.3-6-p-deb11u4_amd64",
-          "name": "libkrb5support0",
-          "version": "1.18.3-6+deb11u4"
-        },
-        {
-          "key": "libkrb5-3_1.18.3-6-p-deb11u4_amd64",
-          "name": "libkrb5-3",
-          "version": "1.18.3-6+deb11u4"
-        },
-        {
-          "key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
-          "name": "libssl1.1",
-          "version": "1.1.1w-0+deb11u1"
-        },
-        {
-          "key": "libkeyutils1_1.6.1-2_amd64",
-          "name": "libkeyutils1",
-          "version": "1.6.1-2"
-        },
-        {
-          "key": "libk5crypto3_1.18.3-6-p-deb11u4_amd64",
-          "name": "libk5crypto3",
-          "version": "1.18.3-6+deb11u4"
-        },
-        {
-          "key": "libcom-err2_1.46.2-2_amd64",
-          "name": "libcom-err2",
-          "version": "1.46.2-2"
-        },
-        {
-          "key": "libnsl2_1.3.0-2_amd64",
-          "name": "libnsl2",
-          "version": "1.3.0-2"
-        },
-        {
-          "key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
-          "name": "libdb5.3",
-          "version": "5.3.28+dfsg1-0.8"
-        },
-        {
-          "key": "libsemanage1_3.1-1-p-b2_amd64",
-          "name": "libsemanage1",
-          "version": "3.1-1+b2"
-        },
-        {
-          "key": "libsepol1_3.1-1_amd64",
-          "name": "libsepol1",
-          "version": "3.1-1"
-        },
-        {
-          "key": "libsemanage-common_3.1-1_amd64",
-          "name": "libsemanage-common",
-          "version": "3.1-1"
-        }
-      ],
-      "key": "apt_2.2.4_amd64",
-      "name": "apt",
-      "sha256": "75f07c4965ff0813f26623a1164e162538f5e94defba6961347527ed71bc4f3d",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_amd64.deb",
-      "version": "2.2.4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libsystemd0_247.3-7-p-deb11u4_amd64",
-      "name": "libsystemd0",
-      "sha256": "e6f3e65e388196a399c1a36564c38ad987337350358732056227db1b6e708878",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_amd64.deb",
-      "version": "247.3-7+deb11u4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
-      "name": "libzstd1",
-      "sha256": "5dcadfbb743bfa1c1c773bff91c018f835e8e8c821d423d3836f3ab84773507b",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_amd64.deb",
-      "version": "1.4.8+dfsg-2.1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "liblz4-1_1.9.3-2_amd64",
-      "name": "liblz4-1",
-      "sha256": "79ac6e9ca19c483f2e8effcc3401d723dd9dbb3a4ae324714de802adb21a8117",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_amd64.deb",
-      "version": "1.9.3-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgcrypt20_1.8.7-6_amd64",
-      "name": "libgcrypt20",
-      "sha256": "7a2e0eef8e0c37f03f3a5fcf7102a2e3dc70ba987f696ab71949f9abf36f35ef",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb",
-      "version": "1.8.7-6"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgpg-error0_1.38-2_amd64",
-      "name": "libgpg-error0",
-      "sha256": "16a507fb20cc58b5a524a0dc254a9cb1df02e1ce758a2d8abde0bc4a3c9b7c26",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb",
-      "version": "1.38-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libstdc-p--p-6_10.2.1-6_amd64",
-      "name": "libstdc++6",
-      "sha256": "5c155c58935870bf3b4bfe769116841c0d286a74f59eccfd5645693ac23f06b1",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libseccomp2_2.5.1-1-p-deb11u1_amd64",
-      "name": "libseccomp2",
-      "sha256": "2617fc8b99dca0fa8ed466ee0f5fe087aa4e8413b88ca45d717290f4a0551e36",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_amd64.deb",
-      "version": "2.5.1-1+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgnutls30_3.7.1-5-p-deb11u4_amd64",
-      "name": "libgnutls30",
-      "sha256": "b2fa128881a16c2196caddb551d3577baa296a7bc5d38109a978e8e69fdb5c94",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_amd64.deb",
-      "version": "3.7.1-5+deb11u4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libunistring2_0.9.10-4_amd64",
-      "name": "libunistring2",
-      "sha256": "654433ad02d3a8b05c1683c6c29a224500bf343039c34dcec4e5e9515345e3d4",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_amd64.deb",
-      "version": "0.9.10-4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libtasn1-6_4.16.0-2-p-deb11u1_amd64",
-      "name": "libtasn1-6",
-      "sha256": "6ebb579337cdc9d6201237a66578425a7a221db622524354e27c0c1bcb6dd7ca",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_amd64.deb",
-      "version": "4.16.0-2+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libp11-kit0_0.23.22-1_amd64",
-      "name": "libp11-kit0",
-      "sha256": "bfef5f31ee1c730e56e16bb62cc5ff8372185106c75bf1ed1756c96703019457",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_amd64.deb",
-      "version": "0.23.22-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libffi7_3.3-6_amd64",
-      "name": "libffi7",
-      "sha256": "30ca89bfddae5fa6e0a2a044f22b6e50cd17c4bc6bc850c579819aeab7101f0f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb",
-      "version": "3.3-6"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnettle8_3.7.3-1_amd64",
-      "name": "libnettle8",
-      "sha256": "e4f8ec31ed14518b241eb7b423ad5ed3f4a4e8ac50aae72c9fd475c569582764",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb",
-      "version": "3.7.3-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libidn2-0_2.3.0-5_amd64",
-      "name": "libidn2-0",
-      "sha256": "cb80cd769171537bafbb4a16c12ec427065795946b3415781bc9792e92d60b59",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_amd64.deb",
-      "version": "2.3.0-5"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libhogweed6_3.7.3-1_amd64",
-      "name": "libhogweed6",
-      "sha256": "6aab2e892cdb2dfba45707601bc6c3b19aa228f70ae5841017f14c3b0ca3d22f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb",
-      "version": "3.7.3-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "debian-archive-keyring_2021.1.1-p-deb11u1_amd64",
-      "name": "debian-archive-keyring",
-      "sha256": "28ca7749ab7978f3c571732c3aa1c56e3ad1d5db3c915293763d4f6cb8fcce89",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
-      "version": "2021.1.1+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libapt-pkg6.0_2.2.4_amd64",
-      "name": "libapt-pkg6.0",
-      "sha256": "4ae47bedf773ad1342e5aae8fa6275f864cfc87a45f4472775f5a9cdd60abbbf",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_amd64.deb",
-      "version": "2.2.4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libxxhash0_0.8.0-2_amd64",
-      "name": "libxxhash0",
-      "sha256": "3fb82550a71d27d05672472508548576dfb34486847bc860d3066cda5aaf186f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_amd64.deb",
-      "version": "0.8.0-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libudev1_247.3-7-p-deb11u4_amd64",
-      "name": "libudev1",
-      "sha256": "9274ca1aa37fcdf5895dad1de0895162351099ef8dff8a62f2f4c9eb181a8fce",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_amd64.deb",
-      "version": "247.3-7+deb11u4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "adduser_3.118-p-deb11u1_amd64",
-      "name": "adduser",
-      "sha256": "1478a610fd50e190882ff41e16c57b628a508bcf5b5ac5313affb49d20818e0a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
-      "version": "3.118+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "passwd_1-4.8.1-1_amd64",
-      "name": "passwd",
-      "sha256": "542593f26502e87b4276fa778e6e3ae52e66b973979986fff77803d9fcb2c2e8",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_amd64.deb",
-      "version": "1:4.8.1-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libpam-modules_1.4.0-9-p-deb11u1_amd64",
-      "name": "libpam-modules",
-      "sha256": "ca1e121700bf4b3eb33e30e0774d3e63e1adae9d4b6a940ea3501225db3cc287",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_amd64.deb",
-      "version": "1.4.0-9+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libpam-modules-bin_1.4.0-9-p-deb11u1_amd64",
-      "name": "libpam-modules-bin",
-      "sha256": "abbbd181329c236676222d3e912df13f8d1d90a117559edd997d90006369e5c8",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_amd64.deb",
-      "version": "1.4.0-9+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libpam0g_1.4.0-9-p-deb11u1_amd64",
-      "name": "libpam0g",
-      "sha256": "496771218fb585bb716fdae6ef8824dbfb5d544b4fa2f3cd4d0e4d7158ae2220",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_amd64.deb",
-      "version": "1.4.0-9+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libaudit1_1-3.0-2_amd64",
-      "name": "libaudit1",
-      "sha256": "e3aa1383e387dc077a1176f7f3cbfdbc084bcc270a8938f598d5cb119773b268",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_amd64.deb",
-      "version": "1:3.0-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libcap-ng0_0.7.9-2.2-p-b1_amd64",
-      "name": "libcap-ng0",
-      "sha256": "d34e29769b8ef23e9b9920814afb7905b8ee749db0814e6a8d937ccc4f309830",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_amd64.deb",
-      "version": "0.7.9-2.2+b1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libaudit-common_1-3.0-2_amd64",
-      "name": "libaudit-common",
-      "sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
-      "version": "1:3.0-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libtirpc3_1.3.1-1-p-deb11u1_amd64",
-      "name": "libtirpc3",
-      "sha256": "86b216d59b6efcd07d56d14b8f4281d5c47f24e9c962f46bbaf02fce762c5e6a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_amd64.deb",
-      "version": "1.3.1-1+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libtirpc-common_1.3.1-1-p-deb11u1_amd64",
-      "name": "libtirpc-common",
-      "sha256": "b2f10cb79e7d7a2f9b30bcdf036127df55cd4a34688547bc2886fa38f4969f77",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb",
-      "version": "1.3.1-1+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_amd64",
-      "name": "libgssapi-krb5-2",
-      "sha256": "037cc4bb34a6cd0d7a6e83bdcae6d68e0d0f9218eb7dedafc8099c8c0be491a2",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_amd64.deb",
-      "version": "1.18.3-6+deb11u4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libkrb5support0_1.18.3-6-p-deb11u4_amd64",
-      "name": "libkrb5support0",
-      "sha256": "da8d022e3dd7f4a72ea32e328b3ac382dbe6bdb91606c5738fe17a29f8ea8080",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_amd64.deb",
-      "version": "1.18.3-6+deb11u4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libkrb5-3_1.18.3-6-p-deb11u4_amd64",
-      "name": "libkrb5-3",
-      "sha256": "b785fa324cf27e6bf7f97fc0279470e6ce8a8cc54f8ccc6c9b24c8111ba5c952",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_amd64.deb",
-      "version": "1.18.3-6+deb11u4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
-      "name": "libssl1.1",
-      "sha256": "aadf8b4b197335645b230c2839b4517aa444fd2e8f434e5438c48a18857988f7",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb",
-      "version": "1.1.1w-0+deb11u1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libkeyutils1_1.6.1-2_amd64",
-      "name": "libkeyutils1",
-      "sha256": "f01060b434d8cad3c58d5811d2082389f11b3db8152657d6c22c1d298953f2a5",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_amd64.deb",
-      "version": "1.6.1-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libk5crypto3_1.18.3-6-p-deb11u4_amd64",
-      "name": "libk5crypto3",
-      "sha256": "f635062bcbfe2eef5a83fcba7d1a8ae343fc7c779cae88b11cae90fd6845a744",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_amd64.deb",
-      "version": "1.18.3-6+deb11u4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libcom-err2_1.46.2-2_amd64",
-      "name": "libcom-err2",
-      "sha256": "d478f132871f4ab8352d39becf936d0ad74db905398bf98465d8fe3da6fb1126",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_amd64.deb",
-      "version": "1.46.2-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnsl2_1.3.0-2_amd64",
-      "name": "libnsl2",
-      "sha256": "c0d83437fdb016cb289436f49f28a36be44b3e8f1f2498c7e3a095f709c0d6f8",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb",
-      "version": "1.3.0-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
-      "name": "libdb5.3",
-      "sha256": "00b9e63e287f45300d4a4f59b6b88e25918443c932ae3e5845d5761ae193c530",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb",
-      "version": "5.3.28+dfsg1-0.8"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libsemanage1_3.1-1-p-b2_amd64",
-      "name": "libsemanage1",
-      "sha256": "d8f2835b22df58ba45d52eb3aab224190f193576caf05e3f80deb2e4f927fad6",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_amd64.deb",
-      "version": "3.1-1+b2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libsepol1_3.1-1_amd64",
-      "name": "libsepol1",
-      "sha256": "b6057dc6806a6dfaef74b09d84d1f18716d7a6d2f1da30520cef555210c6af62",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_amd64.deb",
-      "version": "3.1-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libsemanage-common_3.1-1_amd64",
-      "name": "libsemanage-common",
-      "sha256": "d319a026ecd02e2f605c52350949279f3c331a19380f8b6888ce5b9ef0d31349",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
-      "version": "3.1-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "libperl5.32_5.32.1-4-p-deb11u3_amd64",
-          "name": "libperl5.32",
-          "version": "5.32.1-4+deb11u3"
-        },
-        {
-          "key": "perl-modules-5.32_5.32.1-4-p-deb11u3_amd64",
-          "name": "perl-modules-5.32",
-          "version": "5.32.1-4+deb11u3"
-        },
-        {
-          "key": "perl-base_5.32.1-4-p-deb11u3_amd64",
-          "name": "perl-base",
-          "version": "5.32.1-4+deb11u3"
-        },
-        {
-          "key": "dpkg_1.20.13_amd64",
-          "name": "dpkg",
-          "version": "1.20.13"
-        },
-        {
-          "key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
-          "name": "tar",
-          "version": "1.34+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libselinux1_3.1-3_amd64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_amd64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_amd64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_amd64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_amd64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        },
-        {
-          "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
-          "name": "zlib1g",
-          "version": "1:1.2.11.dfsg-2+deb11u2"
-        },
-        {
-          "key": "liblzma5_5.2.5-2.1~deb11u1_amd64",
-          "name": "liblzma5",
-          "version": "5.2.5-2.1~deb11u1"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-4_amd64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-4"
-        },
-        {
-          "key": "libgdbm6_1.19-2_amd64",
-          "name": "libgdbm6",
-          "version": "1.19-2"
-        },
-        {
-          "key": "libgdbm-compat4_1.19-2_amd64",
-          "name": "libgdbm-compat4",
-          "version": "1.19-2"
-        },
-        {
-          "key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
-          "name": "libdb5.3",
-          "version": "5.3.28+dfsg1-0.8"
-        }
-      ],
-      "key": "perl_5.32.1-4-p-deb11u3_amd64",
-      "name": "perl",
-      "sha256": "d5f710c7db9fcd6d9d6f119cd0dea64a4f765867447dd97b24ab44be1de7c60f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_amd64.deb",
-      "version": "5.32.1-4+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libperl5.32_5.32.1-4-p-deb11u3_amd64",
-      "name": "libperl5.32",
-      "sha256": "078487a45916167e3e4ee2e584c50306c84368dd06dae276604861ca0426c34e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_amd64.deb",
-      "version": "5.32.1-4+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "perl-modules-5.32_5.32.1-4-p-deb11u3_amd64",
-      "name": "perl-modules-5.32",
-      "sha256": "9a5cb99d0f33cb11c7f535aaebfb569c6b6f97a75d748a9a52ea3afed5bd3960",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
-      "version": "5.32.1-4+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "perl-base_5.32.1-4-p-deb11u3_amd64",
-      "name": "perl-base",
-      "sha256": "94c6299552866aadc58acb8ec5111a74b17bcb453f6e2f45ea5f7c4f42580d13",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_amd64.deb",
-      "version": "5.32.1-4+deb11u3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgdbm6_1.19-2_amd64",
-      "name": "libgdbm6",
-      "sha256": "e54cfe4d8b8f209bb7df31a404ce040f7c2f9b1045114a927a7e1061cdf90727",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_amd64.deb",
-      "version": "1.19-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgdbm-compat4_1.19-2_amd64",
-      "name": "libgdbm-compat4",
-      "sha256": "e62caed68b0ffaa03b5fa539d6fdc08c4151f66236d5878949bead0b71b7bb09",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_amd64.deb",
-      "version": "1.19-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "openssl_1.1.1w-0-p-deb11u1_amd64",
-          "name": "openssl",
-          "version": "1.1.1w-0+deb11u1"
-        },
-        {
-          "key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
-          "name": "libssl1.1",
-          "version": "1.1.1w-0+deb11u1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_amd64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_amd64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_amd64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        }
-      ],
-      "key": "ca-certificates_20210119_amd64",
-      "name": "ca-certificates",
-      "sha256": "b2d488ad4d8d8adb3ba319fc9cb2cf9909fc42cb82ad239a26c570a2e749c389",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
-      "version": "20210119"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "openssl_1.1.1w-0-p-deb11u1_amd64",
-      "name": "openssl",
-      "sha256": "04873d74cbe86bad3a9901f6e57f1150040eba9891b443c5c975a72a97238e35",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_amd64.deb",
-      "version": "1.1.1w-0+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "ncurses-base_6.2-p-20201114-2-p-deb11u2_arm64",
-      "name": "ncurses-base",
-      "sha256": "a55a5f94299448279da6a6c2031a9816dc768cd300668ff82ecfc6480bbfc83d",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
-      "version": "6.2+20201114-2+deb11u2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "libc6_2.31-13-p-deb11u8_arm64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_arm64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_arm64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
-          "name": "libtinfo6",
-          "version": "6.2+20201114-2+deb11u2"
-        }
-      ],
-      "key": "libncurses6_6.2-p-20201114-2-p-deb11u2_arm64",
-      "name": "libncurses6",
-      "sha256": "039b71b8839538a92988003e13c29e7cf1149cdc6a77d3de882f1d386a5f3a5c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_arm64.deb",
-      "version": "6.2+20201114-2+deb11u2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libc6_2.31-13-p-deb11u8_arm64",
-      "name": "libc6",
-      "sha256": "6eb629090615ebda5dcac2365a7358c035add00b89c2724c2e9e13ccd5bd9f7c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_arm64.deb",
-      "version": "2.31-13+deb11u8"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libcrypt1_1-4.4.18-4_arm64",
-      "name": "libcrypt1",
-      "sha256": "22b586b29e840dabebf0bf227d233376628b87954915d064bc142ae85d1b7979",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_arm64.deb",
-      "version": "1:4.4.18-4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgcc-s1_10.2.1-6_arm64",
-      "name": "libgcc-s1",
-      "sha256": "e2fcdb378d3c1ad1bcb64d4fb6b37aab44011152beca12a4944f435a2582df1f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_arm64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "gcc-10-base_10.2.1-6_arm64",
-      "name": "gcc-10-base",
-      "sha256": "7d782bece7b4a36bed045a7e17d17244cb8f7e4732466091b01412ebf215defb",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_arm64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
-      "name": "libtinfo6",
-      "sha256": "58027c991756930a2abb2f87a829393d3fdbfb76f4eca9795ef38ea2b0510e27",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb",
-      "version": "6.2+20201114-2+deb11u2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "tzdata_2024a-0-p-deb11u1_arm64",
-      "name": "tzdata",
-      "sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
-      "version": "2024a-0+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "debianutils_4.11.2_arm64",
-          "name": "debianutils",
-          "version": "4.11.2"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_arm64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_arm64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_arm64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "base-files_11.1-p-deb11u9_arm64",
-          "name": "base-files",
-          "version": "11.1+deb11u9"
-        },
-        {
-          "key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
-          "name": "libtinfo6",
-          "version": "6.2+20201114-2+deb11u2"
-        }
-      ],
-      "key": "bash_5.1-2-p-deb11u1_arm64",
-      "name": "bash",
-      "sha256": "d7c7af5d86f43a885069408a89788f67f248e8124c682bb73936f33874e0611b",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb",
-      "version": "5.1-2+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "debianutils_4.11.2_arm64",
-      "name": "debianutils",
-      "sha256": "6543b2b1a61b4b7b4b55b4bd25162309d7d23d14d3303649aee84ad314c30e02",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_arm64.deb",
-      "version": "4.11.2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "base-files_11.1-p-deb11u9_arm64",
-      "name": "base-files",
-      "sha256": "c40dc4d5c6b82f5cfe75efa1a12bd09b9d5b9b8446ea045a991896a1ead8b02c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_arm64.deb",
-      "version": "11.1+deb11u9"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "libselinux1_3.1-3_arm64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_arm64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_arm64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_arm64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
-          "name": "libgmp10",
-          "version": "2:6.2.1+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libattr1_1-2.4.48-6_arm64",
-          "name": "libattr1",
-          "version": "1:2.4.48-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_arm64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        }
-      ],
-      "key": "coreutils_8.32-4_arm64",
-      "name": "coreutils",
-      "sha256": "6210c84d6ff84b867dc430f661f22f536e1704c27bdb79de38e26f75b853d9c0",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4_arm64.deb",
-      "version": "8.32-4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libselinux1_3.1-3_arm64",
-      "name": "libselinux1",
-      "sha256": "da98279a47dabaa46a83514142f5c691c6a71fa7e582661a3a3db6887ad3e9d1",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_arm64.deb",
-      "version": "3.1-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
-      "name": "libpcre2-8-0",
-      "sha256": "27a4362a4793cb67a8ae571bd8c3f7e8654dc2e56d99088391b87af1793cca9c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_arm64.deb",
-      "version": "10.36-2+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
-      "name": "libgmp10",
-      "sha256": "d52619b6ff8829aa5424dfe3189dd05f22118211e69273e9576030584ffcce80",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_arm64.deb",
-      "version": "2:6.2.1+dfsg-1+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libattr1_1-2.4.48-6_arm64",
-      "name": "libattr1",
-      "sha256": "cb9b59be719a6fdbaabaa60e22aa6158b2de7a68c88ccd7c3fb7f41a25fb43d0",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_arm64.deb",
-      "version": "1:2.4.48-6"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libacl1_2.2.53-10_arm64",
-      "name": "libacl1",
-      "sha256": "f164c48192cb47746101de6c59afa3f97777c8fc821e5a30bb890df1f4cb4cfd",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_arm64.deb",
-      "version": "2.2.53-10"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
-          "name": "tar",
-          "version": "1.34+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libselinux1_3.1-3_arm64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_arm64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_arm64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_arm64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_arm64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        },
-        {
-          "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
-          "name": "zlib1g",
-          "version": "1:1.2.11.dfsg-2+deb11u2"
-        },
-        {
-          "key": "liblzma5_5.2.5-2.1~deb11u1_arm64",
-          "name": "liblzma5",
-          "version": "5.2.5-2.1~deb11u1"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-4_arm64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-4"
-        }
-      ],
-      "key": "dpkg_1.20.13_arm64",
-      "name": "dpkg",
-      "sha256": "87b0bce7361d94cc15caf27709fa8a70de44f9dd742cf0d69d25796a03d24853",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_arm64.deb",
-      "version": "1.20.13"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
-      "name": "tar",
-      "sha256": "0f94aac4e6d25e07ed23b7fc3ed06e69074c95276d82caae7fc7b207fd714e39",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_arm64.deb",
-      "version": "1.34+dfsg-1+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
-      "name": "zlib1g",
-      "sha256": "e3963985d1a020d67ffd4180e6f9c4b5c600b515f0c9d8fda513d7a0e48e63a1",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_arm64.deb",
-      "version": "1:1.2.11.dfsg-2+deb11u2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "liblzma5_5.2.5-2.1~deb11u1_arm64",
-      "name": "liblzma5",
-      "sha256": "d865bba41952c707b3fa3ae8cab4d4bd337ee92991d2aead66c925bf7cc48846",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_arm64.deb",
-      "version": "5.2.5-2.1~deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libbz2-1.0_1.0.8-4_arm64",
-      "name": "libbz2-1.0",
-      "sha256": "da340e8470e96445c56966f74e48a9a91dee0fa5c89876e88a4575cc17d17a97",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_arm64.deb",
-      "version": "1.0.8-4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "libsystemd0_247.3-7-p-deb11u4_arm64",
-          "name": "libsystemd0",
-          "version": "247.3-7+deb11u4"
-        },
-        {
-          "key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
-          "name": "libzstd1",
-          "version": "1.4.8+dfsg-2.1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_arm64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_arm64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_arm64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "liblzma5_5.2.5-2.1~deb11u1_arm64",
-          "name": "liblzma5",
-          "version": "5.2.5-2.1~deb11u1"
-        },
-        {
-          "key": "liblz4-1_1.9.3-2_arm64",
-          "name": "liblz4-1",
-          "version": "1.9.3-2"
-        },
-        {
-          "key": "libgcrypt20_1.8.7-6_arm64",
-          "name": "libgcrypt20",
-          "version": "1.8.7-6"
-        },
-        {
-          "key": "libgpg-error0_1.38-2_arm64",
-          "name": "libgpg-error0",
-          "version": "1.38-2"
-        },
-        {
-          "key": "libstdc-p--p-6_10.2.1-6_arm64",
-          "name": "libstdc++6",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libseccomp2_2.5.1-1-p-deb11u1_arm64",
-          "name": "libseccomp2",
-          "version": "2.5.1-1+deb11u1"
-        },
-        {
-          "key": "libgnutls30_3.7.1-5-p-deb11u4_arm64",
-          "name": "libgnutls30",
-          "version": "3.7.1-5+deb11u4"
-        },
-        {
-          "key": "libunistring2_0.9.10-4_arm64",
-          "name": "libunistring2",
-          "version": "0.9.10-4"
-        },
-        {
-          "key": "libtasn1-6_4.16.0-2-p-deb11u1_arm64",
-          "name": "libtasn1-6",
-          "version": "4.16.0-2+deb11u1"
-        },
-        {
-          "key": "libp11-kit0_0.23.22-1_arm64",
-          "name": "libp11-kit0",
-          "version": "0.23.22-1"
-        },
-        {
-          "key": "libffi7_3.3-6_arm64",
-          "name": "libffi7",
-          "version": "3.3-6"
-        },
-        {
-          "key": "libnettle8_3.7.3-1_arm64",
-          "name": "libnettle8",
-          "version": "3.7.3-1"
-        },
-        {
-          "key": "libidn2-0_2.3.0-5_arm64",
-          "name": "libidn2-0",
-          "version": "2.3.0-5"
-        },
-        {
-          "key": "libhogweed6_3.7.3-1_arm64",
-          "name": "libhogweed6",
-          "version": "3.7.3-1"
-        },
-        {
-          "key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
-          "name": "libgmp10",
-          "version": "2:6.2.1+dfsg-1+deb11u1"
-        },
-        {
-          "key": "debian-archive-keyring_2021.1.1-p-deb11u1_arm64",
-          "name": "debian-archive-keyring",
-          "version": "2021.1.1+deb11u1"
-        },
-        {
-          "key": "libapt-pkg6.0_2.2.4_arm64",
-          "name": "libapt-pkg6.0",
-          "version": "2.2.4"
-        },
-        {
-          "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
-          "name": "zlib1g",
-          "version": "1:1.2.11.dfsg-2+deb11u2"
-        },
-        {
-          "key": "libxxhash0_0.8.0-2_arm64",
-          "name": "libxxhash0",
-          "version": "0.8.0-2"
-        },
-        {
-          "key": "libudev1_247.3-7-p-deb11u4_arm64",
-          "name": "libudev1",
-          "version": "247.3-7+deb11u4"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-4_arm64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-4"
-        },
-        {
-          "key": "adduser_3.118-p-deb11u1_arm64",
-          "name": "adduser",
-          "version": "3.118+deb11u1"
-        },
-        {
-          "key": "passwd_1-4.8.1-1_arm64",
-          "name": "passwd",
-          "version": "1:4.8.1-1"
-        },
-        {
-          "key": "libpam-modules_1.4.0-9-p-deb11u1_arm64",
-          "name": "libpam-modules",
-          "version": "1.4.0-9+deb11u1"
-        },
-        {
-          "key": "libpam-modules-bin_1.4.0-9-p-deb11u1_arm64",
-          "name": "libpam-modules-bin",
-          "version": "1.4.0-9+deb11u1"
-        },
-        {
-          "key": "libselinux1_3.1-3_arm64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libpam0g_1.4.0-9-p-deb11u1_arm64",
-          "name": "libpam0g",
-          "version": "1.4.0-9+deb11u1"
-        },
-        {
-          "key": "libaudit1_1-3.0-2_arm64",
-          "name": "libaudit1",
-          "version": "1:3.0-2"
-        },
-        {
-          "key": "libcap-ng0_0.7.9-2.2-p-b1_arm64",
-          "name": "libcap-ng0",
-          "version": "0.7.9-2.2+b1"
-        },
-        {
-          "key": "libaudit-common_1-3.0-2_arm64",
-          "name": "libaudit-common",
-          "version": "1:3.0-2"
-        },
-        {
-          "key": "libtirpc3_1.3.1-1-p-deb11u1_arm64",
-          "name": "libtirpc3",
-          "version": "1.3.1-1+deb11u1"
-        },
-        {
-          "key": "libtirpc-common_1.3.1-1-p-deb11u1_arm64",
-          "name": "libtirpc-common",
-          "version": "1.3.1-1+deb11u1"
-        },
-        {
-          "key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_arm64",
-          "name": "libgssapi-krb5-2",
-          "version": "1.18.3-6+deb11u4"
-        },
-        {
-          "key": "libkrb5support0_1.18.3-6-p-deb11u4_arm64",
-          "name": "libkrb5support0",
-          "version": "1.18.3-6+deb11u4"
-        },
-        {
-          "key": "libkrb5-3_1.18.3-6-p-deb11u4_arm64",
-          "name": "libkrb5-3",
-          "version": "1.18.3-6+deb11u4"
-        },
-        {
-          "key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
-          "name": "libssl1.1",
-          "version": "1.1.1w-0+deb11u1"
-        },
-        {
-          "key": "libkeyutils1_1.6.1-2_arm64",
-          "name": "libkeyutils1",
-          "version": "1.6.1-2"
-        },
-        {
-          "key": "libk5crypto3_1.18.3-6-p-deb11u4_arm64",
-          "name": "libk5crypto3",
-          "version": "1.18.3-6+deb11u4"
-        },
-        {
-          "key": "libcom-err2_1.46.2-2_arm64",
-          "name": "libcom-err2",
-          "version": "1.46.2-2"
-        },
-        {
-          "key": "libnsl2_1.3.0-2_arm64",
-          "name": "libnsl2",
-          "version": "1.3.0-2"
-        },
-        {
-          "key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
-          "name": "libdb5.3",
-          "version": "5.3.28+dfsg1-0.8"
-        },
-        {
-          "key": "libsemanage1_3.1-1-p-b2_arm64",
-          "name": "libsemanage1",
-          "version": "3.1-1+b2"
-        },
-        {
-          "key": "libsepol1_3.1-1_arm64",
-          "name": "libsepol1",
-          "version": "3.1-1"
-        },
-        {
-          "key": "libsemanage-common_3.1-1_arm64",
-          "name": "libsemanage-common",
-          "version": "3.1-1"
-        }
-      ],
-      "key": "apt_2.2.4_arm64",
-      "name": "apt",
-      "sha256": "39cbe42f3e64c6359b445d6fed7385273881e507b8be1d3b653ec9fb7d4c917c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_arm64.deb",
-      "version": "2.2.4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libsystemd0_247.3-7-p-deb11u4_arm64",
-      "name": "libsystemd0",
-      "sha256": "32e8c12301a9ada555adea9a4c2f15df788411dadd164baca5c31690fe06e381",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_arm64.deb",
-      "version": "247.3-7+deb11u4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
-      "name": "libzstd1",
-      "sha256": "dd01659c6c122f983a3369a04ede63539f666585d52a03f8aa2c27b307e547e0",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_arm64.deb",
-      "version": "1.4.8+dfsg-2.1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "liblz4-1_1.9.3-2_arm64",
-      "name": "liblz4-1",
-      "sha256": "83f0ee547cd42854e1b2a2e4c1a5705e28259ee5fa6560119f918f961a5dada2",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_arm64.deb",
-      "version": "1.9.3-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgcrypt20_1.8.7-6_arm64",
-      "name": "libgcrypt20",
-      "sha256": "61ec779149f20923b30adad7bdf4732957e88a5b6a26d94b2210dfe79409959b",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_arm64.deb",
-      "version": "1.8.7-6"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgpg-error0_1.38-2_arm64",
-      "name": "libgpg-error0",
-      "sha256": "d1116f4281d6db35279799a21051e0d0e2600d110d7ee2b95b3cca6bec28067c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_arm64.deb",
-      "version": "1.38-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libstdc-p--p-6_10.2.1-6_arm64",
-      "name": "libstdc++6",
-      "sha256": "7869aa540cc46e9f3d4267d5bde2af0e5b429a820c1d6f1a4cfccfe788c31890",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_arm64.deb",
-      "version": "10.2.1-6"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libseccomp2_2.5.1-1-p-deb11u1_arm64",
-      "name": "libseccomp2",
-      "sha256": "5b8983c2e330790dbe04ae990f166d7939a3e14b75556a8489309ae704fbeb50",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_arm64.deb",
-      "version": "2.5.1-1+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgnutls30_3.7.1-5-p-deb11u4_arm64",
-      "name": "libgnutls30",
-      "sha256": "7153ec6ee985eebba710dcb6e425bb881c91ee5987a4517518f3f44a9bb5fc1a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_arm64.deb",
-      "version": "3.7.1-5+deb11u4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libunistring2_0.9.10-4_arm64",
-      "name": "libunistring2",
-      "sha256": "53ff395ea4d8cf17c52155a452a0dc15af0ee2fa5cb3b0085b9c7335de8d5f7f",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_arm64.deb",
-      "version": "0.9.10-4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libtasn1-6_4.16.0-2-p-deb11u1_arm64",
-      "name": "libtasn1-6",
-      "sha256": "f469147bbd3969055c51fc661c9aa0d56d48eccd070d233f1424b0d8b3f29295",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_arm64.deb",
-      "version": "4.16.0-2+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libp11-kit0_0.23.22-1_arm64",
-      "name": "libp11-kit0",
-      "sha256": "ac6e8eda3277708069bc6f03aff06dc319855d64ede9fca219938e52f92ee09c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_arm64.deb",
-      "version": "0.23.22-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libffi7_3.3-6_arm64",
-      "name": "libffi7",
-      "sha256": "eb748e33ae4ed46f5a4c14b7a2a09792569f2029ede319d0979c373829ba1532",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb",
-      "version": "3.3-6"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnettle8_3.7.3-1_arm64",
-      "name": "libnettle8",
-      "sha256": "5061c931f95dc7277d95fc58bce7c17b1a95c6aa9a9aac781784f3b3dc909047",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb",
-      "version": "3.7.3-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libidn2-0_2.3.0-5_arm64",
-      "name": "libidn2-0",
-      "sha256": "0d2e6d39bf65f16861f284be567c1a6c5d4dc6b54dcfdf9dba631546ff4e6796",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_arm64.deb",
-      "version": "2.3.0-5"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libhogweed6_3.7.3-1_arm64",
-      "name": "libhogweed6",
-      "sha256": "3e9eea5e474dd98a7de9e4c1ecfbfd6f6efb1d40bf51d6473de9713cf41d2191",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb",
-      "version": "3.7.3-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "debian-archive-keyring_2021.1.1-p-deb11u1_arm64",
-      "name": "debian-archive-keyring",
-      "sha256": "28ca7749ab7978f3c571732c3aa1c56e3ad1d5db3c915293763d4f6cb8fcce89",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
-      "version": "2021.1.1+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libapt-pkg6.0_2.2.4_arm64",
-      "name": "libapt-pkg6.0",
-      "sha256": "7cb6015ea5c185ef93706989fb730377406878c72f6943b6ecdd956697f1abe6",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_arm64.deb",
-      "version": "2.2.4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libxxhash0_0.8.0-2_arm64",
-      "name": "libxxhash0",
-      "sha256": "a31effcbd7a248b64dd480330557f41ea796a010b2c2e7ac91ed10f94e605065",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_arm64.deb",
-      "version": "0.8.0-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libudev1_247.3-7-p-deb11u4_arm64",
-      "name": "libudev1",
-      "sha256": "d53ca63927b51ad6f9a85ee1e4ce74d20ef45651179fd70f3c8d72607071e393",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_arm64.deb",
-      "version": "247.3-7+deb11u4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "adduser_3.118-p-deb11u1_arm64",
-      "name": "adduser",
-      "sha256": "1478a610fd50e190882ff41e16c57b628a508bcf5b5ac5313affb49d20818e0a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
-      "version": "3.118+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "passwd_1-4.8.1-1_arm64",
-      "name": "passwd",
-      "sha256": "5a675c9d23f176ea195678a949e144b23c7a8b268b03e0df8919a2cfc198e585",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_arm64.deb",
-      "version": "1:4.8.1-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libpam-modules_1.4.0-9-p-deb11u1_arm64",
-      "name": "libpam-modules",
-      "sha256": "7f46ae216fdc6c69b0120d430936f40f3c5f37249296042324aeb584d5566a3c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_arm64.deb",
-      "version": "1.4.0-9+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libpam-modules-bin_1.4.0-9-p-deb11u1_arm64",
-      "name": "libpam-modules-bin",
-      "sha256": "bc20fa16c91a239de350ffcc019fbae5ce7c47c21235b332ff9d67638804866e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_arm64.deb",
-      "version": "1.4.0-9+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libpam0g_1.4.0-9-p-deb11u1_arm64",
-      "name": "libpam0g",
-      "sha256": "4905e523ce38e80b79f13f0227fca519f6833eb116dd9c58cbbecb39c0e01e3d",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_arm64.deb",
-      "version": "1.4.0-9+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libaudit1_1-3.0-2_arm64",
-      "name": "libaudit1",
-      "sha256": "c93da146715dcd0c71759629c04afb01a41c879d91b2f5330adc74365db03763",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_arm64.deb",
-      "version": "1:3.0-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libcap-ng0_0.7.9-2.2-p-b1_arm64",
-      "name": "libcap-ng0",
-      "sha256": "b7b14e0b7747872f04691efe6c126de5ed0bf1dc200f51b93039cc2f4a65a96a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_arm64.deb",
-      "version": "0.7.9-2.2+b1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libaudit-common_1-3.0-2_arm64",
-      "name": "libaudit-common",
-      "sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
-      "version": "1:3.0-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libtirpc3_1.3.1-1-p-deb11u1_arm64",
-      "name": "libtirpc3",
-      "sha256": "ccff0927f55b97fe9ea13057fab8bff9920bf4628eb2d5d48b9656f2fb74d2e1",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_arm64.deb",
-      "version": "1.3.1-1+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libtirpc-common_1.3.1-1-p-deb11u1_arm64",
-      "name": "libtirpc-common",
-      "sha256": "b2f10cb79e7d7a2f9b30bcdf036127df55cd4a34688547bc2886fa38f4969f77",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb",
-      "version": "1.3.1-1+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_arm64",
-      "name": "libgssapi-krb5-2",
-      "sha256": "5572a462c7f78f9610bd4f1dd9f8e4f8243fa9dc2d1deb5b1cf7cec1f1df83dc",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_arm64.deb",
-      "version": "1.18.3-6+deb11u4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libkrb5support0_1.18.3-6-p-deb11u4_arm64",
-      "name": "libkrb5support0",
-      "sha256": "d44585771e26c9b8d115aad33736fcc3e03cf98238ea7c7985554f166441aa07",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_arm64.deb",
-      "version": "1.18.3-6+deb11u4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libkrb5-3_1.18.3-6-p-deb11u4_arm64",
-      "name": "libkrb5-3",
-      "sha256": "3dcdadb1db461d14b6051a19c6a94ae9f61c3d2b1d35fd9d63326cd8f4ae49e5",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_arm64.deb",
-      "version": "1.18.3-6+deb11u4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
-      "name": "libssl1.1",
-      "sha256": "fe7a7d313c87e46e62e614a07137e4a476a79fc9e5aab7b23e8235211280fee3",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_arm64.deb",
-      "version": "1.1.1w-0+deb11u1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libkeyutils1_1.6.1-2_arm64",
-      "name": "libkeyutils1",
-      "sha256": "7101c2380ab47a3627a6fa076a149ab71078263064f936fccbd43efbaed4a2da",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_arm64.deb",
-      "version": "1.6.1-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libk5crypto3_1.18.3-6-p-deb11u4_arm64",
-      "name": "libk5crypto3",
-      "sha256": "d8f31a8bd83fe2593e83a930fc2713e1213f25311a629836dfcde5bd23a85e83",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_arm64.deb",
-      "version": "1.18.3-6+deb11u4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libcom-err2_1.46.2-2_arm64",
-      "name": "libcom-err2",
-      "sha256": "fc95d415c35f5b687871f660a5bf66963fd117daa490110499119411e2d6145e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_arm64.deb",
-      "version": "1.46.2-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnsl2_1.3.0-2_arm64",
-      "name": "libnsl2",
-      "sha256": "8f9ba58b219779b43c4ccc78c79b0a23f721fc96323c202abb31e02f942104b3",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb",
-      "version": "1.3.0-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
-      "name": "libdb5.3",
-      "sha256": "cf9aa3eae9cfc4c84f93e32f3d11e2707146e4d9707712909e3c61530b50353e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_arm64.deb",
-      "version": "5.3.28+dfsg1-0.8"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libsemanage1_3.1-1-p-b2_arm64",
-      "name": "libsemanage1",
-      "sha256": "342a804007338314211981fac0bc083c3c66c6040bca0e47342c6d9ff44f103e",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_arm64.deb",
-      "version": "3.1-1+b2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libsepol1_3.1-1_arm64",
-      "name": "libsepol1",
-      "sha256": "354d36c3084c14f242baba3a06372a3c034cec7a0cb38e626fc03cc4751b2cd3",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_arm64.deb",
-      "version": "3.1-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libsemanage-common_3.1-1_arm64",
-      "name": "libsemanage-common",
-      "sha256": "d319a026ecd02e2f605c52350949279f3c331a19380f8b6888ce5b9ef0d31349",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
-      "version": "3.1-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "libperl5.32_5.32.1-4-p-deb11u3_arm64",
-          "name": "libperl5.32",
-          "version": "5.32.1-4+deb11u3"
-        },
-        {
-          "key": "perl-modules-5.32_5.32.1-4-p-deb11u3_arm64",
-          "name": "perl-modules-5.32",
-          "version": "5.32.1-4+deb11u3"
-        },
-        {
-          "key": "perl-base_5.32.1-4-p-deb11u3_arm64",
-          "name": "perl-base",
-          "version": "5.32.1-4+deb11u3"
-        },
-        {
-          "key": "dpkg_1.20.13_arm64",
-          "name": "dpkg",
-          "version": "1.20.13"
-        },
-        {
-          "key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
-          "name": "tar",
-          "version": "1.34+dfsg-1+deb11u1"
-        },
-        {
-          "key": "libselinux1_3.1-3_arm64",
-          "name": "libselinux1",
-          "version": "3.1-3"
-        },
-        {
-          "key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
-          "name": "libpcre2-8-0",
-          "version": "10.36-2+deb11u1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_arm64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_arm64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_arm64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "libacl1_2.2.53-10_arm64",
-          "name": "libacl1",
-          "version": "2.2.53-10"
-        },
-        {
-          "key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
-          "name": "zlib1g",
-          "version": "1:1.2.11.dfsg-2+deb11u2"
-        },
-        {
-          "key": "liblzma5_5.2.5-2.1~deb11u1_arm64",
-          "name": "liblzma5",
-          "version": "5.2.5-2.1~deb11u1"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-4_arm64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-4"
-        },
-        {
-          "key": "libgdbm6_1.19-2_arm64",
-          "name": "libgdbm6",
-          "version": "1.19-2"
-        },
-        {
-          "key": "libgdbm-compat4_1.19-2_arm64",
-          "name": "libgdbm-compat4",
-          "version": "1.19-2"
-        },
-        {
-          "key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
-          "name": "libdb5.3",
-          "version": "5.3.28+dfsg1-0.8"
-        }
-      ],
-      "key": "perl_5.32.1-4-p-deb11u3_arm64",
-      "name": "perl",
-      "sha256": "6ed36a59241bbeec132eebec770567a4d23884f71dc922ac6770862cac1f3d9a",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_arm64.deb",
-      "version": "5.32.1-4+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libperl5.32_5.32.1-4-p-deb11u3_arm64",
-      "name": "libperl5.32",
-      "sha256": "9a5524101015f14773246336cb615c0e58fff2e7420a79f511262df9a7ff1c91",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_arm64.deb",
-      "version": "5.32.1-4+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "perl-modules-5.32_5.32.1-4-p-deb11u3_arm64",
-      "name": "perl-modules-5.32",
-      "sha256": "9a5cb99d0f33cb11c7f535aaebfb569c6b6f97a75d748a9a52ea3afed5bd3960",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
-      "version": "5.32.1-4+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "perl-base_5.32.1-4-p-deb11u3_arm64",
-      "name": "perl-base",
-      "sha256": "53e09d9594692c462f33d4e9394bff60f95fe74b70402772dc7396a5829b76e5",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_arm64.deb",
-      "version": "5.32.1-4+deb11u3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgdbm6_1.19-2_arm64",
-      "name": "libgdbm6",
-      "sha256": "97a88c2698bd836d04e51ad70c76826850857869b51e90b5343621ba30bbf525",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_arm64.deb",
-      "version": "1.19-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgdbm-compat4_1.19-2_arm64",
-      "name": "libgdbm-compat4",
-      "sha256": "0853cc0b0f92784b7fbd193d737c63b1d95f932e2b95dc1bb10c273e01a0f754",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_arm64.deb",
-      "version": "1.19-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "openssl_1.1.1w-0-p-deb11u1_arm64",
-          "name": "openssl",
-          "version": "1.1.1w-0+deb11u1"
-        },
-        {
-          "key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
-          "name": "libssl1.1",
-          "version": "1.1.1w-0+deb11u1"
-        },
-        {
-          "key": "libc6_2.31-13-p-deb11u8_arm64",
-          "name": "libc6",
-          "version": "2.31-13+deb11u8"
-        },
-        {
-          "key": "libcrypt1_1-4.4.18-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.18-4"
-        },
-        {
-          "key": "libgcc-s1_10.2.1-6_arm64",
-          "name": "libgcc-s1",
-          "version": "10.2.1-6"
-        },
-        {
-          "key": "gcc-10-base_10.2.1-6_arm64",
-          "name": "gcc-10-base",
-          "version": "10.2.1-6"
-        }
-      ],
-      "key": "ca-certificates_20210119_arm64",
-      "name": "ca-certificates",
-      "sha256": "b2d488ad4d8d8adb3ba319fc9cb2cf9909fc42cb82ad239a26c570a2e749c389",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
-      "version": "20210119"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "openssl_1.1.1w-0-p-deb11u1_arm64",
-      "name": "openssl",
-      "sha256": "d9159af073e95641e7eda440fa1d7623873b8c0034c9826a353f890bed107f3c",
-      "url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_arm64.deb",
-      "version": "1.1.1w-0+deb11u1"
-    }
-  ],
-  "version": 1
+	"packages": [
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "ncurses-base_6.2-p-20201114-2-p-deb11u2_amd64",
+			"name": "ncurses-base",
+			"sha256": "a55a5f94299448279da6a6c2031a9816dc768cd300668ff82ecfc6480bbfc83d",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
+			"version": "6.2+20201114-2+deb11u2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libc6_2.31-13-p-deb11u8_amd64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_amd64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_amd64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
+					"name": "libtinfo6",
+					"version": "6.2+20201114-2+deb11u2"
+				}
+			],
+			"key": "libncurses6_6.2-p-20201114-2-p-deb11u2_amd64",
+			"name": "libncurses6",
+			"sha256": "5b75c540d26d0525f231d39e5cf27ea7919d57305ba7101ea430c975369095eb",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_amd64.deb",
+			"version": "6.2+20201114-2+deb11u2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libc6_2.31-13-p-deb11u8_amd64",
+			"name": "libc6",
+			"sha256": "d55d9c9769336f9b8516c20bd8364ce90746fb860ae3dda242f421e711af3d1a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_amd64.deb",
+			"version": "2.31-13+deb11u8"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.18-4_amd64",
+			"name": "libcrypt1",
+			"sha256": "f617952df0c57b4ee039448e3941bccd3f97bfff71e9b0f87ca6dae15cb3f5ef",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb",
+			"version": "1:4.4.18-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcc-s1_10.2.1-6_amd64",
+			"name": "libgcc-s1",
+			"sha256": "e478f2709d8474165bb664de42e16950c391f30eaa55bc9b3573281d83a29daf",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-10-base_10.2.1-6_amd64",
+			"name": "gcc-10-base",
+			"sha256": "be65535e94f95fbf04b104e8ab36790476f063374430f7dfc6c516cbe2d2cd1e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
+			"name": "libtinfo6",
+			"sha256": "96ed58b8fd656521e08549c763cd18da6cff1b7801a3a22f29678701a95d7e7b",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_amd64.deb",
+			"version": "6.2+20201114-2+deb11u2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tzdata_2024a-0-p-deb11u1_amd64",
+			"name": "tzdata",
+			"sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+			"version": "2024a-0+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "debianutils_4.11.2_amd64",
+					"name": "debianutils",
+					"version": "4.11.2"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_amd64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_amd64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_amd64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "base-files_11.1-p-deb11u9_amd64",
+					"name": "base-files",
+					"version": "11.1+deb11u9"
+				},
+				{
+					"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
+					"name": "libtinfo6",
+					"version": "6.2+20201114-2+deb11u2"
+				}
+			],
+			"key": "bash_5.1-2-p-deb11u1_amd64",
+			"name": "bash",
+			"sha256": "f702ef058e762d7208a9c83f6f6bbf02645533bfd615c54e8cdcce842cd57377",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_amd64.deb",
+			"version": "5.1-2+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "debianutils_4.11.2_amd64",
+			"name": "debianutils",
+			"sha256": "83d21669c5957e3eaee20096a7d8c596bd07f57f1e95dc74f192b3fb7bb2e6a9",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_amd64.deb",
+			"version": "4.11.2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "base-files_11.1-p-deb11u9_amd64",
+			"name": "base-files",
+			"sha256": "1ff08cf6e1b97af1e37cda830f3658f9af43a906abb80a21951c81aea02ce230",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_amd64.deb",
+			"version": "11.1+deb11u9"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libselinux1_3.1-3_amd64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_amd64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_amd64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_amd64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libattr1_1-2.4.48-6_amd64",
+					"name": "libattr1",
+					"version": "1:2.4.48-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_amd64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				}
+			],
+			"key": "coreutils_8.32-4-p-b1_amd64",
+			"name": "coreutils",
+			"sha256": "3558a412ab51eee4b60641327cb145bb91415f127769823b68f9335585b308d4",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4+b1_amd64.deb",
+			"version": "8.32-4+b1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libselinux1_3.1-3_amd64",
+			"name": "libselinux1",
+			"sha256": "339f5ede10500c16dd7192d73169c31c4b27ab12130347275f23044ec8c7d897",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb",
+			"version": "3.1-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
+			"name": "libpcre2-8-0",
+			"sha256": "ee192c8d22624eb9d0a2ae95056bad7fb371e5abc17e23e16b1de3ddb17a1064",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb",
+			"version": "10.36-2+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
+			"name": "libgmp10",
+			"sha256": "fc117ccb084a98d25021f7e01e4dfedd414fa2118fdd1e27d2d801d7248aebbc",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb",
+			"version": "2:6.2.1+dfsg-1+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libattr1_1-2.4.48-6_amd64",
+			"name": "libattr1",
+			"sha256": "af3c3562eb2802481a2b9558df1b389f3c6d9b1bf3b4219e000e05131372ebaf",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_amd64.deb",
+			"version": "1:2.4.48-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libacl1_2.2.53-10_amd64",
+			"name": "libacl1",
+			"sha256": "aa18d721be8aea50fbdb32cd9a319cb18a3f111ea6ad17399aa4ba9324c8e26a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb",
+			"version": "2.2.53-10"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
+					"name": "tar",
+					"version": "1.34+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libselinux1_3.1-3_amd64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_amd64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_amd64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_amd64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_amd64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2+deb11u2"
+				},
+				{
+					"key": "liblzma5_5.2.5-2.1_deb11u1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2.1~deb11u1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-4_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-4"
+				}
+			],
+			"key": "dpkg_1.20.13_amd64",
+			"name": "dpkg",
+			"sha256": "eb2b7ba3a3c4e905a380045a2d1cd219d2d45755aba5966d6c804b79400beb05",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb",
+			"version": "1.20.13"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
+			"name": "tar",
+			"sha256": "41c9c31f67a76b3532036f09ceac1f40a9224f1680395d120a8b24eae60dd54a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_amd64.deb",
+			"version": "1.34+dfsg-1+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
+			"name": "zlib1g",
+			"sha256": "03d2ab2174af76df6f517b854b77460fbdafc3dac0dca979317da67538159a3e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_amd64.deb",
+			"version": "1:1.2.11.dfsg-2+deb11u2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblzma5_5.2.5-2.1_deb11u1_amd64",
+			"name": "liblzma5",
+			"sha256": "1c79a02415ca5ee7234ac60502fb33ee94fa70b02d1c329a6a14178f8329c435",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_amd64.deb",
+			"version": "5.2.5-2.1~deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbz2-1.0_1.0.8-4_amd64",
+			"name": "libbz2-1.0",
+			"sha256": "16e27c3ebd97981e70db3733f899963362748f178a62644df69d1f247e741379",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb",
+			"version": "1.0.8-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libsystemd0_247.3-7-p-deb11u4_amd64",
+					"name": "libsystemd0",
+					"version": "247.3-7+deb11u4"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-2.1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_amd64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_amd64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_amd64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "liblzma5_5.2.5-2.1_deb11u1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2.1~deb11u1"
+				},
+				{
+					"key": "liblz4-1_1.9.3-2_amd64",
+					"name": "liblz4-1",
+					"version": "1.9.3-2"
+				},
+				{
+					"key": "libgcrypt20_1.8.7-6_amd64",
+					"name": "libgcrypt20",
+					"version": "1.8.7-6"
+				},
+				{
+					"key": "libgpg-error0_1.38-2_amd64",
+					"name": "libgpg-error0",
+					"version": "1.38-2"
+				},
+				{
+					"key": "libstdc-p--p-6_10.2.1-6_amd64",
+					"name": "libstdc++6",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libseccomp2_2.5.1-1-p-deb11u1_amd64",
+					"name": "libseccomp2",
+					"version": "2.5.1-1+deb11u1"
+				},
+				{
+					"key": "libgnutls30_3.7.1-5-p-deb11u4_amd64",
+					"name": "libgnutls30",
+					"version": "3.7.1-5+deb11u4"
+				},
+				{
+					"key": "libunistring2_0.9.10-4_amd64",
+					"name": "libunistring2",
+					"version": "0.9.10-4"
+				},
+				{
+					"key": "libtasn1-6_4.16.0-2-p-deb11u1_amd64",
+					"name": "libtasn1-6",
+					"version": "4.16.0-2+deb11u1"
+				},
+				{
+					"key": "libp11-kit0_0.23.22-1_amd64",
+					"name": "libp11-kit0",
+					"version": "0.23.22-1"
+				},
+				{
+					"key": "libffi7_3.3-6_amd64",
+					"name": "libffi7",
+					"version": "3.3-6"
+				},
+				{
+					"key": "libnettle8_3.7.3-1_amd64",
+					"name": "libnettle8",
+					"version": "3.7.3-1"
+				},
+				{
+					"key": "libidn2-0_2.3.0-5_amd64",
+					"name": "libidn2-0",
+					"version": "2.3.0-5"
+				},
+				{
+					"key": "libhogweed6_3.7.3-1_amd64",
+					"name": "libhogweed6",
+					"version": "3.7.3-1"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-1+deb11u1"
+				},
+				{
+					"key": "debian-archive-keyring_2021.1.1-p-deb11u1_amd64",
+					"name": "debian-archive-keyring",
+					"version": "2021.1.1+deb11u1"
+				},
+				{
+					"key": "libapt-pkg6.0_2.2.4_amd64",
+					"name": "libapt-pkg6.0",
+					"version": "2.2.4"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2+deb11u2"
+				},
+				{
+					"key": "libxxhash0_0.8.0-2_amd64",
+					"name": "libxxhash0",
+					"version": "0.8.0-2"
+				},
+				{
+					"key": "libudev1_247.3-7-p-deb11u4_amd64",
+					"name": "libudev1",
+					"version": "247.3-7+deb11u4"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-4_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-4"
+				},
+				{
+					"key": "adduser_3.118-p-deb11u1_amd64",
+					"name": "adduser",
+					"version": "3.118+deb11u1"
+				},
+				{
+					"key": "passwd_1-4.8.1-1_amd64",
+					"name": "passwd",
+					"version": "1:4.8.1-1"
+				},
+				{
+					"key": "libpam-modules_1.4.0-9-p-deb11u1_amd64",
+					"name": "libpam-modules",
+					"version": "1.4.0-9+deb11u1"
+				},
+				{
+					"key": "libpam-modules-bin_1.4.0-9-p-deb11u1_amd64",
+					"name": "libpam-modules-bin",
+					"version": "1.4.0-9+deb11u1"
+				},
+				{
+					"key": "libselinux1_3.1-3_amd64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libpam0g_1.4.0-9-p-deb11u1_amd64",
+					"name": "libpam0g",
+					"version": "1.4.0-9+deb11u1"
+				},
+				{
+					"key": "libaudit1_1-3.0-2_amd64",
+					"name": "libaudit1",
+					"version": "1:3.0-2"
+				},
+				{
+					"key": "libcap-ng0_0.7.9-2.2-p-b1_amd64",
+					"name": "libcap-ng0",
+					"version": "0.7.9-2.2+b1"
+				},
+				{
+					"key": "libaudit-common_1-3.0-2_amd64",
+					"name": "libaudit-common",
+					"version": "1:3.0-2"
+				},
+				{
+					"key": "libtirpc3_1.3.1-1-p-deb11u1_amd64",
+					"name": "libtirpc3",
+					"version": "1.3.1-1+deb11u1"
+				},
+				{
+					"key": "libtirpc-common_1.3.1-1-p-deb11u1_amd64",
+					"name": "libtirpc-common",
+					"version": "1.3.1-1+deb11u1"
+				},
+				{
+					"key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_amd64",
+					"name": "libgssapi-krb5-2",
+					"version": "1.18.3-6+deb11u4"
+				},
+				{
+					"key": "libkrb5support0_1.18.3-6-p-deb11u4_amd64",
+					"name": "libkrb5support0",
+					"version": "1.18.3-6+deb11u4"
+				},
+				{
+					"key": "libkrb5-3_1.18.3-6-p-deb11u4_amd64",
+					"name": "libkrb5-3",
+					"version": "1.18.3-6+deb11u4"
+				},
+				{
+					"key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
+					"name": "libssl1.1",
+					"version": "1.1.1w-0+deb11u1"
+				},
+				{
+					"key": "libkeyutils1_1.6.1-2_amd64",
+					"name": "libkeyutils1",
+					"version": "1.6.1-2"
+				},
+				{
+					"key": "libk5crypto3_1.18.3-6-p-deb11u4_amd64",
+					"name": "libk5crypto3",
+					"version": "1.18.3-6+deb11u4"
+				},
+				{
+					"key": "libcom-err2_1.46.2-2_amd64",
+					"name": "libcom-err2",
+					"version": "1.46.2-2"
+				},
+				{
+					"key": "libnsl2_1.3.0-2_amd64",
+					"name": "libnsl2",
+					"version": "1.3.0-2"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.8"
+				},
+				{
+					"key": "libsemanage1_3.1-1-p-b2_amd64",
+					"name": "libsemanage1",
+					"version": "3.1-1+b2"
+				},
+				{
+					"key": "libsepol1_3.1-1_amd64",
+					"name": "libsepol1",
+					"version": "3.1-1"
+				},
+				{
+					"key": "libsemanage-common_3.1-1_amd64",
+					"name": "libsemanage-common",
+					"version": "3.1-1"
+				}
+			],
+			"key": "apt_2.2.4_amd64",
+			"name": "apt",
+			"sha256": "75f07c4965ff0813f26623a1164e162538f5e94defba6961347527ed71bc4f3d",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_amd64.deb",
+			"version": "2.2.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsystemd0_247.3-7-p-deb11u4_amd64",
+			"name": "libsystemd0",
+			"sha256": "e6f3e65e388196a399c1a36564c38ad987337350358732056227db1b6e708878",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_amd64.deb",
+			"version": "247.3-7+deb11u4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
+			"name": "libzstd1",
+			"sha256": "5dcadfbb743bfa1c1c773bff91c018f835e8e8c821d423d3836f3ab84773507b",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_amd64.deb",
+			"version": "1.4.8+dfsg-2.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblz4-1_1.9.3-2_amd64",
+			"name": "liblz4-1",
+			"sha256": "79ac6e9ca19c483f2e8effcc3401d723dd9dbb3a4ae324714de802adb21a8117",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_amd64.deb",
+			"version": "1.9.3-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcrypt20_1.8.7-6_amd64",
+			"name": "libgcrypt20",
+			"sha256": "7a2e0eef8e0c37f03f3a5fcf7102a2e3dc70ba987f696ab71949f9abf36f35ef",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb",
+			"version": "1.8.7-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgpg-error0_1.38-2_amd64",
+			"name": "libgpg-error0",
+			"sha256": "16a507fb20cc58b5a524a0dc254a9cb1df02e1ce758a2d8abde0bc4a3c9b7c26",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb",
+			"version": "1.38-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libstdc-p--p-6_10.2.1-6_amd64",
+			"name": "libstdc++6",
+			"sha256": "5c155c58935870bf3b4bfe769116841c0d286a74f59eccfd5645693ac23f06b1",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libseccomp2_2.5.1-1-p-deb11u1_amd64",
+			"name": "libseccomp2",
+			"sha256": "2617fc8b99dca0fa8ed466ee0f5fe087aa4e8413b88ca45d717290f4a0551e36",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_amd64.deb",
+			"version": "2.5.1-1+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgnutls30_3.7.1-5-p-deb11u4_amd64",
+			"name": "libgnutls30",
+			"sha256": "b2fa128881a16c2196caddb551d3577baa296a7bc5d38109a978e8e69fdb5c94",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_amd64.deb",
+			"version": "3.7.1-5+deb11u4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libunistring2_0.9.10-4_amd64",
+			"name": "libunistring2",
+			"sha256": "654433ad02d3a8b05c1683c6c29a224500bf343039c34dcec4e5e9515345e3d4",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_amd64.deb",
+			"version": "0.9.10-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtasn1-6_4.16.0-2-p-deb11u1_amd64",
+			"name": "libtasn1-6",
+			"sha256": "6ebb579337cdc9d6201237a66578425a7a221db622524354e27c0c1bcb6dd7ca",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_amd64.deb",
+			"version": "4.16.0-2+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libp11-kit0_0.23.22-1_amd64",
+			"name": "libp11-kit0",
+			"sha256": "bfef5f31ee1c730e56e16bb62cc5ff8372185106c75bf1ed1756c96703019457",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_amd64.deb",
+			"version": "0.23.22-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libffi7_3.3-6_amd64",
+			"name": "libffi7",
+			"sha256": "30ca89bfddae5fa6e0a2a044f22b6e50cd17c4bc6bc850c579819aeab7101f0f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb",
+			"version": "3.3-6"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnettle8_3.7.3-1_amd64",
+			"name": "libnettle8",
+			"sha256": "e4f8ec31ed14518b241eb7b423ad5ed3f4a4e8ac50aae72c9fd475c569582764",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb",
+			"version": "3.7.3-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libidn2-0_2.3.0-5_amd64",
+			"name": "libidn2-0",
+			"sha256": "cb80cd769171537bafbb4a16c12ec427065795946b3415781bc9792e92d60b59",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_amd64.deb",
+			"version": "2.3.0-5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libhogweed6_3.7.3-1_amd64",
+			"name": "libhogweed6",
+			"sha256": "6aab2e892cdb2dfba45707601bc6c3b19aa228f70ae5841017f14c3b0ca3d22f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb",
+			"version": "3.7.3-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "debian-archive-keyring_2021.1.1-p-deb11u1_amd64",
+			"name": "debian-archive-keyring",
+			"sha256": "28ca7749ab7978f3c571732c3aa1c56e3ad1d5db3c915293763d4f6cb8fcce89",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
+			"version": "2021.1.1+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libapt-pkg6.0_2.2.4_amd64",
+			"name": "libapt-pkg6.0",
+			"sha256": "4ae47bedf773ad1342e5aae8fa6275f864cfc87a45f4472775f5a9cdd60abbbf",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_amd64.deb",
+			"version": "2.2.4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxxhash0_0.8.0-2_amd64",
+			"name": "libxxhash0",
+			"sha256": "3fb82550a71d27d05672472508548576dfb34486847bc860d3066cda5aaf186f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_amd64.deb",
+			"version": "0.8.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libudev1_247.3-7-p-deb11u4_amd64",
+			"name": "libudev1",
+			"sha256": "9274ca1aa37fcdf5895dad1de0895162351099ef8dff8a62f2f4c9eb181a8fce",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_amd64.deb",
+			"version": "247.3-7+deb11u4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "adduser_3.118-p-deb11u1_amd64",
+			"name": "adduser",
+			"sha256": "1478a610fd50e190882ff41e16c57b628a508bcf5b5ac5313affb49d20818e0a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
+			"version": "3.118+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "passwd_1-4.8.1-1_amd64",
+			"name": "passwd",
+			"sha256": "542593f26502e87b4276fa778e6e3ae52e66b973979986fff77803d9fcb2c2e8",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_amd64.deb",
+			"version": "1:4.8.1-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpam-modules_1.4.0-9-p-deb11u1_amd64",
+			"name": "libpam-modules",
+			"sha256": "ca1e121700bf4b3eb33e30e0774d3e63e1adae9d4b6a940ea3501225db3cc287",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_amd64.deb",
+			"version": "1.4.0-9+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpam-modules-bin_1.4.0-9-p-deb11u1_amd64",
+			"name": "libpam-modules-bin",
+			"sha256": "abbbd181329c236676222d3e912df13f8d1d90a117559edd997d90006369e5c8",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_amd64.deb",
+			"version": "1.4.0-9+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpam0g_1.4.0-9-p-deb11u1_amd64",
+			"name": "libpam0g",
+			"sha256": "496771218fb585bb716fdae6ef8824dbfb5d544b4fa2f3cd4d0e4d7158ae2220",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_amd64.deb",
+			"version": "1.4.0-9+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libaudit1_1-3.0-2_amd64",
+			"name": "libaudit1",
+			"sha256": "e3aa1383e387dc077a1176f7f3cbfdbc084bcc270a8938f598d5cb119773b268",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_amd64.deb",
+			"version": "1:3.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcap-ng0_0.7.9-2.2-p-b1_amd64",
+			"name": "libcap-ng0",
+			"sha256": "d34e29769b8ef23e9b9920814afb7905b8ee749db0814e6a8d937ccc4f309830",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_amd64.deb",
+			"version": "0.7.9-2.2+b1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libaudit-common_1-3.0-2_amd64",
+			"name": "libaudit-common",
+			"sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+			"version": "1:3.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtirpc3_1.3.1-1-p-deb11u1_amd64",
+			"name": "libtirpc3",
+			"sha256": "86b216d59b6efcd07d56d14b8f4281d5c47f24e9c962f46bbaf02fce762c5e6a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_amd64.deb",
+			"version": "1.3.1-1+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtirpc-common_1.3.1-1-p-deb11u1_amd64",
+			"name": "libtirpc-common",
+			"sha256": "b2f10cb79e7d7a2f9b30bcdf036127df55cd4a34688547bc2886fa38f4969f77",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb",
+			"version": "1.3.1-1+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_amd64",
+			"name": "libgssapi-krb5-2",
+			"sha256": "037cc4bb34a6cd0d7a6e83bdcae6d68e0d0f9218eb7dedafc8099c8c0be491a2",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_amd64.deb",
+			"version": "1.18.3-6+deb11u4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkrb5support0_1.18.3-6-p-deb11u4_amd64",
+			"name": "libkrb5support0",
+			"sha256": "da8d022e3dd7f4a72ea32e328b3ac382dbe6bdb91606c5738fe17a29f8ea8080",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_amd64.deb",
+			"version": "1.18.3-6+deb11u4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkrb5-3_1.18.3-6-p-deb11u4_amd64",
+			"name": "libkrb5-3",
+			"sha256": "b785fa324cf27e6bf7f97fc0279470e6ce8a8cc54f8ccc6c9b24c8111ba5c952",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_amd64.deb",
+			"version": "1.18.3-6+deb11u4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
+			"name": "libssl1.1",
+			"sha256": "aadf8b4b197335645b230c2839b4517aa444fd2e8f434e5438c48a18857988f7",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb",
+			"version": "1.1.1w-0+deb11u1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libkeyutils1_1.6.1-2_amd64",
+			"name": "libkeyutils1",
+			"sha256": "f01060b434d8cad3c58d5811d2082389f11b3db8152657d6c22c1d298953f2a5",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_amd64.deb",
+			"version": "1.6.1-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libk5crypto3_1.18.3-6-p-deb11u4_amd64",
+			"name": "libk5crypto3",
+			"sha256": "f635062bcbfe2eef5a83fcba7d1a8ae343fc7c779cae88b11cae90fd6845a744",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_amd64.deb",
+			"version": "1.18.3-6+deb11u4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcom-err2_1.46.2-2_amd64",
+			"name": "libcom-err2",
+			"sha256": "d478f132871f4ab8352d39becf936d0ad74db905398bf98465d8fe3da6fb1126",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_amd64.deb",
+			"version": "1.46.2-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnsl2_1.3.0-2_amd64",
+			"name": "libnsl2",
+			"sha256": "c0d83437fdb016cb289436f49f28a36be44b3e8f1f2498c7e3a095f709c0d6f8",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb",
+			"version": "1.3.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
+			"name": "libdb5.3",
+			"sha256": "00b9e63e287f45300d4a4f59b6b88e25918443c932ae3e5845d5761ae193c530",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb",
+			"version": "5.3.28+dfsg1-0.8"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsemanage1_3.1-1-p-b2_amd64",
+			"name": "libsemanage1",
+			"sha256": "d8f2835b22df58ba45d52eb3aab224190f193576caf05e3f80deb2e4f927fad6",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_amd64.deb",
+			"version": "3.1-1+b2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsepol1_3.1-1_amd64",
+			"name": "libsepol1",
+			"sha256": "b6057dc6806a6dfaef74b09d84d1f18716d7a6d2f1da30520cef555210c6af62",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_amd64.deb",
+			"version": "3.1-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsemanage-common_3.1-1_amd64",
+			"name": "libsemanage-common",
+			"sha256": "d319a026ecd02e2f605c52350949279f3c331a19380f8b6888ce5b9ef0d31349",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
+			"version": "3.1-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libperl5.32_5.32.1-4-p-deb11u3_amd64",
+					"name": "libperl5.32",
+					"version": "5.32.1-4+deb11u3"
+				},
+				{
+					"key": "perl-modules-5.32_5.32.1-4-p-deb11u3_amd64",
+					"name": "perl-modules-5.32",
+					"version": "5.32.1-4+deb11u3"
+				},
+				{
+					"key": "perl-base_5.32.1-4-p-deb11u3_amd64",
+					"name": "perl-base",
+					"version": "5.32.1-4+deb11u3"
+				},
+				{
+					"key": "dpkg_1.20.13_amd64",
+					"name": "dpkg",
+					"version": "1.20.13"
+				},
+				{
+					"key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
+					"name": "tar",
+					"version": "1.34+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libselinux1_3.1-3_amd64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_amd64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_amd64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_amd64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_amd64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2+deb11u2"
+				},
+				{
+					"key": "liblzma5_5.2.5-2.1_deb11u1_amd64",
+					"name": "liblzma5",
+					"version": "5.2.5-2.1~deb11u1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-4_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-4"
+				},
+				{
+					"key": "libgdbm6_1.19-2_amd64",
+					"name": "libgdbm6",
+					"version": "1.19-2"
+				},
+				{
+					"key": "libgdbm-compat4_1.19-2_amd64",
+					"name": "libgdbm-compat4",
+					"version": "1.19-2"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.8"
+				}
+			],
+			"key": "perl_5.32.1-4-p-deb11u3_amd64",
+			"name": "perl",
+			"sha256": "d5f710c7db9fcd6d9d6f119cd0dea64a4f765867447dd97b24ab44be1de7c60f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_amd64.deb",
+			"version": "5.32.1-4+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libperl5.32_5.32.1-4-p-deb11u3_amd64",
+			"name": "libperl5.32",
+			"sha256": "078487a45916167e3e4ee2e584c50306c84368dd06dae276604861ca0426c34e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_amd64.deb",
+			"version": "5.32.1-4+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "perl-modules-5.32_5.32.1-4-p-deb11u3_amd64",
+			"name": "perl-modules-5.32",
+			"sha256": "9a5cb99d0f33cb11c7f535aaebfb569c6b6f97a75d748a9a52ea3afed5bd3960",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
+			"version": "5.32.1-4+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "perl-base_5.32.1-4-p-deb11u3_amd64",
+			"name": "perl-base",
+			"sha256": "94c6299552866aadc58acb8ec5111a74b17bcb453f6e2f45ea5f7c4f42580d13",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_amd64.deb",
+			"version": "5.32.1-4+deb11u3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgdbm6_1.19-2_amd64",
+			"name": "libgdbm6",
+			"sha256": "e54cfe4d8b8f209bb7df31a404ce040f7c2f9b1045114a927a7e1061cdf90727",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_amd64.deb",
+			"version": "1.19-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgdbm-compat4_1.19-2_amd64",
+			"name": "libgdbm-compat4",
+			"sha256": "e62caed68b0ffaa03b5fa539d6fdc08c4151f66236d5878949bead0b71b7bb09",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_amd64.deb",
+			"version": "1.19-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "openssl_1.1.1w-0-p-deb11u1_amd64",
+					"name": "openssl",
+					"version": "1.1.1w-0+deb11u1"
+				},
+				{
+					"key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
+					"name": "libssl1.1",
+					"version": "1.1.1w-0+deb11u1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_amd64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_amd64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_amd64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				}
+			],
+			"key": "ca-certificates_20210119_amd64",
+			"name": "ca-certificates",
+			"sha256": "b2d488ad4d8d8adb3ba319fc9cb2cf9909fc42cb82ad239a26c570a2e749c389",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
+			"version": "20210119"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "openssl_1.1.1w-0-p-deb11u1_amd64",
+			"name": "openssl",
+			"sha256": "04873d74cbe86bad3a9901f6e57f1150040eba9891b443c5c975a72a97238e35",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_amd64.deb",
+			"version": "1.1.1w-0+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "ncurses-base_6.2-p-20201114-2-p-deb11u2_arm64",
+			"name": "ncurses-base",
+			"sha256": "a55a5f94299448279da6a6c2031a9816dc768cd300668ff82ecfc6480bbfc83d",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
+			"version": "6.2+20201114-2+deb11u2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libc6_2.31-13-p-deb11u8_arm64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_arm64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_arm64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
+					"name": "libtinfo6",
+					"version": "6.2+20201114-2+deb11u2"
+				}
+			],
+			"key": "libncurses6_6.2-p-20201114-2-p-deb11u2_arm64",
+			"name": "libncurses6",
+			"sha256": "039b71b8839538a92988003e13c29e7cf1149cdc6a77d3de882f1d386a5f3a5c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_arm64.deb",
+			"version": "6.2+20201114-2+deb11u2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libc6_2.31-13-p-deb11u8_arm64",
+			"name": "libc6",
+			"sha256": "6eb629090615ebda5dcac2365a7358c035add00b89c2724c2e9e13ccd5bd9f7c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_arm64.deb",
+			"version": "2.31-13+deb11u8"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.18-4_arm64",
+			"name": "libcrypt1",
+			"sha256": "22b586b29e840dabebf0bf227d233376628b87954915d064bc142ae85d1b7979",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_arm64.deb",
+			"version": "1:4.4.18-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcc-s1_10.2.1-6_arm64",
+			"name": "libgcc-s1",
+			"sha256": "e2fcdb378d3c1ad1bcb64d4fb6b37aab44011152beca12a4944f435a2582df1f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_arm64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc-10-base_10.2.1-6_arm64",
+			"name": "gcc-10-base",
+			"sha256": "7d782bece7b4a36bed045a7e17d17244cb8f7e4732466091b01412ebf215defb",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_arm64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
+			"name": "libtinfo6",
+			"sha256": "58027c991756930a2abb2f87a829393d3fdbfb76f4eca9795ef38ea2b0510e27",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb",
+			"version": "6.2+20201114-2+deb11u2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "tzdata_2024a-0-p-deb11u1_arm64",
+			"name": "tzdata",
+			"sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+			"version": "2024a-0+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "debianutils_4.11.2_arm64",
+					"name": "debianutils",
+					"version": "4.11.2"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_arm64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_arm64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_arm64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "base-files_11.1-p-deb11u9_arm64",
+					"name": "base-files",
+					"version": "11.1+deb11u9"
+				},
+				{
+					"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
+					"name": "libtinfo6",
+					"version": "6.2+20201114-2+deb11u2"
+				}
+			],
+			"key": "bash_5.1-2-p-deb11u1_arm64",
+			"name": "bash",
+			"sha256": "d7c7af5d86f43a885069408a89788f67f248e8124c682bb73936f33874e0611b",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb",
+			"version": "5.1-2+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "debianutils_4.11.2_arm64",
+			"name": "debianutils",
+			"sha256": "6543b2b1a61b4b7b4b55b4bd25162309d7d23d14d3303649aee84ad314c30e02",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_arm64.deb",
+			"version": "4.11.2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "base-files_11.1-p-deb11u9_arm64",
+			"name": "base-files",
+			"sha256": "c40dc4d5c6b82f5cfe75efa1a12bd09b9d5b9b8446ea045a991896a1ead8b02c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_arm64.deb",
+			"version": "11.1+deb11u9"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libselinux1_3.1-3_arm64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_arm64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_arm64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_arm64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libattr1_1-2.4.48-6_arm64",
+					"name": "libattr1",
+					"version": "1:2.4.48-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_arm64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				}
+			],
+			"key": "coreutils_8.32-4_arm64",
+			"name": "coreutils",
+			"sha256": "6210c84d6ff84b867dc430f661f22f536e1704c27bdb79de38e26f75b853d9c0",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4_arm64.deb",
+			"version": "8.32-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libselinux1_3.1-3_arm64",
+			"name": "libselinux1",
+			"sha256": "da98279a47dabaa46a83514142f5c691c6a71fa7e582661a3a3db6887ad3e9d1",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_arm64.deb",
+			"version": "3.1-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
+			"name": "libpcre2-8-0",
+			"sha256": "27a4362a4793cb67a8ae571bd8c3f7e8654dc2e56d99088391b87af1793cca9c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_arm64.deb",
+			"version": "10.36-2+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
+			"name": "libgmp10",
+			"sha256": "d52619b6ff8829aa5424dfe3189dd05f22118211e69273e9576030584ffcce80",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_arm64.deb",
+			"version": "2:6.2.1+dfsg-1+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libattr1_1-2.4.48-6_arm64",
+			"name": "libattr1",
+			"sha256": "cb9b59be719a6fdbaabaa60e22aa6158b2de7a68c88ccd7c3fb7f41a25fb43d0",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_arm64.deb",
+			"version": "1:2.4.48-6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libacl1_2.2.53-10_arm64",
+			"name": "libacl1",
+			"sha256": "f164c48192cb47746101de6c59afa3f97777c8fc821e5a30bb890df1f4cb4cfd",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_arm64.deb",
+			"version": "2.2.53-10"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
+					"name": "tar",
+					"version": "1.34+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libselinux1_3.1-3_arm64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_arm64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_arm64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_arm64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_arm64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2+deb11u2"
+				},
+				{
+					"key": "liblzma5_5.2.5-2.1_deb11u1_arm64",
+					"name": "liblzma5",
+					"version": "5.2.5-2.1~deb11u1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-4_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-4"
+				}
+			],
+			"key": "dpkg_1.20.13_arm64",
+			"name": "dpkg",
+			"sha256": "87b0bce7361d94cc15caf27709fa8a70de44f9dd742cf0d69d25796a03d24853",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_arm64.deb",
+			"version": "1.20.13"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
+			"name": "tar",
+			"sha256": "0f94aac4e6d25e07ed23b7fc3ed06e69074c95276d82caae7fc7b207fd714e39",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_arm64.deb",
+			"version": "1.34+dfsg-1+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
+			"name": "zlib1g",
+			"sha256": "e3963985d1a020d67ffd4180e6f9c4b5c600b515f0c9d8fda513d7a0e48e63a1",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_arm64.deb",
+			"version": "1:1.2.11.dfsg-2+deb11u2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "liblzma5_5.2.5-2.1_deb11u1_arm64",
+			"name": "liblzma5",
+			"sha256": "d865bba41952c707b3fa3ae8cab4d4bd337ee92991d2aead66c925bf7cc48846",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_arm64.deb",
+			"version": "5.2.5-2.1~deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libbz2-1.0_1.0.8-4_arm64",
+			"name": "libbz2-1.0",
+			"sha256": "da340e8470e96445c56966f74e48a9a91dee0fa5c89876e88a4575cc17d17a97",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_arm64.deb",
+			"version": "1.0.8-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libsystemd0_247.3-7-p-deb11u4_arm64",
+					"name": "libsystemd0",
+					"version": "247.3-7+deb11u4"
+				},
+				{
+					"key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
+					"name": "libzstd1",
+					"version": "1.4.8+dfsg-2.1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_arm64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_arm64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_arm64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "liblzma5_5.2.5-2.1_deb11u1_arm64",
+					"name": "liblzma5",
+					"version": "5.2.5-2.1~deb11u1"
+				},
+				{
+					"key": "liblz4-1_1.9.3-2_arm64",
+					"name": "liblz4-1",
+					"version": "1.9.3-2"
+				},
+				{
+					"key": "libgcrypt20_1.8.7-6_arm64",
+					"name": "libgcrypt20",
+					"version": "1.8.7-6"
+				},
+				{
+					"key": "libgpg-error0_1.38-2_arm64",
+					"name": "libgpg-error0",
+					"version": "1.38-2"
+				},
+				{
+					"key": "libstdc-p--p-6_10.2.1-6_arm64",
+					"name": "libstdc++6",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libseccomp2_2.5.1-1-p-deb11u1_arm64",
+					"name": "libseccomp2",
+					"version": "2.5.1-1+deb11u1"
+				},
+				{
+					"key": "libgnutls30_3.7.1-5-p-deb11u4_arm64",
+					"name": "libgnutls30",
+					"version": "3.7.1-5+deb11u4"
+				},
+				{
+					"key": "libunistring2_0.9.10-4_arm64",
+					"name": "libunistring2",
+					"version": "0.9.10-4"
+				},
+				{
+					"key": "libtasn1-6_4.16.0-2-p-deb11u1_arm64",
+					"name": "libtasn1-6",
+					"version": "4.16.0-2+deb11u1"
+				},
+				{
+					"key": "libp11-kit0_0.23.22-1_arm64",
+					"name": "libp11-kit0",
+					"version": "0.23.22-1"
+				},
+				{
+					"key": "libffi7_3.3-6_arm64",
+					"name": "libffi7",
+					"version": "3.3-6"
+				},
+				{
+					"key": "libnettle8_3.7.3-1_arm64",
+					"name": "libnettle8",
+					"version": "3.7.3-1"
+				},
+				{
+					"key": "libidn2-0_2.3.0-5_arm64",
+					"name": "libidn2-0",
+					"version": "2.3.0-5"
+				},
+				{
+					"key": "libhogweed6_3.7.3-1_arm64",
+					"name": "libhogweed6",
+					"version": "3.7.3-1"
+				},
+				{
+					"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
+					"name": "libgmp10",
+					"version": "2:6.2.1+dfsg-1+deb11u1"
+				},
+				{
+					"key": "debian-archive-keyring_2021.1.1-p-deb11u1_arm64",
+					"name": "debian-archive-keyring",
+					"version": "2021.1.1+deb11u1"
+				},
+				{
+					"key": "libapt-pkg6.0_2.2.4_arm64",
+					"name": "libapt-pkg6.0",
+					"version": "2.2.4"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2+deb11u2"
+				},
+				{
+					"key": "libxxhash0_0.8.0-2_arm64",
+					"name": "libxxhash0",
+					"version": "0.8.0-2"
+				},
+				{
+					"key": "libudev1_247.3-7-p-deb11u4_arm64",
+					"name": "libudev1",
+					"version": "247.3-7+deb11u4"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-4_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-4"
+				},
+				{
+					"key": "adduser_3.118-p-deb11u1_arm64",
+					"name": "adduser",
+					"version": "3.118+deb11u1"
+				},
+				{
+					"key": "passwd_1-4.8.1-1_arm64",
+					"name": "passwd",
+					"version": "1:4.8.1-1"
+				},
+				{
+					"key": "libpam-modules_1.4.0-9-p-deb11u1_arm64",
+					"name": "libpam-modules",
+					"version": "1.4.0-9+deb11u1"
+				},
+				{
+					"key": "libpam-modules-bin_1.4.0-9-p-deb11u1_arm64",
+					"name": "libpam-modules-bin",
+					"version": "1.4.0-9+deb11u1"
+				},
+				{
+					"key": "libselinux1_3.1-3_arm64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libpam0g_1.4.0-9-p-deb11u1_arm64",
+					"name": "libpam0g",
+					"version": "1.4.0-9+deb11u1"
+				},
+				{
+					"key": "libaudit1_1-3.0-2_arm64",
+					"name": "libaudit1",
+					"version": "1:3.0-2"
+				},
+				{
+					"key": "libcap-ng0_0.7.9-2.2-p-b1_arm64",
+					"name": "libcap-ng0",
+					"version": "0.7.9-2.2+b1"
+				},
+				{
+					"key": "libaudit-common_1-3.0-2_arm64",
+					"name": "libaudit-common",
+					"version": "1:3.0-2"
+				},
+				{
+					"key": "libtirpc3_1.3.1-1-p-deb11u1_arm64",
+					"name": "libtirpc3",
+					"version": "1.3.1-1+deb11u1"
+				},
+				{
+					"key": "libtirpc-common_1.3.1-1-p-deb11u1_arm64",
+					"name": "libtirpc-common",
+					"version": "1.3.1-1+deb11u1"
+				},
+				{
+					"key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_arm64",
+					"name": "libgssapi-krb5-2",
+					"version": "1.18.3-6+deb11u4"
+				},
+				{
+					"key": "libkrb5support0_1.18.3-6-p-deb11u4_arm64",
+					"name": "libkrb5support0",
+					"version": "1.18.3-6+deb11u4"
+				},
+				{
+					"key": "libkrb5-3_1.18.3-6-p-deb11u4_arm64",
+					"name": "libkrb5-3",
+					"version": "1.18.3-6+deb11u4"
+				},
+				{
+					"key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
+					"name": "libssl1.1",
+					"version": "1.1.1w-0+deb11u1"
+				},
+				{
+					"key": "libkeyutils1_1.6.1-2_arm64",
+					"name": "libkeyutils1",
+					"version": "1.6.1-2"
+				},
+				{
+					"key": "libk5crypto3_1.18.3-6-p-deb11u4_arm64",
+					"name": "libk5crypto3",
+					"version": "1.18.3-6+deb11u4"
+				},
+				{
+					"key": "libcom-err2_1.46.2-2_arm64",
+					"name": "libcom-err2",
+					"version": "1.46.2-2"
+				},
+				{
+					"key": "libnsl2_1.3.0-2_arm64",
+					"name": "libnsl2",
+					"version": "1.3.0-2"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.8"
+				},
+				{
+					"key": "libsemanage1_3.1-1-p-b2_arm64",
+					"name": "libsemanage1",
+					"version": "3.1-1+b2"
+				},
+				{
+					"key": "libsepol1_3.1-1_arm64",
+					"name": "libsepol1",
+					"version": "3.1-1"
+				},
+				{
+					"key": "libsemanage-common_3.1-1_arm64",
+					"name": "libsemanage-common",
+					"version": "3.1-1"
+				}
+			],
+			"key": "apt_2.2.4_arm64",
+			"name": "apt",
+			"sha256": "39cbe42f3e64c6359b445d6fed7385273881e507b8be1d3b653ec9fb7d4c917c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_arm64.deb",
+			"version": "2.2.4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsystemd0_247.3-7-p-deb11u4_arm64",
+			"name": "libsystemd0",
+			"sha256": "32e8c12301a9ada555adea9a4c2f15df788411dadd164baca5c31690fe06e381",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_arm64.deb",
+			"version": "247.3-7+deb11u4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
+			"name": "libzstd1",
+			"sha256": "dd01659c6c122f983a3369a04ede63539f666585d52a03f8aa2c27b307e547e0",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_arm64.deb",
+			"version": "1.4.8+dfsg-2.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "liblz4-1_1.9.3-2_arm64",
+			"name": "liblz4-1",
+			"sha256": "83f0ee547cd42854e1b2a2e4c1a5705e28259ee5fa6560119f918f961a5dada2",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_arm64.deb",
+			"version": "1.9.3-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcrypt20_1.8.7-6_arm64",
+			"name": "libgcrypt20",
+			"sha256": "61ec779149f20923b30adad7bdf4732957e88a5b6a26d94b2210dfe79409959b",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_arm64.deb",
+			"version": "1.8.7-6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgpg-error0_1.38-2_arm64",
+			"name": "libgpg-error0",
+			"sha256": "d1116f4281d6db35279799a21051e0d0e2600d110d7ee2b95b3cca6bec28067c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_arm64.deb",
+			"version": "1.38-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libstdc-p--p-6_10.2.1-6_arm64",
+			"name": "libstdc++6",
+			"sha256": "7869aa540cc46e9f3d4267d5bde2af0e5b429a820c1d6f1a4cfccfe788c31890",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_arm64.deb",
+			"version": "10.2.1-6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libseccomp2_2.5.1-1-p-deb11u1_arm64",
+			"name": "libseccomp2",
+			"sha256": "5b8983c2e330790dbe04ae990f166d7939a3e14b75556a8489309ae704fbeb50",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_arm64.deb",
+			"version": "2.5.1-1+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgnutls30_3.7.1-5-p-deb11u4_arm64",
+			"name": "libgnutls30",
+			"sha256": "7153ec6ee985eebba710dcb6e425bb881c91ee5987a4517518f3f44a9bb5fc1a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_arm64.deb",
+			"version": "3.7.1-5+deb11u4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libunistring2_0.9.10-4_arm64",
+			"name": "libunistring2",
+			"sha256": "53ff395ea4d8cf17c52155a452a0dc15af0ee2fa5cb3b0085b9c7335de8d5f7f",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_arm64.deb",
+			"version": "0.9.10-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtasn1-6_4.16.0-2-p-deb11u1_arm64",
+			"name": "libtasn1-6",
+			"sha256": "f469147bbd3969055c51fc661c9aa0d56d48eccd070d233f1424b0d8b3f29295",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_arm64.deb",
+			"version": "4.16.0-2+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libp11-kit0_0.23.22-1_arm64",
+			"name": "libp11-kit0",
+			"sha256": "ac6e8eda3277708069bc6f03aff06dc319855d64ede9fca219938e52f92ee09c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_arm64.deb",
+			"version": "0.23.22-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libffi7_3.3-6_arm64",
+			"name": "libffi7",
+			"sha256": "eb748e33ae4ed46f5a4c14b7a2a09792569f2029ede319d0979c373829ba1532",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb",
+			"version": "3.3-6"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnettle8_3.7.3-1_arm64",
+			"name": "libnettle8",
+			"sha256": "5061c931f95dc7277d95fc58bce7c17b1a95c6aa9a9aac781784f3b3dc909047",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb",
+			"version": "3.7.3-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libidn2-0_2.3.0-5_arm64",
+			"name": "libidn2-0",
+			"sha256": "0d2e6d39bf65f16861f284be567c1a6c5d4dc6b54dcfdf9dba631546ff4e6796",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_arm64.deb",
+			"version": "2.3.0-5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libhogweed6_3.7.3-1_arm64",
+			"name": "libhogweed6",
+			"sha256": "3e9eea5e474dd98a7de9e4c1ecfbfd6f6efb1d40bf51d6473de9713cf41d2191",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb",
+			"version": "3.7.3-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "debian-archive-keyring_2021.1.1-p-deb11u1_arm64",
+			"name": "debian-archive-keyring",
+			"sha256": "28ca7749ab7978f3c571732c3aa1c56e3ad1d5db3c915293763d4f6cb8fcce89",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
+			"version": "2021.1.1+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libapt-pkg6.0_2.2.4_arm64",
+			"name": "libapt-pkg6.0",
+			"sha256": "7cb6015ea5c185ef93706989fb730377406878c72f6943b6ecdd956697f1abe6",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_arm64.deb",
+			"version": "2.2.4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libxxhash0_0.8.0-2_arm64",
+			"name": "libxxhash0",
+			"sha256": "a31effcbd7a248b64dd480330557f41ea796a010b2c2e7ac91ed10f94e605065",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_arm64.deb",
+			"version": "0.8.0-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libudev1_247.3-7-p-deb11u4_arm64",
+			"name": "libudev1",
+			"sha256": "d53ca63927b51ad6f9a85ee1e4ce74d20ef45651179fd70f3c8d72607071e393",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_arm64.deb",
+			"version": "247.3-7+deb11u4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "adduser_3.118-p-deb11u1_arm64",
+			"name": "adduser",
+			"sha256": "1478a610fd50e190882ff41e16c57b628a508bcf5b5ac5313affb49d20818e0a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
+			"version": "3.118+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "passwd_1-4.8.1-1_arm64",
+			"name": "passwd",
+			"sha256": "5a675c9d23f176ea195678a949e144b23c7a8b268b03e0df8919a2cfc198e585",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_arm64.deb",
+			"version": "1:4.8.1-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpam-modules_1.4.0-9-p-deb11u1_arm64",
+			"name": "libpam-modules",
+			"sha256": "7f46ae216fdc6c69b0120d430936f40f3c5f37249296042324aeb584d5566a3c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_arm64.deb",
+			"version": "1.4.0-9+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpam-modules-bin_1.4.0-9-p-deb11u1_arm64",
+			"name": "libpam-modules-bin",
+			"sha256": "bc20fa16c91a239de350ffcc019fbae5ce7c47c21235b332ff9d67638804866e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_arm64.deb",
+			"version": "1.4.0-9+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpam0g_1.4.0-9-p-deb11u1_arm64",
+			"name": "libpam0g",
+			"sha256": "4905e523ce38e80b79f13f0227fca519f6833eb116dd9c58cbbecb39c0e01e3d",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_arm64.deb",
+			"version": "1.4.0-9+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libaudit1_1-3.0-2_arm64",
+			"name": "libaudit1",
+			"sha256": "c93da146715dcd0c71759629c04afb01a41c879d91b2f5330adc74365db03763",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_arm64.deb",
+			"version": "1:3.0-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcap-ng0_0.7.9-2.2-p-b1_arm64",
+			"name": "libcap-ng0",
+			"sha256": "b7b14e0b7747872f04691efe6c126de5ed0bf1dc200f51b93039cc2f4a65a96a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_arm64.deb",
+			"version": "0.7.9-2.2+b1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libaudit-common_1-3.0-2_arm64",
+			"name": "libaudit-common",
+			"sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+			"version": "1:3.0-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtirpc3_1.3.1-1-p-deb11u1_arm64",
+			"name": "libtirpc3",
+			"sha256": "ccff0927f55b97fe9ea13057fab8bff9920bf4628eb2d5d48b9656f2fb74d2e1",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_arm64.deb",
+			"version": "1.3.1-1+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtirpc-common_1.3.1-1-p-deb11u1_arm64",
+			"name": "libtirpc-common",
+			"sha256": "b2f10cb79e7d7a2f9b30bcdf036127df55cd4a34688547bc2886fa38f4969f77",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb",
+			"version": "1.3.1-1+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_arm64",
+			"name": "libgssapi-krb5-2",
+			"sha256": "5572a462c7f78f9610bd4f1dd9f8e4f8243fa9dc2d1deb5b1cf7cec1f1df83dc",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_arm64.deb",
+			"version": "1.18.3-6+deb11u4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libkrb5support0_1.18.3-6-p-deb11u4_arm64",
+			"name": "libkrb5support0",
+			"sha256": "d44585771e26c9b8d115aad33736fcc3e03cf98238ea7c7985554f166441aa07",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_arm64.deb",
+			"version": "1.18.3-6+deb11u4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libkrb5-3_1.18.3-6-p-deb11u4_arm64",
+			"name": "libkrb5-3",
+			"sha256": "3dcdadb1db461d14b6051a19c6a94ae9f61c3d2b1d35fd9d63326cd8f4ae49e5",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_arm64.deb",
+			"version": "1.18.3-6+deb11u4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
+			"name": "libssl1.1",
+			"sha256": "fe7a7d313c87e46e62e614a07137e4a476a79fc9e5aab7b23e8235211280fee3",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_arm64.deb",
+			"version": "1.1.1w-0+deb11u1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libkeyutils1_1.6.1-2_arm64",
+			"name": "libkeyutils1",
+			"sha256": "7101c2380ab47a3627a6fa076a149ab71078263064f936fccbd43efbaed4a2da",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_arm64.deb",
+			"version": "1.6.1-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libk5crypto3_1.18.3-6-p-deb11u4_arm64",
+			"name": "libk5crypto3",
+			"sha256": "d8f31a8bd83fe2593e83a930fc2713e1213f25311a629836dfcde5bd23a85e83",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_arm64.deb",
+			"version": "1.18.3-6+deb11u4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcom-err2_1.46.2-2_arm64",
+			"name": "libcom-err2",
+			"sha256": "fc95d415c35f5b687871f660a5bf66963fd117daa490110499119411e2d6145e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_arm64.deb",
+			"version": "1.46.2-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnsl2_1.3.0-2_arm64",
+			"name": "libnsl2",
+			"sha256": "8f9ba58b219779b43c4ccc78c79b0a23f721fc96323c202abb31e02f942104b3",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb",
+			"version": "1.3.0-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
+			"name": "libdb5.3",
+			"sha256": "cf9aa3eae9cfc4c84f93e32f3d11e2707146e4d9707712909e3c61530b50353e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_arm64.deb",
+			"version": "5.3.28+dfsg1-0.8"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsemanage1_3.1-1-p-b2_arm64",
+			"name": "libsemanage1",
+			"sha256": "342a804007338314211981fac0bc083c3c66c6040bca0e47342c6d9ff44f103e",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_arm64.deb",
+			"version": "3.1-1+b2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsepol1_3.1-1_arm64",
+			"name": "libsepol1",
+			"sha256": "354d36c3084c14f242baba3a06372a3c034cec7a0cb38e626fc03cc4751b2cd3",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_arm64.deb",
+			"version": "3.1-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsemanage-common_3.1-1_arm64",
+			"name": "libsemanage-common",
+			"sha256": "d319a026ecd02e2f605c52350949279f3c331a19380f8b6888ce5b9ef0d31349",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
+			"version": "3.1-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libperl5.32_5.32.1-4-p-deb11u3_arm64",
+					"name": "libperl5.32",
+					"version": "5.32.1-4+deb11u3"
+				},
+				{
+					"key": "perl-modules-5.32_5.32.1-4-p-deb11u3_arm64",
+					"name": "perl-modules-5.32",
+					"version": "5.32.1-4+deb11u3"
+				},
+				{
+					"key": "perl-base_5.32.1-4-p-deb11u3_arm64",
+					"name": "perl-base",
+					"version": "5.32.1-4+deb11u3"
+				},
+				{
+					"key": "dpkg_1.20.13_arm64",
+					"name": "dpkg",
+					"version": "1.20.13"
+				},
+				{
+					"key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
+					"name": "tar",
+					"version": "1.34+dfsg-1+deb11u1"
+				},
+				{
+					"key": "libselinux1_3.1-3_arm64",
+					"name": "libselinux1",
+					"version": "3.1-3"
+				},
+				{
+					"key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.36-2+deb11u1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_arm64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_arm64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_arm64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "libacl1_2.2.53-10_arm64",
+					"name": "libacl1",
+					"version": "2.2.53-10"
+				},
+				{
+					"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
+					"name": "zlib1g",
+					"version": "1:1.2.11.dfsg-2+deb11u2"
+				},
+				{
+					"key": "liblzma5_5.2.5-2.1_deb11u1_arm64",
+					"name": "liblzma5",
+					"version": "5.2.5-2.1~deb11u1"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-4_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-4"
+				},
+				{
+					"key": "libgdbm6_1.19-2_arm64",
+					"name": "libgdbm6",
+					"version": "1.19-2"
+				},
+				{
+					"key": "libgdbm-compat4_1.19-2_arm64",
+					"name": "libgdbm-compat4",
+					"version": "1.19-2"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg1-0.8"
+				}
+			],
+			"key": "perl_5.32.1-4-p-deb11u3_arm64",
+			"name": "perl",
+			"sha256": "6ed36a59241bbeec132eebec770567a4d23884f71dc922ac6770862cac1f3d9a",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_arm64.deb",
+			"version": "5.32.1-4+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libperl5.32_5.32.1-4-p-deb11u3_arm64",
+			"name": "libperl5.32",
+			"sha256": "9a5524101015f14773246336cb615c0e58fff2e7420a79f511262df9a7ff1c91",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_arm64.deb",
+			"version": "5.32.1-4+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "perl-modules-5.32_5.32.1-4-p-deb11u3_arm64",
+			"name": "perl-modules-5.32",
+			"sha256": "9a5cb99d0f33cb11c7f535aaebfb569c6b6f97a75d748a9a52ea3afed5bd3960",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
+			"version": "5.32.1-4+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "perl-base_5.32.1-4-p-deb11u3_arm64",
+			"name": "perl-base",
+			"sha256": "53e09d9594692c462f33d4e9394bff60f95fe74b70402772dc7396a5829b76e5",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_arm64.deb",
+			"version": "5.32.1-4+deb11u3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgdbm6_1.19-2_arm64",
+			"name": "libgdbm6",
+			"sha256": "97a88c2698bd836d04e51ad70c76826850857869b51e90b5343621ba30bbf525",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_arm64.deb",
+			"version": "1.19-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgdbm-compat4_1.19-2_arm64",
+			"name": "libgdbm-compat4",
+			"sha256": "0853cc0b0f92784b7fbd193d737c63b1d95f932e2b95dc1bb10c273e01a0f754",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_arm64.deb",
+			"version": "1.19-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "openssl_1.1.1w-0-p-deb11u1_arm64",
+					"name": "openssl",
+					"version": "1.1.1w-0+deb11u1"
+				},
+				{
+					"key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
+					"name": "libssl1.1",
+					"version": "1.1.1w-0+deb11u1"
+				},
+				{
+					"key": "libc6_2.31-13-p-deb11u8_arm64",
+					"name": "libc6",
+					"version": "2.31-13+deb11u8"
+				},
+				{
+					"key": "libcrypt1_1-4.4.18-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.18-4"
+				},
+				{
+					"key": "libgcc-s1_10.2.1-6_arm64",
+					"name": "libgcc-s1",
+					"version": "10.2.1-6"
+				},
+				{
+					"key": "gcc-10-base_10.2.1-6_arm64",
+					"name": "gcc-10-base",
+					"version": "10.2.1-6"
+				}
+			],
+			"key": "ca-certificates_20210119_arm64",
+			"name": "ca-certificates",
+			"sha256": "b2d488ad4d8d8adb3ba319fc9cb2cf9909fc42cb82ad239a26c570a2e749c389",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
+			"version": "20210119"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "openssl_1.1.1w-0-p-deb11u1_arm64",
+			"name": "openssl",
+			"sha256": "d9159af073e95641e7eda440fa1d7623873b8c0034c9826a353f890bed107f3c",
+			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_arm64.deb",
+			"version": "1.1.1w-0+deb11u1"
+		}
+	],
+	"version": 1
 }

--- a/examples/ubuntu_snapshot/BUILD.bazel
+++ b/examples/ubuntu_snapshot/BUILD.bazel
@@ -111,8 +111,10 @@ container_structure_test(
         "@platforms//cpu:x86_64": ["test_linux_amd64.yaml"],
     }),
     image = ":noble",
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
+    target_compatible_with = select({
+        "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],
+        "@platforms//cpu:arm64": ["@platforms//cpu:arm64"],
+    }) + [
         "@platforms//os:linux",
     ],
 )

--- a/examples/ubuntu_snapshot/noble.lock.json
+++ b/examples/ubuntu_snapshot/noble.lock.json
@@ -1,1463 +1,1813 @@
 {
-  "packages": [
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "ncurses-base_6.4-p-20240113-1ubuntu1_amd64",
-      "name": "ncurses-base",
-      "sha256": "1ea2be0cadf1299e5ed2967269c01e1935ddf5a733a496893b4334994aea2755",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/ncurses-base_6.4+20240113-1ubuntu1_all.deb",
-      "version": "6.4+20240113-1ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "libc6_2.39-0ubuntu2_amd64",
-          "name": "libc6",
-          "version": "2.39-0ubuntu2"
-        },
-        {
-          "key": "libgcc-s1_14-20240221-2.1ubuntu1_amd64",
-          "name": "libgcc-s1",
-          "version": "14-20240221-2.1ubuntu1"
-        },
-        {
-          "key": "gcc-14-base_14-20240221-2.1ubuntu1_amd64",
-          "name": "gcc-14-base",
-          "version": "14-20240221-2.1ubuntu1"
-        },
-        {
-          "key": "libtinfo6_6.4-p-20240113-1ubuntu1_amd64",
-          "name": "libtinfo6",
-          "version": "6.4+20240113-1ubuntu1"
-        }
-      ],
-      "key": "libncurses6_6.4-p-20240113-1ubuntu1_amd64",
-      "name": "libncurses6",
-      "sha256": "b5669082396328597c62e51caeb2ee258015e92bd87f6670acee9f396a30b978",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/libncurses6_6.4+20240113-1ubuntu1_amd64.deb",
-      "version": "6.4+20240113-1ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libc6_2.39-0ubuntu2_amd64",
-      "name": "libc6",
-      "sha256": "4bd128b75db38b7e9147c0333908e2c7fbc41631f284360f95118fe1c6c162f3",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/glibc/libc6_2.39-0ubuntu2_amd64.deb",
-      "version": "2.39-0ubuntu2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgcc-s1_14-20240221-2.1ubuntu1_amd64",
-      "name": "libgcc-s1",
-      "sha256": "ffc195df7e897aaec468e8f62b08660cc711c7449113102491fdd6baa6901f6d",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/libgcc-s1_14-20240221-2.1ubuntu1_amd64.deb",
-      "version": "14-20240221-2.1ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "gcc-14-base_14-20240221-2.1ubuntu1_amd64",
-      "name": "gcc-14-base",
-      "sha256": "2e1ae2c2ccf2d1b6d09c657af1492a8b7a348e899f9ad25d4925b170571a0887",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/gcc-14-base_14-20240221-2.1ubuntu1_amd64.deb",
-      "version": "14-20240221-2.1ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libtinfo6_6.4-p-20240113-1ubuntu1_amd64",
-      "name": "libtinfo6",
-      "sha256": "80378382ba4f672f8d5579cb953fc43edfe246eb96ee4d453af1ac3d7768c8aa",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/libtinfo6_6.4+20240113-1ubuntu1_amd64.deb",
-      "version": "6.4+20240113-1ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "tzdata_2024a-1ubuntu1_amd64",
-      "name": "tzdata",
-      "sha256": "26cdb43f541d5b7d089d2c1cf7d50b4c5e630c79a6d4d6ce34e20dcace4f0d29",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/t/tzdata/tzdata_2024a-1ubuntu1_all.deb",
-      "version": "2024a-1ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "debianutils_5.16_amd64",
-          "name": "debianutils",
-          "version": "5.16"
-        },
-        {
-          "key": "base-files_13ubuntu7_amd64",
-          "name": "base-files",
-          "version": "13ubuntu7"
-        },
-        {
-          "key": "libcrypt1_1-4.4.36-4_amd64",
-          "name": "libcrypt1",
-          "version": "1:4.4.36-4"
-        }
-      ],
-      "key": "bash_5.2.21-2ubuntu2_amd64",
-      "name": "bash",
-      "sha256": "ad21b2dbc6991a08c62e519d920a326f23f3ee2a0ac91c6c448978595d5ae685",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/bash/bash_5.2.21-2ubuntu2_amd64.deb",
-      "version": "5.2.21-2ubuntu2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "debianutils_5.16_amd64",
-      "name": "debianutils",
-      "sha256": "b1c3597e81831cf3d37cf84f06afaf05d90a55d717f643cead55fe4b223cc04a",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/debianutils/debianutils_5.16_amd64.deb",
-      "version": "5.16"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "base-files_13ubuntu7_amd64",
-      "name": "base-files",
-      "sha256": "d2fe9680dea0b8f6d6d675eceaf2bf00da8d1b3da1604f0e3b47ee26866feadd",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/base-files/base-files_13ubuntu7_amd64.deb",
-      "version": "13ubuntu7"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libcrypt1_1-4.4.36-4_amd64",
-      "name": "libcrypt1",
-      "sha256": "51ad101808e6a9d6b9c21bcf0b6f27c8ab34f6af53184fc6305f96770cc3a8d9",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libx/libxcrypt/libcrypt1_4.4.36-4_amd64.deb",
-      "version": "1:4.4.36-4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "libssl3_3.0.10-1ubuntu4_amd64",
-          "name": "libssl3",
-          "version": "3.0.10-1ubuntu4"
-        },
-        {
-          "key": "libselinux1_3.5-2build1_amd64",
-          "name": "libselinux1",
-          "version": "3.5-2build1"
-        },
-        {
-          "key": "libpcre2-8-0_10.42-4ubuntu1_amd64",
-          "name": "libpcre2-8-0",
-          "version": "10.42-4ubuntu1"
-        },
-        {
-          "key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu4_amd64",
-          "name": "libgmp10",
-          "version": "2:6.3.0+dfsg-2ubuntu4"
-        },
-        {
-          "key": "libattr1_1-2.5.2-1_amd64",
-          "name": "libattr1",
-          "version": "1:2.5.2-1"
-        },
-        {
-          "key": "libacl1_2.3.2-1_amd64",
-          "name": "libacl1",
-          "version": "2.3.2-1"
-        }
-      ],
-      "key": "coreutils_9.4-2ubuntu4_amd64",
-      "name": "coreutils",
-      "sha256": "12f958744332b290cb5d577cb5304c09f5fceddc776a2ea29329c1cca2628567",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/c/coreutils/coreutils_9.4-2ubuntu4_amd64.deb",
-      "version": "9.4-2ubuntu4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libssl3_3.0.10-1ubuntu4_amd64",
-      "name": "libssl3",
-      "sha256": "8228c52b80fc7c39619b4d2246a0fd9beb838272c848fc9718062af7102324a6",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/o/openssl/libssl3_3.0.10-1ubuntu4_amd64.deb",
-      "version": "3.0.10-1ubuntu4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libselinux1_3.5-2build1_amd64",
-      "name": "libselinux1",
-      "sha256": "139f29430e3d265fc8d9b9da7dd3f704ee3f1838c37a5d512cf265ec0b4eba28",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libselinux/libselinux1_3.5-2build1_amd64.deb",
-      "version": "3.5-2build1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libpcre2-8-0_10.42-4ubuntu1_amd64",
-      "name": "libpcre2-8-0",
-      "sha256": "3fbf30adf862c4e510a9260c7666a1a5326bc5fed8021090bc75a4ecbaa52fa4",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/pcre2/libpcre2-8-0_10.42-4ubuntu1_amd64.deb",
-      "version": "10.42-4ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu4_amd64",
-      "name": "libgmp10",
-      "sha256": "b0ede0faa0154c946ad5602e0d613b3266ff6ade089b0e939f23ad6e43964872",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2ubuntu4_amd64.deb",
-      "version": "2:6.3.0+dfsg-2ubuntu4"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libattr1_1-2.5.2-1_amd64",
-      "name": "libattr1",
-      "sha256": "38dbd3d90e88529f6f6e97f5564f333e38db8d20a704c7e8f484ed8705767382",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/attr/libattr1_2.5.2-1_amd64.deb",
-      "version": "1:2.5.2-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libacl1_2.3.2-1_amd64",
-      "name": "libacl1",
-      "sha256": "275cc58e50e49b8226f1ca705ac79bea3997b6e15b59e76cd2ade7d753a9298f",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/acl/libacl1_2.3.2-1_amd64.deb",
-      "version": "2.3.2-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "tar_1.35-p-dfsg-3_amd64",
-          "name": "tar",
-          "version": "1.35+dfsg-3"
-        },
-        {
-          "key": "zlib1g_1-1.3.dfsg-3ubuntu1_amd64",
-          "name": "zlib1g",
-          "version": "1:1.3.dfsg-3ubuntu1"
-        },
-        {
-          "key": "libzstd1_1.5.5-p-dfsg2-2_amd64",
-          "name": "libzstd1",
-          "version": "1.5.5+dfsg2-2"
-        },
-        {
-          "key": "libmd0_1.1.0-2_amd64",
-          "name": "libmd0",
-          "version": "1.1.0-2"
-        },
-        {
-          "key": "liblzma5_5.4.5-0.3_amd64",
-          "name": "liblzma5",
-          "version": "5.4.5-0.3"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-5ubuntu1_amd64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-5ubuntu1"
-        }
-      ],
-      "key": "dpkg_1.22.4ubuntu5_amd64",
-      "name": "dpkg",
-      "sha256": "15b3fa045cb0ab82682aa581219d24a6dd7e74dd0dd5c03b35a5278eab1ec2fa",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/dpkg/dpkg_1.22.4ubuntu5_amd64.deb",
-      "version": "1.22.4ubuntu5"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "tar_1.35-p-dfsg-3_amd64",
-      "name": "tar",
-      "sha256": "2fa676173c0076f59e423bd82d2ac00eba7c51fa1ae8903f09b88270b1c560ba",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/t/tar/tar_1.35+dfsg-3_amd64.deb",
-      "version": "1.35+dfsg-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "zlib1g_1-1.3.dfsg-3ubuntu1_amd64",
-      "name": "zlib1g",
-      "sha256": "35cfe44912765862374112e83c178c095448f247785772147c42c0c843b67c97",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3ubuntu1_amd64.deb",
-      "version": "1:1.3.dfsg-3ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libzstd1_1.5.5-p-dfsg2-2_amd64",
-      "name": "libzstd1",
-      "sha256": "7926bb8267652dd7df2c78c5e7541df6e62dbc10ed2efd4c2b869c75538b2ff1",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libz/libzstd/libzstd1_1.5.5+dfsg2-2_amd64.deb",
-      "version": "1.5.5+dfsg2-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libmd0_1.1.0-2_amd64",
-      "name": "libmd0",
-      "sha256": "128be9909c4ce8f2126e5f3d1a04fc11510c519409d64d324d724aae8347cd13",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libm/libmd/libmd0_1.1.0-2_amd64.deb",
-      "version": "1.1.0-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "liblzma5_5.4.5-0.3_amd64",
-      "name": "liblzma5",
-      "sha256": "02bb3148ccfa7408b3f12833aa483c2dd4e3a6ee647fe8bbc3bc60ef50761ead",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_amd64.deb",
-      "version": "5.4.5-0.3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libbz2-1.0_1.0.8-5ubuntu1_amd64",
-      "name": "libbz2-1.0",
-      "sha256": "8925b88fac7e8162a5c9dfcb078bb33932cb8aee51bb33db209ca97840f65369",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-5ubuntu1_amd64.deb",
-      "version": "1.0.8-5ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "libsystemd0_255.2-3ubuntu2_amd64",
-          "name": "libsystemd0",
-          "version": "255.2-3ubuntu2"
-        },
-        {
-          "key": "liblz4-1_1.9.4-1_amd64",
-          "name": "liblz4-1",
-          "version": "1.9.4-1"
-        },
-        {
-          "key": "libgcrypt20_1.10.3-2_amd64",
-          "name": "libgcrypt20",
-          "version": "1.10.3-2"
-        },
-        {
-          "key": "libgpg-error0_1.47-3build1_amd64",
-          "name": "libgpg-error0",
-          "version": "1.47-3build1"
-        },
-        {
-          "key": "libcap2_1-2.66-5ubuntu1_amd64",
-          "name": "libcap2",
-          "version": "1:2.66-5ubuntu1"
-        },
-        {
-          "key": "libstdc-p--p-6_14-20240221-2.1ubuntu1_amd64",
-          "name": "libstdc++6",
-          "version": "14-20240221-2.1ubuntu1"
-        },
-        {
-          "key": "libseccomp2_2.5.5-1ubuntu1_amd64",
-          "name": "libseccomp2",
-          "version": "2.5.5-1ubuntu1"
-        },
-        {
-          "key": "libgnutls30_3.8.3-1ubuntu1_amd64",
-          "name": "libgnutls30",
-          "version": "3.8.3-1ubuntu1"
-        },
-        {
-          "key": "libunistring5_1.1-2_amd64",
-          "name": "libunistring5",
-          "version": "1.1-2"
-        },
-        {
-          "key": "libtasn1-6_4.19.0-3_amd64",
-          "name": "libtasn1-6",
-          "version": "4.19.0-3"
-        },
-        {
-          "key": "libp11-kit0_0.25.3-4ubuntu1_amd64",
-          "name": "libp11-kit0",
-          "version": "0.25.3-4ubuntu1"
-        },
-        {
-          "key": "libffi8_3.4.6-1_amd64",
-          "name": "libffi8",
-          "version": "3.4.6-1"
-        },
-        {
-          "key": "libnettle8_3.9.1-2_amd64",
-          "name": "libnettle8",
-          "version": "3.9.1-2"
-        },
-        {
-          "key": "libidn2-0_2.3.7-2_amd64",
-          "name": "libidn2-0",
-          "version": "2.3.7-2"
-        },
-        {
-          "key": "libhogweed6_3.9.1-2_amd64",
-          "name": "libhogweed6",
-          "version": "3.9.1-2"
-        },
-        {
-          "key": "ubuntu-keyring_2023.11.28.1_amd64",
-          "name": "ubuntu-keyring",
-          "version": "2023.11.28.1"
-        },
-        {
-          "key": "libapt-pkg6.0_2.7.12_amd64",
-          "name": "libapt-pkg6.0",
-          "version": "2.7.12"
-        },
-        {
-          "key": "libxxhash0_0.8.2-2_amd64",
-          "name": "libxxhash0",
-          "version": "0.8.2-2"
-        },
-        {
-          "key": "libudev1_255.2-3ubuntu2_amd64",
-          "name": "libudev1",
-          "version": "255.2-3ubuntu2"
-        },
-        {
-          "key": "gpgv_2.4.4-2ubuntu7_amd64",
-          "name": "gpgv",
-          "version": "2.4.4-2ubuntu7"
-        },
-        {
-          "key": "libnpth0_1.6-3build2_amd64",
-          "name": "libnpth0",
-          "version": "1.6-3build2"
-        },
-        {
-          "key": "libassuan0_2.5.6-1_amd64",
-          "name": "libassuan0",
-          "version": "2.5.6-1"
-        }
-      ],
-      "key": "apt_2.7.12_amd64",
-      "name": "apt",
-      "sha256": "ffde38ea5a2d42045732a83633737741259cc517a8c52e3c2776b0b4ea75843d",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/apt/apt_2.7.12_amd64.deb",
-      "version": "2.7.12"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libsystemd0_255.2-3ubuntu2_amd64",
-      "name": "libsystemd0",
-      "sha256": "2b795ada9003c3d43fea41ede816fe9ffeac9e283c2cdc627ea41a123b110f4f",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/s/systemd/libsystemd0_255.2-3ubuntu2_amd64.deb",
-      "version": "255.2-3ubuntu2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "liblz4-1_1.9.4-1_amd64",
-      "name": "liblz4-1",
-      "sha256": "8c2ac2844f58875ebd1c78cc397ef3889d58050b40299f5dc267d7a77957dc48",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/l/lz4/liblz4-1_1.9.4-1_amd64.deb",
-      "version": "1.9.4-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgcrypt20_1.10.3-2_amd64",
-      "name": "libgcrypt20",
-      "sha256": "ad2547e30a16c475e1eb4ac6ba77d06a261fdeb5af4407c4b1655ce1ad38dff4",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_amd64.deb",
-      "version": "1.10.3-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgpg-error0_1.47-3build1_amd64",
-      "name": "libgpg-error0",
-      "sha256": "2d033b832a3b537538c9bd13c35ecafc7b78aa8c4d7b28859e65d1a6528e2d92",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libg/libgpg-error/libgpg-error0_1.47-3build1_amd64.deb",
-      "version": "1.47-3build1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libcap2_1-2.66-5ubuntu1_amd64",
-      "name": "libcap2",
-      "sha256": "ac02d261cf8fe7be4cef3e43ff67906da85de4e359ed5c4199b707bdeff0ab62",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libc/libcap2/libcap2_2.66-5ubuntu1_amd64.deb",
-      "version": "1:2.66-5ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libstdc-p--p-6_14-20240221-2.1ubuntu1_amd64",
-      "name": "libstdc++6",
-      "sha256": "3311c13f2e26c20369e937051c78f07c495f6112a0d6c32d3285b47021457ec2",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/libstdc++6_14-20240221-2.1ubuntu1_amd64.deb",
-      "version": "14-20240221-2.1ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libseccomp2_2.5.5-1ubuntu1_amd64",
-      "name": "libseccomp2",
-      "sha256": "23b58d5dbae7f6875955a61afd782aade21869015a2a710bf3deef6894a691fb",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libseccomp/libseccomp2_2.5.5-1ubuntu1_amd64.deb",
-      "version": "2.5.5-1ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgnutls30_3.8.3-1ubuntu1_amd64",
-      "name": "libgnutls30",
-      "sha256": "9638b9847ba94bbf3a81ddd491911aa29e6c8eb2cd9f998b38f4599fbbf76c99",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gnutls28/libgnutls30_3.8.3-1ubuntu1_amd64.deb",
-      "version": "3.8.3-1ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libunistring5_1.1-2_amd64",
-      "name": "libunistring5",
-      "sha256": "cbdbbbf7552e953e3b58c512eb99891fa3ea8b2847a1a8194c5fb9abdb7066b5",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libu/libunistring/libunistring5_1.1-2_amd64.deb",
-      "version": "1.1-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libtasn1-6_4.19.0-3_amd64",
-      "name": "libtasn1-6",
-      "sha256": "84f16110976e40a7aaa11eb0a291bd85f4002fb8b87f6355ff2f8340d9cf4a62",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0-3_amd64.deb",
-      "version": "4.19.0-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libp11-kit0_0.25.3-4ubuntu1_amd64",
-      "name": "libp11-kit0",
-      "sha256": "55e257759c223816b23af975d792519c738db9b0e0687c071429db74e1912aa3",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/p11-kit/libp11-kit0_0.25.3-4ubuntu1_amd64.deb",
-      "version": "0.25.3-4ubuntu1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libffi8_3.4.6-1_amd64",
-      "name": "libffi8",
-      "sha256": "bd30f638a82381979c4c07b3acabb7fccaeed7f9b094e27c9a676d2e94572b14",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libf/libffi/libffi8_3.4.6-1_amd64.deb",
-      "version": "3.4.6-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnettle8_3.9.1-2_amd64",
-      "name": "libnettle8",
-      "sha256": "c38dd77f817639a2d524956a391393f7d3cdca38724e92ed6d04768fa0a282e9",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/nettle/libnettle8_3.9.1-2_amd64.deb",
-      "version": "3.9.1-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libidn2-0_2.3.7-2_amd64",
-      "name": "libidn2-0",
-      "sha256": "6a00f2cbdfd1e628556bcbc4c1edab07066f6c47f4e75657d8e8b6900704312c",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libi/libidn2/libidn2-0_2.3.7-2_amd64.deb",
-      "version": "2.3.7-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libhogweed6_3.9.1-2_amd64",
-      "name": "libhogweed6",
-      "sha256": "9644344e343eea3d82f35c4d70e33cfc9b36e139f109a78aaf7a6feb9a3126f2",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/nettle/libhogweed6_3.9.1-2_amd64.deb",
-      "version": "3.9.1-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "ubuntu-keyring_2023.11.28.1_amd64",
-      "name": "ubuntu-keyring",
-      "sha256": "36de43b15853ccae0028e9a767613770c704833f82586f28eb262f0311adb8a8",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/u/ubuntu-keyring/ubuntu-keyring_2023.11.28.1_all.deb",
-      "version": "2023.11.28.1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libapt-pkg6.0_2.7.12_amd64",
-      "name": "libapt-pkg6.0",
-      "sha256": "6eafb79a865ba21b3e33fc9e49e6c3d09e336dd403d87647bcbe0cd3a614871a",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/apt/libapt-pkg6.0_2.7.12_amd64.deb",
-      "version": "2.7.12"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libxxhash0_0.8.2-2_amd64",
-      "name": "libxxhash0",
-      "sha256": "fbee58694f740de786455ceb5b34550c3ceb067df59fddf0e9d7d713528eb9cb",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/x/xxhash/libxxhash0_0.8.2-2_amd64.deb",
-      "version": "0.8.2-2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libudev1_255.2-3ubuntu2_amd64",
-      "name": "libudev1",
-      "sha256": "c84b059e2c070796cd0a92f5645801a12be726860b4f52153bede2819bbaa980",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/s/systemd/libudev1_255.2-3ubuntu2_amd64.deb",
-      "version": "255.2-3ubuntu2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "gpgv_2.4.4-2ubuntu7_amd64",
-      "name": "gpgv",
-      "sha256": "5e34a3132f9ecff5276e2d443f85f1fbfc8fe8aa3964dc6bd089123b137676e0",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gnupg2/gpgv_2.4.4-2ubuntu7_amd64.deb",
-      "version": "2.4.4-2ubuntu7"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libnpth0_1.6-3build2_amd64",
-      "name": "libnpth0",
-      "sha256": "e6e05ed1c4ccfbdc4ca3af2696dadbd0313b5287221ecafa306911da6fbbf89a",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/npth/libnpth0_1.6-3build2_amd64.deb",
-      "version": "1.6-3build2"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libassuan0_2.5.6-1_amd64",
-      "name": "libassuan0",
-      "sha256": "c976b785f81b23888bc39a16f9f3cfaf031536ff23f0b6fb24d4812019f20138",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/liba/libassuan/libassuan0_2.5.6-1_amd64.deb",
-      "version": "2.5.6-1"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [
-        {
-          "key": "libperl5.38_5.38.2-3_amd64",
-          "name": "libperl5.38",
-          "version": "5.38.2-3"
-        },
-        {
-          "key": "perl-modules-5.38_5.38.2-3_amd64",
-          "name": "perl-modules-5.38",
-          "version": "5.38.2-3"
-        },
-        {
-          "key": "perl-base_5.38.2-3_amd64",
-          "name": "perl-base",
-          "version": "5.38.2-3"
-        },
-        {
-          "key": "libgdbm6_1.23-5_amd64",
-          "name": "libgdbm6",
-          "version": "1.23-5"
-        },
-        {
-          "key": "libgdbm-compat4_1.23-5_amd64",
-          "name": "libgdbm-compat4",
-          "version": "1.23-5"
-        },
-        {
-          "key": "libdb5.3_5.3.28-p-dfsg2-4_amd64",
-          "name": "libdb5.3",
-          "version": "5.3.28+dfsg2-4"
-        }
-      ],
-      "key": "perl_5.38.2-3_amd64",
-      "name": "perl",
-      "sha256": "af6657fcbd23694120410423ad59bdf8d0ad5139e5e80cc10599b1a44706fdf6",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl_5.38.2-3_amd64.deb",
-      "version": "5.38.2-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libperl5.38_5.38.2-3_amd64",
-      "name": "libperl5.38",
-      "sha256": "62a161cb99621bb3e69b51bd1ff00ff4ad77cbd357d525182830571d52656cf3",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/libperl5.38_5.38.2-3_amd64.deb",
-      "version": "5.38.2-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "perl-modules-5.38_5.38.2-3_amd64",
-      "name": "perl-modules-5.38",
-      "sha256": "127dd76635d1d3d135caa5bbc4d5ae96a1c88a36c21313602c4c416270040849",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl-modules-5.38_5.38.2-3_all.deb",
-      "version": "5.38.2-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "perl-base_5.38.2-3_amd64",
-      "name": "perl-base",
-      "sha256": "bd0c5e1b72bdc400005330094101d83628604af5b132df4ea4132eb58e349aa0",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl-base_5.38.2-3_amd64.deb",
-      "version": "5.38.2-3"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgdbm6_1.23-5_amd64",
-      "name": "libgdbm6",
-      "sha256": "c3f20aaeeb16d33907b08bd5ca8d179e3d03cfd90d48a631954011179e19225a",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gdbm/libgdbm6_1.23-5_amd64.deb",
-      "version": "1.23-5"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libgdbm-compat4_1.23-5_amd64",
-      "name": "libgdbm-compat4",
-      "sha256": "788b045f2ed29aad67e3e4dec448c71ec12c1e5f653a1b36422b3fb2082409dc",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gdbm/libgdbm-compat4_1.23-5_amd64.deb",
-      "version": "1.23-5"
-    },
-    {
-      "arch": "amd64",
-      "dependencies": [],
-      "key": "libdb5.3_5.3.28-p-dfsg2-4_amd64",
-      "name": "libdb5.3",
-      "sha256": "439d822a4d19edb3ea466b3ad085d1783d2319611061090df4bef2c562bc625e",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg2-4_amd64.deb",
-      "version": "5.3.28+dfsg2-4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "ncurses-base_6.4-p-20240113-1ubuntu1_arm64",
-      "name": "ncurses-base",
-      "sha256": "1ea2be0cadf1299e5ed2967269c01e1935ddf5a733a496893b4334994aea2755",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/ncurses-base_6.4+20240113-1ubuntu1_all.deb",
-      "version": "6.4+20240113-1ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "libc6_2.39-0ubuntu2_arm64",
-          "name": "libc6",
-          "version": "2.39-0ubuntu2"
-        },
-        {
-          "key": "libgcc-s1_14-20240221-2.1ubuntu1_arm64",
-          "name": "libgcc-s1",
-          "version": "14-20240221-2.1ubuntu1"
-        },
-        {
-          "key": "gcc-14-base_14-20240221-2.1ubuntu1_arm64",
-          "name": "gcc-14-base",
-          "version": "14-20240221-2.1ubuntu1"
-        },
-        {
-          "key": "libtinfo6_6.4-p-20240113-1ubuntu1_arm64",
-          "name": "libtinfo6",
-          "version": "6.4+20240113-1ubuntu1"
-        }
-      ],
-      "key": "libncurses6_6.4-p-20240113-1ubuntu1_arm64",
-      "name": "libncurses6",
-      "sha256": "5cb643f9a938f783a72b85c2c102b977e7e2d137c0d3564ff1df6652de89296f",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/libncurses6_6.4+20240113-1ubuntu1_arm64.deb",
-      "version": "6.4+20240113-1ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libc6_2.39-0ubuntu2_arm64",
-      "name": "libc6",
-      "sha256": "522238223618b52aae530256dfaea19e746649c382983d99c9e79d1f7e6afeef",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/glibc/libc6_2.39-0ubuntu2_arm64.deb",
-      "version": "2.39-0ubuntu2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgcc-s1_14-20240221-2.1ubuntu1_arm64",
-      "name": "libgcc-s1",
-      "sha256": "d3aec36dbcea7dcf910f7ece43d3e31260bb0cd0a2b58808efaa999af1798511",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/libgcc-s1_14-20240221-2.1ubuntu1_arm64.deb",
-      "version": "14-20240221-2.1ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "gcc-14-base_14-20240221-2.1ubuntu1_arm64",
-      "name": "gcc-14-base",
-      "sha256": "9886cc5eec6df002429338e26ce1670ada931f9b91fe147eee483ae11cc9cdda",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/gcc-14-base_14-20240221-2.1ubuntu1_arm64.deb",
-      "version": "14-20240221-2.1ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libtinfo6_6.4-p-20240113-1ubuntu1_arm64",
-      "name": "libtinfo6",
-      "sha256": "4a190c05ea7e919e4e796e1321f7923158048e1bdc58c71c11692628f6064bcb",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/libtinfo6_6.4+20240113-1ubuntu1_arm64.deb",
-      "version": "6.4+20240113-1ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "tzdata_2024a-1ubuntu1_arm64",
-      "name": "tzdata",
-      "sha256": "26cdb43f541d5b7d089d2c1cf7d50b4c5e630c79a6d4d6ce34e20dcace4f0d29",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/t/tzdata/tzdata_2024a-1ubuntu1_all.deb",
-      "version": "2024a-1ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "debianutils_5.16_arm64",
-          "name": "debianutils",
-          "version": "5.16"
-        },
-        {
-          "key": "base-files_13ubuntu7_arm64",
-          "name": "base-files",
-          "version": "13ubuntu7"
-        },
-        {
-          "key": "libcrypt1_1-4.4.36-4_arm64",
-          "name": "libcrypt1",
-          "version": "1:4.4.36-4"
-        }
-      ],
-      "key": "bash_5.2.21-2ubuntu2_arm64",
-      "name": "bash",
-      "sha256": "f6e49a0e27e9f73a10a95cfce04f5449834cf5c2f0f12caffa273297385a0f46",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/bash/bash_5.2.21-2ubuntu2_arm64.deb",
-      "version": "5.2.21-2ubuntu2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "debianutils_5.16_arm64",
-      "name": "debianutils",
-      "sha256": "59efa8456b8f2dd76860ba306dbc397673170d9dfa969f58fba8891329a7d5b5",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/debianutils/debianutils_5.16_arm64.deb",
-      "version": "5.16"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "base-files_13ubuntu7_arm64",
-      "name": "base-files",
-      "sha256": "fca1f68e39dca654190f4a3bd4879659f90781d3d509c3882db0e75c1ce2ebc6",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/base-files/base-files_13ubuntu7_arm64.deb",
-      "version": "13ubuntu7"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libcrypt1_1-4.4.36-4_arm64",
-      "name": "libcrypt1",
-      "sha256": "3dd680dd15a31e7a023f47008b99b1aceed3104a01afacb775fa888a8fdb9f90",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libx/libxcrypt/libcrypt1_4.4.36-4_arm64.deb",
-      "version": "1:4.4.36-4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "libselinux1_3.5-2build1_arm64",
-          "name": "libselinux1",
-          "version": "3.5-2build1"
-        },
-        {
-          "key": "libpcre2-8-0_10.42-4ubuntu1_arm64",
-          "name": "libpcre2-8-0",
-          "version": "10.42-4ubuntu1"
-        },
-        {
-          "key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu4_arm64",
-          "name": "libgmp10",
-          "version": "2:6.3.0+dfsg-2ubuntu4"
-        },
-        {
-          "key": "libattr1_1-2.5.2-1_arm64",
-          "name": "libattr1",
-          "version": "1:2.5.2-1"
-        },
-        {
-          "key": "libacl1_2.3.2-1_arm64",
-          "name": "libacl1",
-          "version": "2.3.2-1"
-        }
-      ],
-      "key": "coreutils_9.4-2ubuntu4_arm64",
-      "name": "coreutils",
-      "sha256": "a73b6f3b14c2578c12ba8ed8c7e55df8b94aa60088713b85ecaa56149f704788",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/c/coreutils/coreutils_9.4-2ubuntu4_arm64.deb",
-      "version": "9.4-2ubuntu4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libselinux1_3.5-2build1_arm64",
-      "name": "libselinux1",
-      "sha256": "9d22b9775025031775c8cf77568b427e7f7bff49d097b5c9885657edfaf71193",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libselinux/libselinux1_3.5-2build1_arm64.deb",
-      "version": "3.5-2build1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libpcre2-8-0_10.42-4ubuntu1_arm64",
-      "name": "libpcre2-8-0",
-      "sha256": "14214893ef06c573ad2e6d99ab6cebbaf26c204818cf898ea7abc8b0339f1791",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/pcre2/libpcre2-8-0_10.42-4ubuntu1_arm64.deb",
-      "version": "10.42-4ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu4_arm64",
-      "name": "libgmp10",
-      "sha256": "8f35d6d5564801218d19c864361726bf9ba8a171896e1c183dd7ecb70973592b",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2ubuntu4_arm64.deb",
-      "version": "2:6.3.0+dfsg-2ubuntu4"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libattr1_1-2.5.2-1_arm64",
-      "name": "libattr1",
-      "sha256": "0cfd6967c0ca25b16db868d819f47ffcca5d43aa22e3227c7be08626dc73d7cb",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/attr/libattr1_2.5.2-1_arm64.deb",
-      "version": "1:2.5.2-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libacl1_2.3.2-1_arm64",
-      "name": "libacl1",
-      "sha256": "1e683ce20074199ed9dd9c4ffdbb5bf30f5e494d9c9452512f8709a9fbe76562",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/acl/libacl1_2.3.2-1_arm64.deb",
-      "version": "2.3.2-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "tar_1.35-p-dfsg-3_arm64",
-          "name": "tar",
-          "version": "1.35+dfsg-3"
-        },
-        {
-          "key": "zlib1g_1-1.3.dfsg-3ubuntu1_arm64",
-          "name": "zlib1g",
-          "version": "1:1.3.dfsg-3ubuntu1"
-        },
-        {
-          "key": "libzstd1_1.5.5-p-dfsg2-2_arm64",
-          "name": "libzstd1",
-          "version": "1.5.5+dfsg2-2"
-        },
-        {
-          "key": "libmd0_1.1.0-2_arm64",
-          "name": "libmd0",
-          "version": "1.1.0-2"
-        },
-        {
-          "key": "liblzma5_5.4.5-0.3_arm64",
-          "name": "liblzma5",
-          "version": "5.4.5-0.3"
-        },
-        {
-          "key": "libbz2-1.0_1.0.8-5ubuntu1_arm64",
-          "name": "libbz2-1.0",
-          "version": "1.0.8-5ubuntu1"
-        }
-      ],
-      "key": "dpkg_1.22.4ubuntu5_arm64",
-      "name": "dpkg",
-      "sha256": "352d489b2b457728a2cfd253172080729ce3ac635bc8cf9809acb9c92e2dd149",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/dpkg/dpkg_1.22.4ubuntu5_arm64.deb",
-      "version": "1.22.4ubuntu5"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "tar_1.35-p-dfsg-3_arm64",
-      "name": "tar",
-      "sha256": "15ed5677151c6f224799e82f90515c77e744a68d99d2ea3d8bf2877e9effd575",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/t/tar/tar_1.35+dfsg-3_arm64.deb",
-      "version": "1.35+dfsg-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "zlib1g_1-1.3.dfsg-3ubuntu1_arm64",
-      "name": "zlib1g",
-      "sha256": "bb947ff78e0aee7477aeea1bc82a5db2e80f5b1322f460ecc06710200a16326f",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3ubuntu1_arm64.deb",
-      "version": "1:1.3.dfsg-3ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libzstd1_1.5.5-p-dfsg2-2_arm64",
-      "name": "libzstd1",
-      "sha256": "a6c2bcacff770685b3ef262943bbb3ce2060b9de83e1698590f5b576d5e7827e",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libz/libzstd/libzstd1_1.5.5+dfsg2-2_arm64.deb",
-      "version": "1.5.5+dfsg2-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libmd0_1.1.0-2_arm64",
-      "name": "libmd0",
-      "sha256": "884597eb942118b246a79e68aa619e3b6d22125e5cd7948557b542b6e70bdb54",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libm/libmd/libmd0_1.1.0-2_arm64.deb",
-      "version": "1.1.0-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "liblzma5_5.4.5-0.3_arm64",
-      "name": "liblzma5",
-      "sha256": "d0e936978175a45bb317a5ca17c29f0d610126e21f5ce6900f107244a6e333b6",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_arm64.deb",
-      "version": "5.4.5-0.3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libbz2-1.0_1.0.8-5ubuntu1_arm64",
-      "name": "libbz2-1.0",
-      "sha256": "0c479f94c97d2ab5641bf7b967d37daad61c5e8c4ea998ebd710d2125d4eb027",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-5ubuntu1_arm64.deb",
-      "version": "1.0.8-5ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "libsystemd0_255.2-3ubuntu2_arm64",
-          "name": "libsystemd0",
-          "version": "255.2-3ubuntu2"
-        },
-        {
-          "key": "liblz4-1_1.9.4-1_arm64",
-          "name": "liblz4-1",
-          "version": "1.9.4-1"
-        },
-        {
-          "key": "libgcrypt20_1.10.3-2_arm64",
-          "name": "libgcrypt20",
-          "version": "1.10.3-2"
-        },
-        {
-          "key": "libgpg-error0_1.47-3build1_arm64",
-          "name": "libgpg-error0",
-          "version": "1.47-3build1"
-        },
-        {
-          "key": "libcap2_1-2.66-5ubuntu1_arm64",
-          "name": "libcap2",
-          "version": "1:2.66-5ubuntu1"
-        },
-        {
-          "key": "libstdc-p--p-6_14-20240221-2.1ubuntu1_arm64",
-          "name": "libstdc++6",
-          "version": "14-20240221-2.1ubuntu1"
-        },
-        {
-          "key": "libseccomp2_2.5.5-1ubuntu1_arm64",
-          "name": "libseccomp2",
-          "version": "2.5.5-1ubuntu1"
-        },
-        {
-          "key": "libgnutls30_3.8.3-1ubuntu1_arm64",
-          "name": "libgnutls30",
-          "version": "3.8.3-1ubuntu1"
-        },
-        {
-          "key": "libunistring5_1.1-2_arm64",
-          "name": "libunistring5",
-          "version": "1.1-2"
-        },
-        {
-          "key": "libtasn1-6_4.19.0-3_arm64",
-          "name": "libtasn1-6",
-          "version": "4.19.0-3"
-        },
-        {
-          "key": "libp11-kit0_0.25.3-4ubuntu1_arm64",
-          "name": "libp11-kit0",
-          "version": "0.25.3-4ubuntu1"
-        },
-        {
-          "key": "libffi8_3.4.6-1_arm64",
-          "name": "libffi8",
-          "version": "3.4.6-1"
-        },
-        {
-          "key": "libnettle8_3.9.1-2_arm64",
-          "name": "libnettle8",
-          "version": "3.9.1-2"
-        },
-        {
-          "key": "libidn2-0_2.3.7-2_arm64",
-          "name": "libidn2-0",
-          "version": "2.3.7-2"
-        },
-        {
-          "key": "libhogweed6_3.9.1-2_arm64",
-          "name": "libhogweed6",
-          "version": "3.9.1-2"
-        },
-        {
-          "key": "ubuntu-keyring_2023.11.28.1_arm64",
-          "name": "ubuntu-keyring",
-          "version": "2023.11.28.1"
-        },
-        {
-          "key": "libapt-pkg6.0_2.7.12_arm64",
-          "name": "libapt-pkg6.0",
-          "version": "2.7.12"
-        },
-        {
-          "key": "libxxhash0_0.8.2-2_arm64",
-          "name": "libxxhash0",
-          "version": "0.8.2-2"
-        },
-        {
-          "key": "libudev1_255.2-3ubuntu2_arm64",
-          "name": "libudev1",
-          "version": "255.2-3ubuntu2"
-        },
-        {
-          "key": "gpgv_2.4.4-2ubuntu7_arm64",
-          "name": "gpgv",
-          "version": "2.4.4-2ubuntu7"
-        },
-        {
-          "key": "libnpth0_1.6-3build2_arm64",
-          "name": "libnpth0",
-          "version": "1.6-3build2"
-        },
-        {
-          "key": "libassuan0_2.5.6-1_arm64",
-          "name": "libassuan0",
-          "version": "2.5.6-1"
-        }
-      ],
-      "key": "apt_2.7.12_arm64",
-      "name": "apt",
-      "sha256": "a0f922f9133bff9b87f5887757434ab94c04efe9fb3f96ecb0a9acca845f5b28",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/apt/apt_2.7.12_arm64.deb",
-      "version": "2.7.12"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libsystemd0_255.2-3ubuntu2_arm64",
-      "name": "libsystemd0",
-      "sha256": "7cccc1271839ac53030490b84de797239db5bf53bb623a87e8762385b17136a1",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/s/systemd/libsystemd0_255.2-3ubuntu2_arm64.deb",
-      "version": "255.2-3ubuntu2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "liblz4-1_1.9.4-1_arm64",
-      "name": "liblz4-1",
-      "sha256": "3ca249f3f32308f8465b9c7447517b1e860539609e590d98b45c1878fad83c55",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/l/lz4/liblz4-1_1.9.4-1_arm64.deb",
-      "version": "1.9.4-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgcrypt20_1.10.3-2_arm64",
-      "name": "libgcrypt20",
-      "sha256": "fc9bf9dc690198d52aab5cbd325ce9b7f6ff2060cea320e35e5be741bcdbd863",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_arm64.deb",
-      "version": "1.10.3-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgpg-error0_1.47-3build1_arm64",
-      "name": "libgpg-error0",
-      "sha256": "431841c82321886700592874b5042f64908e53bb9560eff351664a9c38a22eaf",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libg/libgpg-error/libgpg-error0_1.47-3build1_arm64.deb",
-      "version": "1.47-3build1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libcap2_1-2.66-5ubuntu1_arm64",
-      "name": "libcap2",
-      "sha256": "f9e54bda3c9b38cdd95dccfaca37ba2a46220414116506f256e235307d5b7209",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libc/libcap2/libcap2_2.66-5ubuntu1_arm64.deb",
-      "version": "1:2.66-5ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libstdc-p--p-6_14-20240221-2.1ubuntu1_arm64",
-      "name": "libstdc++6",
-      "sha256": "538f5a9f9b7bfdff1e0317b6d1e21a7b6fdef8d82d07036c89716e35266a4cbf",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/libstdc++6_14-20240221-2.1ubuntu1_arm64.deb",
-      "version": "14-20240221-2.1ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libseccomp2_2.5.5-1ubuntu1_arm64",
-      "name": "libseccomp2",
-      "sha256": "b11084b3907453470014cc95d30e3217c0c655b2c4a29891a3ab27ebfeaa9674",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libseccomp/libseccomp2_2.5.5-1ubuntu1_arm64.deb",
-      "version": "2.5.5-1ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgnutls30_3.8.3-1ubuntu1_arm64",
-      "name": "libgnutls30",
-      "sha256": "5cd70f6fa56513bb91144bb3877d20315cd01ab57d1ff862762983b4dae3e9ed",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gnutls28/libgnutls30_3.8.3-1ubuntu1_arm64.deb",
-      "version": "3.8.3-1ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libunistring5_1.1-2_arm64",
-      "name": "libunistring5",
-      "sha256": "caf4c2c543f9204ff05308966440030d0878ab639ffbbbd667d160b64e1ee645",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libu/libunistring/libunistring5_1.1-2_arm64.deb",
-      "version": "1.1-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libtasn1-6_4.19.0-3_arm64",
-      "name": "libtasn1-6",
-      "sha256": "6ee67d52a802f55d419b52125796407d36a6e731f21f8f5d29101a2086d521bd",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0-3_arm64.deb",
-      "version": "4.19.0-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libp11-kit0_0.25.3-4ubuntu1_arm64",
-      "name": "libp11-kit0",
-      "sha256": "1d2e7b8b7755f3a0fccec3d5ef0248a98f17cef0e352f2ff4a2f00a8fe30561e",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/p11-kit/libp11-kit0_0.25.3-4ubuntu1_arm64.deb",
-      "version": "0.25.3-4ubuntu1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libffi8_3.4.6-1_arm64",
-      "name": "libffi8",
-      "sha256": "420c53c1715064d8dd8c04805d43e9ed422455d09185aecc77ec45295d326bcc",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libf/libffi/libffi8_3.4.6-1_arm64.deb",
-      "version": "3.4.6-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnettle8_3.9.1-2_arm64",
-      "name": "libnettle8",
-      "sha256": "0d8860e05b6d440b34edbf46e88db2bfc6298063285b3f9eab567f8aa1af7983",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/nettle/libnettle8_3.9.1-2_arm64.deb",
-      "version": "3.9.1-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libidn2-0_2.3.7-2_arm64",
-      "name": "libidn2-0",
-      "sha256": "68e9d51078a345540829cd4ae4d95912f1c3ec3aaf454984e3393081d8d92e6f",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libi/libidn2/libidn2-0_2.3.7-2_arm64.deb",
-      "version": "2.3.7-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libhogweed6_3.9.1-2_arm64",
-      "name": "libhogweed6",
-      "sha256": "6b378b847a96dd187789c02a314ea6aa02a9894f53fcbcf166b1f4a7383d596a",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/nettle/libhogweed6_3.9.1-2_arm64.deb",
-      "version": "3.9.1-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "ubuntu-keyring_2023.11.28.1_arm64",
-      "name": "ubuntu-keyring",
-      "sha256": "36de43b15853ccae0028e9a767613770c704833f82586f28eb262f0311adb8a8",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/u/ubuntu-keyring/ubuntu-keyring_2023.11.28.1_all.deb",
-      "version": "2023.11.28.1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libapt-pkg6.0_2.7.12_arm64",
-      "name": "libapt-pkg6.0",
-      "sha256": "74a6337693c313bb4b563fcf829b06b5e209827bf91ed202e5407490e0ec5d26",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/apt/libapt-pkg6.0_2.7.12_arm64.deb",
-      "version": "2.7.12"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libxxhash0_0.8.2-2_arm64",
-      "name": "libxxhash0",
-      "sha256": "24c2da6d81871201d5a1e0bf5e718314438cad697d5f445bf579c37120331896",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/x/xxhash/libxxhash0_0.8.2-2_arm64.deb",
-      "version": "0.8.2-2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libudev1_255.2-3ubuntu2_arm64",
-      "name": "libudev1",
-      "sha256": "db9af267ca5e6148c9b6328dcb98643e0e7729f208e95916042aa87f363c2078",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/s/systemd/libudev1_255.2-3ubuntu2_arm64.deb",
-      "version": "255.2-3ubuntu2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "gpgv_2.4.4-2ubuntu7_arm64",
-      "name": "gpgv",
-      "sha256": "0b536711c2b86f7f793626df517eae887c9ac4c0582f3f50966ac5fa3ac62fb5",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gnupg2/gpgv_2.4.4-2ubuntu7_arm64.deb",
-      "version": "2.4.4-2ubuntu7"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libnpth0_1.6-3build2_arm64",
-      "name": "libnpth0",
-      "sha256": "433259a1f7ef32e9dcc83c5e2c596cae5571eefd0131e3c44c52fb58f81d6b7c",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/npth/libnpth0_1.6-3build2_arm64.deb",
-      "version": "1.6-3build2"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libassuan0_2.5.6-1_arm64",
-      "name": "libassuan0",
-      "sha256": "b93a9d3e3351269fb4e612e5a4b42b14f068514be40897e484170ac82bb6d7b7",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/liba/libassuan/libassuan0_2.5.6-1_arm64.deb",
-      "version": "2.5.6-1"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [
-        {
-          "key": "libperl5.38_5.38.2-3_arm64",
-          "name": "libperl5.38",
-          "version": "5.38.2-3"
-        },
-        {
-          "key": "perl-modules-5.38_5.38.2-3_arm64",
-          "name": "perl-modules-5.38",
-          "version": "5.38.2-3"
-        },
-        {
-          "key": "perl-base_5.38.2-3_arm64",
-          "name": "perl-base",
-          "version": "5.38.2-3"
-        },
-        {
-          "key": "libgdbm6_1.23-5_arm64",
-          "name": "libgdbm6",
-          "version": "1.23-5"
-        },
-        {
-          "key": "libgdbm-compat4_1.23-5_arm64",
-          "name": "libgdbm-compat4",
-          "version": "1.23-5"
-        },
-        {
-          "key": "libdb5.3_5.3.28-p-dfsg2-4_arm64",
-          "name": "libdb5.3",
-          "version": "5.3.28+dfsg2-4"
-        }
-      ],
-      "key": "perl_5.38.2-3_arm64",
-      "name": "perl",
-      "sha256": "649812e92fd35d1cd3d8b71233a7fda8e56fb7da761376904607d8233a37cbac",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl_5.38.2-3_arm64.deb",
-      "version": "5.38.2-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libperl5.38_5.38.2-3_arm64",
-      "name": "libperl5.38",
-      "sha256": "c6256802c884974ed62e3e11bbee7c36cc0075679c5f7b6289692a7ed036476a",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/libperl5.38_5.38.2-3_arm64.deb",
-      "version": "5.38.2-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "perl-modules-5.38_5.38.2-3_arm64",
-      "name": "perl-modules-5.38",
-      "sha256": "127dd76635d1d3d135caa5bbc4d5ae96a1c88a36c21313602c4c416270040849",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl-modules-5.38_5.38.2-3_all.deb",
-      "version": "5.38.2-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "perl-base_5.38.2-3_arm64",
-      "name": "perl-base",
-      "sha256": "b502331d6d9198caec0df1230980cbb2a0ee8b08edbf1a73f776d87f2377c293",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl-base_5.38.2-3_arm64.deb",
-      "version": "5.38.2-3"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgdbm6_1.23-5_arm64",
-      "name": "libgdbm6",
-      "sha256": "ef9cecd3ce774b709a226f234eaf11b66a9a1aeae96f5d14600882192aab304a",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gdbm/libgdbm6_1.23-5_arm64.deb",
-      "version": "1.23-5"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libgdbm-compat4_1.23-5_arm64",
-      "name": "libgdbm-compat4",
-      "sha256": "eb0ada72e019ce958cc01c09419a61215f6c9ffb468eed59944dce21060f6354",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gdbm/libgdbm-compat4_1.23-5_arm64.deb",
-      "version": "1.23-5"
-    },
-    {
-      "arch": "arm64",
-      "dependencies": [],
-      "key": "libdb5.3_5.3.28-p-dfsg2-4_arm64",
-      "name": "libdb5.3",
-      "sha256": "522c7f6719d3e950eb6e7809af4c072a137c2c29927a0167745a997582ea7cde",
-      "url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg2-4_arm64.deb",
-      "version": "5.3.28+dfsg2-4"
-    }
-  ],
-  "version": 1
+	"packages": [
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "ncurses-base_6.4-p-20240113-1ubuntu1_amd64",
+			"name": "ncurses-base",
+			"sha256": "1ea2be0cadf1299e5ed2967269c01e1935ddf5a733a496893b4334994aea2755",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/ncurses-base_6.4+20240113-1ubuntu1_all.deb",
+			"version": "6.4+20240113-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libc6_2.39-0ubuntu2_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_amd64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu1_amd64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu1"
+				}
+			],
+			"key": "libncurses6_6.4-p-20240113-1ubuntu1_amd64",
+			"name": "libncurses6",
+			"sha256": "b5669082396328597c62e51caeb2ee258015e92bd87f6670acee9f396a30b978",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/libncurses6_6.4+20240113-1ubuntu1_amd64.deb",
+			"version": "6.4+20240113-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libc6_2.39-0ubuntu2_amd64",
+			"name": "libc6",
+			"sha256": "4bd128b75db38b7e9147c0333908e2c7fbc41631f284360f95118fe1c6c162f3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/glibc/libc6_2.39-0ubuntu2_amd64.deb",
+			"version": "2.39-0ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcc-s1_14-20240221-2.1ubuntu1_amd64",
+			"name": "libgcc-s1",
+			"sha256": "ffc195df7e897aaec468e8f62b08660cc711c7449113102491fdd6baa6901f6d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/libgcc-s1_14-20240221-2.1ubuntu1_amd64.deb",
+			"version": "14-20240221-2.1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gcc-14-base_14-20240221-2.1ubuntu1_amd64",
+			"name": "gcc-14-base",
+			"sha256": "2e1ae2c2ccf2d1b6d09c657af1492a8b7a348e899f9ad25d4925b170571a0887",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/gcc-14-base_14-20240221-2.1ubuntu1_amd64.deb",
+			"version": "14-20240221-2.1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtinfo6_6.4-p-20240113-1ubuntu1_amd64",
+			"name": "libtinfo6",
+			"sha256": "80378382ba4f672f8d5579cb953fc43edfe246eb96ee4d453af1ac3d7768c8aa",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/libtinfo6_6.4+20240113-1ubuntu1_amd64.deb",
+			"version": "6.4+20240113-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tzdata_2024a-1ubuntu1_amd64",
+			"name": "tzdata",
+			"sha256": "26cdb43f541d5b7d089d2c1cf7d50b4c5e630c79a6d4d6ce34e20dcace4f0d29",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/t/tzdata/tzdata_2024a-1ubuntu1_all.deb",
+			"version": "2024a-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "debianutils_5.16_amd64",
+					"name": "debianutils",
+					"version": "5.16"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu2_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_amd64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "base-files_13ubuntu7_amd64",
+					"name": "base-files",
+					"version": "13ubuntu7"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu1_amd64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu1"
+				}
+			],
+			"key": "bash_5.2.21-2ubuntu2_amd64",
+			"name": "bash",
+			"sha256": "ad21b2dbc6991a08c62e519d920a326f23f3ee2a0ac91c6c448978595d5ae685",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/bash/bash_5.2.21-2ubuntu2_amd64.deb",
+			"version": "5.2.21-2ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "debianutils_5.16_amd64",
+			"name": "debianutils",
+			"sha256": "b1c3597e81831cf3d37cf84f06afaf05d90a55d717f643cead55fe4b223cc04a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/debianutils/debianutils_5.16_amd64.deb",
+			"version": "5.16"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "base-files_13ubuntu7_amd64",
+			"name": "base-files",
+			"sha256": "d2fe9680dea0b8f6d6d675eceaf2bf00da8d1b3da1604f0e3b47ee26866feadd",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/base-files/base-files_13ubuntu7_amd64.deb",
+			"version": "13ubuntu7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.36-4_amd64",
+			"name": "libcrypt1",
+			"sha256": "51ad101808e6a9d6b9c21bcf0b6f27c8ab34f6af53184fc6305f96770cc3a8d9",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libx/libxcrypt/libcrypt1_4.4.36-4_amd64.deb",
+			"version": "1:4.4.36-4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libssl3_3.0.10-1ubuntu4_amd64",
+					"name": "libssl3",
+					"version": "3.0.10-1ubuntu4"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu2_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_amd64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "libselinux1_3.5-2build1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2build1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu1"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu4_amd64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu4"
+				},
+				{
+					"key": "libattr1_1-2.5.2-1_amd64",
+					"name": "libattr1",
+					"version": "1:2.5.2-1"
+				},
+				{
+					"key": "libacl1_2.3.2-1_amd64",
+					"name": "libacl1",
+					"version": "2.3.2-1"
+				}
+			],
+			"key": "coreutils_9.4-2ubuntu4_amd64",
+			"name": "coreutils",
+			"sha256": "12f958744332b290cb5d577cb5304c09f5fceddc776a2ea29329c1cca2628567",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/c/coreutils/coreutils_9.4-2ubuntu4_amd64.deb",
+			"version": "9.4-2ubuntu4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libssl3_3.0.10-1ubuntu4_amd64",
+			"name": "libssl3",
+			"sha256": "8228c52b80fc7c39619b4d2246a0fd9beb838272c848fc9718062af7102324a6",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/o/openssl/libssl3_3.0.10-1ubuntu4_amd64.deb",
+			"version": "3.0.10-1ubuntu4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libselinux1_3.5-2build1_amd64",
+			"name": "libselinux1",
+			"sha256": "139f29430e3d265fc8d9b9da7dd3f704ee3f1838c37a5d512cf265ec0b4eba28",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libselinux/libselinux1_3.5-2build1_amd64.deb",
+			"version": "3.5-2build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.42-4ubuntu1_amd64",
+			"name": "libpcre2-8-0",
+			"sha256": "3fbf30adf862c4e510a9260c7666a1a5326bc5fed8021090bc75a4ecbaa52fa4",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/pcre2/libpcre2-8-0_10.42-4ubuntu1_amd64.deb",
+			"version": "10.42-4ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu4_amd64",
+			"name": "libgmp10",
+			"sha256": "b0ede0faa0154c946ad5602e0d613b3266ff6ade089b0e939f23ad6e43964872",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2ubuntu4_amd64.deb",
+			"version": "2:6.3.0+dfsg-2ubuntu4"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libattr1_1-2.5.2-1_amd64",
+			"name": "libattr1",
+			"sha256": "38dbd3d90e88529f6f6e97f5564f333e38db8d20a704c7e8f484ed8705767382",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/attr/libattr1_2.5.2-1_amd64.deb",
+			"version": "1:2.5.2-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libacl1_2.3.2-1_amd64",
+			"name": "libacl1",
+			"sha256": "275cc58e50e49b8226f1ca705ac79bea3997b6e15b59e76cd2ade7d753a9298f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/acl/libacl1_2.3.2-1_amd64.deb",
+			"version": "2.3.2-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "tar_1.35-p-dfsg-3_amd64",
+					"name": "tar",
+					"version": "1.35+dfsg-3"
+				},
+				{
+					"key": "libselinux1_3.5-2build1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2build1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu2_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_amd64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "libacl1_2.3.2-1_amd64",
+					"name": "libacl1",
+					"version": "2.3.2-1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3ubuntu1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3ubuntu1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2"
+				},
+				{
+					"key": "libmd0_1.1.0-2_amd64",
+					"name": "libmd0",
+					"version": "1.1.0-2"
+				},
+				{
+					"key": "liblzma5_5.4.5-0.3_amd64",
+					"name": "liblzma5",
+					"version": "5.4.5-0.3"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5ubuntu1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5ubuntu1"
+				}
+			],
+			"key": "dpkg_1.22.4ubuntu5_amd64",
+			"name": "dpkg",
+			"sha256": "15b3fa045cb0ab82682aa581219d24a6dd7e74dd0dd5c03b35a5278eab1ec2fa",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/dpkg/dpkg_1.22.4ubuntu5_amd64.deb",
+			"version": "1.22.4ubuntu5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "tar_1.35-p-dfsg-3_amd64",
+			"name": "tar",
+			"sha256": "2fa676173c0076f59e423bd82d2ac00eba7c51fa1ae8903f09b88270b1c560ba",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/t/tar/tar_1.35+dfsg-3_amd64.deb",
+			"version": "1.35+dfsg-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.3.dfsg-3ubuntu1_amd64",
+			"name": "zlib1g",
+			"sha256": "35cfe44912765862374112e83c178c095448f247785772147c42c0c843b67c97",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3ubuntu1_amd64.deb",
+			"version": "1:1.3.dfsg-3ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libzstd1_1.5.5-p-dfsg2-2_amd64",
+			"name": "libzstd1",
+			"sha256": "7926bb8267652dd7df2c78c5e7541df6e62dbc10ed2efd4c2b869c75538b2ff1",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libz/libzstd/libzstd1_1.5.5+dfsg2-2_amd64.deb",
+			"version": "1.5.5+dfsg2-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libmd0_1.1.0-2_amd64",
+			"name": "libmd0",
+			"sha256": "128be9909c4ce8f2126e5f3d1a04fc11510c519409d64d324d724aae8347cd13",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libm/libmd/libmd0_1.1.0-2_amd64.deb",
+			"version": "1.1.0-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblzma5_5.4.5-0.3_amd64",
+			"name": "liblzma5",
+			"sha256": "02bb3148ccfa7408b3f12833aa483c2dd4e3a6ee647fe8bbc3bc60ef50761ead",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_amd64.deb",
+			"version": "5.4.5-0.3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libbz2-1.0_1.0.8-5ubuntu1_amd64",
+			"name": "libbz2-1.0",
+			"sha256": "8925b88fac7e8162a5c9dfcb078bb33932cb8aee51bb33db209ca97840f65369",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-5ubuntu1_amd64.deb",
+			"version": "1.0.8-5ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libsystemd0_255.2-3ubuntu2_amd64",
+					"name": "libsystemd0",
+					"version": "255.2-3ubuntu2"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu2_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_amd64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "liblzma5_5.4.5-0.3_amd64",
+					"name": "liblzma5",
+					"version": "5.4.5-0.3"
+				},
+				{
+					"key": "liblz4-1_1.9.4-1_amd64",
+					"name": "liblz4-1",
+					"version": "1.9.4-1"
+				},
+				{
+					"key": "libgcrypt20_1.10.3-2_amd64",
+					"name": "libgcrypt20",
+					"version": "1.10.3-2"
+				},
+				{
+					"key": "libgpg-error0_1.47-3build1_amd64",
+					"name": "libgpg-error0",
+					"version": "1.47-3build1"
+				},
+				{
+					"key": "libcap2_1-2.66-5ubuntu1_amd64",
+					"name": "libcap2",
+					"version": "1:2.66-5ubuntu1"
+				},
+				{
+					"key": "libstdc-p--p-6_14-20240221-2.1ubuntu1_amd64",
+					"name": "libstdc++6",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "libseccomp2_2.5.5-1ubuntu1_amd64",
+					"name": "libseccomp2",
+					"version": "2.5.5-1ubuntu1"
+				},
+				{
+					"key": "libgnutls30_3.8.3-1ubuntu1_amd64",
+					"name": "libgnutls30",
+					"version": "3.8.3-1ubuntu1"
+				},
+				{
+					"key": "libunistring5_1.1-2_amd64",
+					"name": "libunistring5",
+					"version": "1.1-2"
+				},
+				{
+					"key": "libtasn1-6_4.19.0-3_amd64",
+					"name": "libtasn1-6",
+					"version": "4.19.0-3"
+				},
+				{
+					"key": "libp11-kit0_0.25.3-4ubuntu1_amd64",
+					"name": "libp11-kit0",
+					"version": "0.25.3-4ubuntu1"
+				},
+				{
+					"key": "libffi8_3.4.6-1_amd64",
+					"name": "libffi8",
+					"version": "3.4.6-1"
+				},
+				{
+					"key": "libnettle8_3.9.1-2_amd64",
+					"name": "libnettle8",
+					"version": "3.9.1-2"
+				},
+				{
+					"key": "libidn2-0_2.3.7-2_amd64",
+					"name": "libidn2-0",
+					"version": "2.3.7-2"
+				},
+				{
+					"key": "libhogweed6_3.9.1-2_amd64",
+					"name": "libhogweed6",
+					"version": "3.9.1-2"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu4_amd64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu4"
+				},
+				{
+					"key": "ubuntu-keyring_2023.11.28.1_amd64",
+					"name": "ubuntu-keyring",
+					"version": "2023.11.28.1"
+				},
+				{
+					"key": "libapt-pkg6.0_2.7.12_amd64",
+					"name": "libapt-pkg6.0",
+					"version": "2.7.12"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3ubuntu1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3ubuntu1"
+				},
+				{
+					"key": "libxxhash0_0.8.2-2_amd64",
+					"name": "libxxhash0",
+					"version": "0.8.2-2"
+				},
+				{
+					"key": "libudev1_255.2-3ubuntu2_amd64",
+					"name": "libudev1",
+					"version": "255.2-3ubuntu2"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5ubuntu1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5ubuntu1"
+				},
+				{
+					"key": "gpgv_2.4.4-2ubuntu7_amd64",
+					"name": "gpgv",
+					"version": "2.4.4-2ubuntu7"
+				},
+				{
+					"key": "libnpth0_1.6-3build2_amd64",
+					"name": "libnpth0",
+					"version": "1.6-3build2"
+				},
+				{
+					"key": "libassuan0_2.5.6-1_amd64",
+					"name": "libassuan0",
+					"version": "2.5.6-1"
+				}
+			],
+			"key": "apt_2.7.12_amd64",
+			"name": "apt",
+			"sha256": "ffde38ea5a2d42045732a83633737741259cc517a8c52e3c2776b0b4ea75843d",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/apt/apt_2.7.12_amd64.deb",
+			"version": "2.7.12"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libsystemd0_255.2-3ubuntu2_amd64",
+			"name": "libsystemd0",
+			"sha256": "2b795ada9003c3d43fea41ede816fe9ffeac9e283c2cdc627ea41a123b110f4f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/s/systemd/libsystemd0_255.2-3ubuntu2_amd64.deb",
+			"version": "255.2-3ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "liblz4-1_1.9.4-1_amd64",
+			"name": "liblz4-1",
+			"sha256": "8c2ac2844f58875ebd1c78cc397ef3889d58050b40299f5dc267d7a77957dc48",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/l/lz4/liblz4-1_1.9.4-1_amd64.deb",
+			"version": "1.9.4-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgcrypt20_1.10.3-2_amd64",
+			"name": "libgcrypt20",
+			"sha256": "ad2547e30a16c475e1eb4ac6ba77d06a261fdeb5af4407c4b1655ce1ad38dff4",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_amd64.deb",
+			"version": "1.10.3-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgpg-error0_1.47-3build1_amd64",
+			"name": "libgpg-error0",
+			"sha256": "2d033b832a3b537538c9bd13c35ecafc7b78aa8c4d7b28859e65d1a6528e2d92",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libg/libgpg-error/libgpg-error0_1.47-3build1_amd64.deb",
+			"version": "1.47-3build1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libcap2_1-2.66-5ubuntu1_amd64",
+			"name": "libcap2",
+			"sha256": "ac02d261cf8fe7be4cef3e43ff67906da85de4e359ed5c4199b707bdeff0ab62",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libc/libcap2/libcap2_2.66-5ubuntu1_amd64.deb",
+			"version": "1:2.66-5ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libstdc-p--p-6_14-20240221-2.1ubuntu1_amd64",
+			"name": "libstdc++6",
+			"sha256": "3311c13f2e26c20369e937051c78f07c495f6112a0d6c32d3285b47021457ec2",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/libstdc++6_14-20240221-2.1ubuntu1_amd64.deb",
+			"version": "14-20240221-2.1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libseccomp2_2.5.5-1ubuntu1_amd64",
+			"name": "libseccomp2",
+			"sha256": "23b58d5dbae7f6875955a61afd782aade21869015a2a710bf3deef6894a691fb",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libseccomp/libseccomp2_2.5.5-1ubuntu1_amd64.deb",
+			"version": "2.5.5-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgnutls30_3.8.3-1ubuntu1_amd64",
+			"name": "libgnutls30",
+			"sha256": "9638b9847ba94bbf3a81ddd491911aa29e6c8eb2cd9f998b38f4599fbbf76c99",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gnutls28/libgnutls30_3.8.3-1ubuntu1_amd64.deb",
+			"version": "3.8.3-1ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libunistring5_1.1-2_amd64",
+			"name": "libunistring5",
+			"sha256": "cbdbbbf7552e953e3b58c512eb99891fa3ea8b2847a1a8194c5fb9abdb7066b5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libu/libunistring/libunistring5_1.1-2_amd64.deb",
+			"version": "1.1-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libtasn1-6_4.19.0-3_amd64",
+			"name": "libtasn1-6",
+			"sha256": "84f16110976e40a7aaa11eb0a291bd85f4002fb8b87f6355ff2f8340d9cf4a62",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0-3_amd64.deb",
+			"version": "4.19.0-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libp11-kit0_0.25.3-4ubuntu1_amd64",
+			"name": "libp11-kit0",
+			"sha256": "55e257759c223816b23af975d792519c738db9b0e0687c071429db74e1912aa3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/p11-kit/libp11-kit0_0.25.3-4ubuntu1_amd64.deb",
+			"version": "0.25.3-4ubuntu1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libffi8_3.4.6-1_amd64",
+			"name": "libffi8",
+			"sha256": "bd30f638a82381979c4c07b3acabb7fccaeed7f9b094e27c9a676d2e94572b14",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libf/libffi/libffi8_3.4.6-1_amd64.deb",
+			"version": "3.4.6-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnettle8_3.9.1-2_amd64",
+			"name": "libnettle8",
+			"sha256": "c38dd77f817639a2d524956a391393f7d3cdca38724e92ed6d04768fa0a282e9",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/nettle/libnettle8_3.9.1-2_amd64.deb",
+			"version": "3.9.1-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libidn2-0_2.3.7-2_amd64",
+			"name": "libidn2-0",
+			"sha256": "6a00f2cbdfd1e628556bcbc4c1edab07066f6c47f4e75657d8e8b6900704312c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libi/libidn2/libidn2-0_2.3.7-2_amd64.deb",
+			"version": "2.3.7-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libhogweed6_3.9.1-2_amd64",
+			"name": "libhogweed6",
+			"sha256": "9644344e343eea3d82f35c4d70e33cfc9b36e139f109a78aaf7a6feb9a3126f2",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/nettle/libhogweed6_3.9.1-2_amd64.deb",
+			"version": "3.9.1-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "ubuntu-keyring_2023.11.28.1_amd64",
+			"name": "ubuntu-keyring",
+			"sha256": "36de43b15853ccae0028e9a767613770c704833f82586f28eb262f0311adb8a8",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/u/ubuntu-keyring/ubuntu-keyring_2023.11.28.1_all.deb",
+			"version": "2023.11.28.1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libapt-pkg6.0_2.7.12_amd64",
+			"name": "libapt-pkg6.0",
+			"sha256": "6eafb79a865ba21b3e33fc9e49e6c3d09e336dd403d87647bcbe0cd3a614871a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/apt/libapt-pkg6.0_2.7.12_amd64.deb",
+			"version": "2.7.12"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libxxhash0_0.8.2-2_amd64",
+			"name": "libxxhash0",
+			"sha256": "fbee58694f740de786455ceb5b34550c3ceb067df59fddf0e9d7d713528eb9cb",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/x/xxhash/libxxhash0_0.8.2-2_amd64.deb",
+			"version": "0.8.2-2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libudev1_255.2-3ubuntu2_amd64",
+			"name": "libudev1",
+			"sha256": "c84b059e2c070796cd0a92f5645801a12be726860b4f52153bede2819bbaa980",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/s/systemd/libudev1_255.2-3ubuntu2_amd64.deb",
+			"version": "255.2-3ubuntu2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "gpgv_2.4.4-2ubuntu7_amd64",
+			"name": "gpgv",
+			"sha256": "5e34a3132f9ecff5276e2d443f85f1fbfc8fe8aa3964dc6bd089123b137676e0",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gnupg2/gpgv_2.4.4-2ubuntu7_amd64.deb",
+			"version": "2.4.4-2ubuntu7"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libnpth0_1.6-3build2_amd64",
+			"name": "libnpth0",
+			"sha256": "e6e05ed1c4ccfbdc4ca3af2696dadbd0313b5287221ecafa306911da6fbbf89a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/npth/libnpth0_1.6-3build2_amd64.deb",
+			"version": "1.6-3build2"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libassuan0_2.5.6-1_amd64",
+			"name": "libassuan0",
+			"sha256": "c976b785f81b23888bc39a16f9f3cfaf031536ff23f0b6fb24d4812019f20138",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/liba/libassuan/libassuan0_2.5.6-1_amd64.deb",
+			"version": "2.5.6-1"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [
+				{
+					"key": "libperl5.38_5.38.2-3_amd64",
+					"name": "libperl5.38",
+					"version": "5.38.2-3"
+				},
+				{
+					"key": "perl-modules-5.38_5.38.2-3_amd64",
+					"name": "perl-modules-5.38",
+					"version": "5.38.2-3"
+				},
+				{
+					"key": "perl-base_5.38.2-3_amd64",
+					"name": "perl-base",
+					"version": "5.38.2-3"
+				},
+				{
+					"key": "dpkg_1.22.4ubuntu5_amd64",
+					"name": "dpkg",
+					"version": "1.22.4ubuntu5"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3_amd64",
+					"name": "tar",
+					"version": "1.35+dfsg-3"
+				},
+				{
+					"key": "libselinux1_3.5-2build1_amd64",
+					"name": "libselinux1",
+					"version": "3.5-2build1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu1_amd64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu2_amd64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_amd64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_amd64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "libacl1_2.3.2-1_amd64",
+					"name": "libacl1",
+					"version": "2.3.2-1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3ubuntu1_amd64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3ubuntu1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2_amd64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2"
+				},
+				{
+					"key": "libmd0_1.1.0-2_amd64",
+					"name": "libmd0",
+					"version": "1.1.0-2"
+				},
+				{
+					"key": "liblzma5_5.4.5-0.3_amd64",
+					"name": "liblzma5",
+					"version": "5.4.5-0.3"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5ubuntu1_amd64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5ubuntu1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4_amd64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4"
+				},
+				{
+					"key": "libgdbm6_1.23-5_amd64",
+					"name": "libgdbm6",
+					"version": "1.23-5"
+				},
+				{
+					"key": "libgdbm-compat4_1.23-5_amd64",
+					"name": "libgdbm-compat4",
+					"version": "1.23-5"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg2-4_amd64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg2-4"
+				}
+			],
+			"key": "perl_5.38.2-3_amd64",
+			"name": "perl",
+			"sha256": "af6657fcbd23694120410423ad59bdf8d0ad5139e5e80cc10599b1a44706fdf6",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl_5.38.2-3_amd64.deb",
+			"version": "5.38.2-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libperl5.38_5.38.2-3_amd64",
+			"name": "libperl5.38",
+			"sha256": "62a161cb99621bb3e69b51bd1ff00ff4ad77cbd357d525182830571d52656cf3",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/libperl5.38_5.38.2-3_amd64.deb",
+			"version": "5.38.2-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "perl-modules-5.38_5.38.2-3_amd64",
+			"name": "perl-modules-5.38",
+			"sha256": "127dd76635d1d3d135caa5bbc4d5ae96a1c88a36c21313602c4c416270040849",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl-modules-5.38_5.38.2-3_all.deb",
+			"version": "5.38.2-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "perl-base_5.38.2-3_amd64",
+			"name": "perl-base",
+			"sha256": "bd0c5e1b72bdc400005330094101d83628604af5b132df4ea4132eb58e349aa0",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl-base_5.38.2-3_amd64.deb",
+			"version": "5.38.2-3"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgdbm6_1.23-5_amd64",
+			"name": "libgdbm6",
+			"sha256": "c3f20aaeeb16d33907b08bd5ca8d179e3d03cfd90d48a631954011179e19225a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gdbm/libgdbm6_1.23-5_amd64.deb",
+			"version": "1.23-5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libgdbm-compat4_1.23-5_amd64",
+			"name": "libgdbm-compat4",
+			"sha256": "788b045f2ed29aad67e3e4dec448c71ec12c1e5f653a1b36422b3fb2082409dc",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gdbm/libgdbm-compat4_1.23-5_amd64.deb",
+			"version": "1.23-5"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "libdb5.3_5.3.28-p-dfsg2-4_amd64",
+			"name": "libdb5.3",
+			"sha256": "439d822a4d19edb3ea466b3ad085d1783d2319611061090df4bef2c562bc625e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg2-4_amd64.deb",
+			"version": "5.3.28+dfsg2-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "ncurses-base_6.4-p-20240113-1ubuntu1_arm64",
+			"name": "ncurses-base",
+			"sha256": "1ea2be0cadf1299e5ed2967269c01e1935ddf5a733a496893b4334994aea2755",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/ncurses-base_6.4+20240113-1ubuntu1_all.deb",
+			"version": "6.4+20240113-1ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libc6_2.39-0ubuntu2_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_arm64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_arm64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu1_arm64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu1"
+				}
+			],
+			"key": "libncurses6_6.4-p-20240113-1ubuntu1_arm64",
+			"name": "libncurses6",
+			"sha256": "5cb643f9a938f783a72b85c2c102b977e7e2d137c0d3564ff1df6652de89296f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/libncurses6_6.4+20240113-1ubuntu1_arm64.deb",
+			"version": "6.4+20240113-1ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libc6_2.39-0ubuntu2_arm64",
+			"name": "libc6",
+			"sha256": "522238223618b52aae530256dfaea19e746649c382983d99c9e79d1f7e6afeef",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/glibc/libc6_2.39-0ubuntu2_arm64.deb",
+			"version": "2.39-0ubuntu2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcc-s1_14-20240221-2.1ubuntu1_arm64",
+			"name": "libgcc-s1",
+			"sha256": "d3aec36dbcea7dcf910f7ece43d3e31260bb0cd0a2b58808efaa999af1798511",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/libgcc-s1_14-20240221-2.1ubuntu1_arm64.deb",
+			"version": "14-20240221-2.1ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gcc-14-base_14-20240221-2.1ubuntu1_arm64",
+			"name": "gcc-14-base",
+			"sha256": "9886cc5eec6df002429338e26ce1670ada931f9b91fe147eee483ae11cc9cdda",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/gcc-14-base_14-20240221-2.1ubuntu1_arm64.deb",
+			"version": "14-20240221-2.1ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtinfo6_6.4-p-20240113-1ubuntu1_arm64",
+			"name": "libtinfo6",
+			"sha256": "4a190c05ea7e919e4e796e1321f7923158048e1bdc58c71c11692628f6064bcb",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/ncurses/libtinfo6_6.4+20240113-1ubuntu1_arm64.deb",
+			"version": "6.4+20240113-1ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "tzdata_2024a-1ubuntu1_arm64",
+			"name": "tzdata",
+			"sha256": "26cdb43f541d5b7d089d2c1cf7d50b4c5e630c79a6d4d6ce34e20dcace4f0d29",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/t/tzdata/tzdata_2024a-1ubuntu1_all.deb",
+			"version": "2024a-1ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "debianutils_5.16_arm64",
+					"name": "debianutils",
+					"version": "5.16"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu2_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_arm64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_arm64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "base-files_13ubuntu7_arm64",
+					"name": "base-files",
+					"version": "13ubuntu7"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4"
+				},
+				{
+					"key": "libtinfo6_6.4-p-20240113-1ubuntu1_arm64",
+					"name": "libtinfo6",
+					"version": "6.4+20240113-1ubuntu1"
+				}
+			],
+			"key": "bash_5.2.21-2ubuntu2_arm64",
+			"name": "bash",
+			"sha256": "f6e49a0e27e9f73a10a95cfce04f5449834cf5c2f0f12caffa273297385a0f46",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/bash/bash_5.2.21-2ubuntu2_arm64.deb",
+			"version": "5.2.21-2ubuntu2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "debianutils_5.16_arm64",
+			"name": "debianutils",
+			"sha256": "59efa8456b8f2dd76860ba306dbc397673170d9dfa969f58fba8891329a7d5b5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/debianutils/debianutils_5.16_arm64.deb",
+			"version": "5.16"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "base-files_13ubuntu7_arm64",
+			"name": "base-files",
+			"sha256": "fca1f68e39dca654190f4a3bd4879659f90781d3d509c3882db0e75c1ce2ebc6",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/base-files/base-files_13ubuntu7_arm64.deb",
+			"version": "13ubuntu7"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcrypt1_1-4.4.36-4_arm64",
+			"name": "libcrypt1",
+			"sha256": "3dd680dd15a31e7a023f47008b99b1aceed3104a01afacb775fa888a8fdb9f90",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libx/libxcrypt/libcrypt1_4.4.36-4_arm64.deb",
+			"version": "1:4.4.36-4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libselinux1_3.5-2build1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2build1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu2_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_arm64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_arm64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu4_arm64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu4"
+				},
+				{
+					"key": "libattr1_1-2.5.2-1_arm64",
+					"name": "libattr1",
+					"version": "1:2.5.2-1"
+				},
+				{
+					"key": "libacl1_2.3.2-1_arm64",
+					"name": "libacl1",
+					"version": "2.3.2-1"
+				}
+			],
+			"key": "coreutils_9.4-2ubuntu4_arm64",
+			"name": "coreutils",
+			"sha256": "a73b6f3b14c2578c12ba8ed8c7e55df8b94aa60088713b85ecaa56149f704788",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/c/coreutils/coreutils_9.4-2ubuntu4_arm64.deb",
+			"version": "9.4-2ubuntu4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libselinux1_3.5-2build1_arm64",
+			"name": "libselinux1",
+			"sha256": "9d22b9775025031775c8cf77568b427e7f7bff49d097b5c9885657edfaf71193",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libselinux/libselinux1_3.5-2build1_arm64.deb",
+			"version": "3.5-2build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libpcre2-8-0_10.42-4ubuntu1_arm64",
+			"name": "libpcre2-8-0",
+			"sha256": "14214893ef06c573ad2e6d99ab6cebbaf26c204818cf898ea7abc8b0339f1791",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/pcre2/libpcre2-8-0_10.42-4ubuntu1_arm64.deb",
+			"version": "10.42-4ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu4_arm64",
+			"name": "libgmp10",
+			"sha256": "8f35d6d5564801218d19c864361726bf9ba8a171896e1c183dd7ecb70973592b",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2ubuntu4_arm64.deb",
+			"version": "2:6.3.0+dfsg-2ubuntu4"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libattr1_1-2.5.2-1_arm64",
+			"name": "libattr1",
+			"sha256": "0cfd6967c0ca25b16db868d819f47ffcca5d43aa22e3227c7be08626dc73d7cb",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/attr/libattr1_2.5.2-1_arm64.deb",
+			"version": "1:2.5.2-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libacl1_2.3.2-1_arm64",
+			"name": "libacl1",
+			"sha256": "1e683ce20074199ed9dd9c4ffdbb5bf30f5e494d9c9452512f8709a9fbe76562",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/acl/libacl1_2.3.2-1_arm64.deb",
+			"version": "2.3.2-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "tar_1.35-p-dfsg-3_arm64",
+					"name": "tar",
+					"version": "1.35+dfsg-3"
+				},
+				{
+					"key": "libselinux1_3.5-2build1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2build1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu2_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_arm64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_arm64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "libacl1_2.3.2-1_arm64",
+					"name": "libacl1",
+					"version": "2.3.2-1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3ubuntu1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3ubuntu1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2_arm64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2"
+				},
+				{
+					"key": "libmd0_1.1.0-2_arm64",
+					"name": "libmd0",
+					"version": "1.1.0-2"
+				},
+				{
+					"key": "liblzma5_5.4.5-0.3_arm64",
+					"name": "liblzma5",
+					"version": "5.4.5-0.3"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5ubuntu1_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5ubuntu1"
+				}
+			],
+			"key": "dpkg_1.22.4ubuntu5_arm64",
+			"name": "dpkg",
+			"sha256": "352d489b2b457728a2cfd253172080729ce3ac635bc8cf9809acb9c92e2dd149",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/dpkg/dpkg_1.22.4ubuntu5_arm64.deb",
+			"version": "1.22.4ubuntu5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "tar_1.35-p-dfsg-3_arm64",
+			"name": "tar",
+			"sha256": "15ed5677151c6f224799e82f90515c77e744a68d99d2ea3d8bf2877e9effd575",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/t/tar/tar_1.35+dfsg-3_arm64.deb",
+			"version": "1.35+dfsg-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "zlib1g_1-1.3.dfsg-3ubuntu1_arm64",
+			"name": "zlib1g",
+			"sha256": "bb947ff78e0aee7477aeea1bc82a5db2e80f5b1322f460ecc06710200a16326f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/z/zlib/zlib1g_1.3.dfsg-3ubuntu1_arm64.deb",
+			"version": "1:1.3.dfsg-3ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libzstd1_1.5.5-p-dfsg2-2_arm64",
+			"name": "libzstd1",
+			"sha256": "a6c2bcacff770685b3ef262943bbb3ce2060b9de83e1698590f5b576d5e7827e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libz/libzstd/libzstd1_1.5.5+dfsg2-2_arm64.deb",
+			"version": "1.5.5+dfsg2-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libmd0_1.1.0-2_arm64",
+			"name": "libmd0",
+			"sha256": "884597eb942118b246a79e68aa619e3b6d22125e5cd7948557b542b6e70bdb54",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libm/libmd/libmd0_1.1.0-2_arm64.deb",
+			"version": "1.1.0-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "liblzma5_5.4.5-0.3_arm64",
+			"name": "liblzma5",
+			"sha256": "d0e936978175a45bb317a5ca17c29f0d610126e21f5ce6900f107244a6e333b6",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/x/xz-utils/liblzma5_5.4.5-0.3_arm64.deb",
+			"version": "5.4.5-0.3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libbz2-1.0_1.0.8-5ubuntu1_arm64",
+			"name": "libbz2-1.0",
+			"sha256": "0c479f94c97d2ab5641bf7b967d37daad61c5e8c4ea998ebd710d2125d4eb027",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-5ubuntu1_arm64.deb",
+			"version": "1.0.8-5ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libsystemd0_255.2-3ubuntu2_arm64",
+					"name": "libsystemd0",
+					"version": "255.2-3ubuntu2"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2_arm64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu2_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_arm64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_arm64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "liblzma5_5.4.5-0.3_arm64",
+					"name": "liblzma5",
+					"version": "5.4.5-0.3"
+				},
+				{
+					"key": "liblz4-1_1.9.4-1_arm64",
+					"name": "liblz4-1",
+					"version": "1.9.4-1"
+				},
+				{
+					"key": "libgcrypt20_1.10.3-2_arm64",
+					"name": "libgcrypt20",
+					"version": "1.10.3-2"
+				},
+				{
+					"key": "libgpg-error0_1.47-3build1_arm64",
+					"name": "libgpg-error0",
+					"version": "1.47-3build1"
+				},
+				{
+					"key": "libcap2_1-2.66-5ubuntu1_arm64",
+					"name": "libcap2",
+					"version": "1:2.66-5ubuntu1"
+				},
+				{
+					"key": "libstdc-p--p-6_14-20240221-2.1ubuntu1_arm64",
+					"name": "libstdc++6",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "libseccomp2_2.5.5-1ubuntu1_arm64",
+					"name": "libseccomp2",
+					"version": "2.5.5-1ubuntu1"
+				},
+				{
+					"key": "libgnutls30_3.8.3-1ubuntu1_arm64",
+					"name": "libgnutls30",
+					"version": "3.8.3-1ubuntu1"
+				},
+				{
+					"key": "libunistring5_1.1-2_arm64",
+					"name": "libunistring5",
+					"version": "1.1-2"
+				},
+				{
+					"key": "libtasn1-6_4.19.0-3_arm64",
+					"name": "libtasn1-6",
+					"version": "4.19.0-3"
+				},
+				{
+					"key": "libp11-kit0_0.25.3-4ubuntu1_arm64",
+					"name": "libp11-kit0",
+					"version": "0.25.3-4ubuntu1"
+				},
+				{
+					"key": "libffi8_3.4.6-1_arm64",
+					"name": "libffi8",
+					"version": "3.4.6-1"
+				},
+				{
+					"key": "libnettle8_3.9.1-2_arm64",
+					"name": "libnettle8",
+					"version": "3.9.1-2"
+				},
+				{
+					"key": "libidn2-0_2.3.7-2_arm64",
+					"name": "libidn2-0",
+					"version": "2.3.7-2"
+				},
+				{
+					"key": "libhogweed6_3.9.1-2_arm64",
+					"name": "libhogweed6",
+					"version": "3.9.1-2"
+				},
+				{
+					"key": "libgmp10_2-6.3.0-p-dfsg-2ubuntu4_arm64",
+					"name": "libgmp10",
+					"version": "2:6.3.0+dfsg-2ubuntu4"
+				},
+				{
+					"key": "ubuntu-keyring_2023.11.28.1_arm64",
+					"name": "ubuntu-keyring",
+					"version": "2023.11.28.1"
+				},
+				{
+					"key": "libapt-pkg6.0_2.7.12_arm64",
+					"name": "libapt-pkg6.0",
+					"version": "2.7.12"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3ubuntu1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3ubuntu1"
+				},
+				{
+					"key": "libxxhash0_0.8.2-2_arm64",
+					"name": "libxxhash0",
+					"version": "0.8.2-2"
+				},
+				{
+					"key": "libudev1_255.2-3ubuntu2_arm64",
+					"name": "libudev1",
+					"version": "255.2-3ubuntu2"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5ubuntu1_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5ubuntu1"
+				},
+				{
+					"key": "gpgv_2.4.4-2ubuntu7_arm64",
+					"name": "gpgv",
+					"version": "2.4.4-2ubuntu7"
+				},
+				{
+					"key": "libnpth0_1.6-3build2_arm64",
+					"name": "libnpth0",
+					"version": "1.6-3build2"
+				},
+				{
+					"key": "libassuan0_2.5.6-1_arm64",
+					"name": "libassuan0",
+					"version": "2.5.6-1"
+				}
+			],
+			"key": "apt_2.7.12_arm64",
+			"name": "apt",
+			"sha256": "a0f922f9133bff9b87f5887757434ab94c04efe9fb3f96ecb0a9acca845f5b28",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/apt/apt_2.7.12_arm64.deb",
+			"version": "2.7.12"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libsystemd0_255.2-3ubuntu2_arm64",
+			"name": "libsystemd0",
+			"sha256": "7cccc1271839ac53030490b84de797239db5bf53bb623a87e8762385b17136a1",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/s/systemd/libsystemd0_255.2-3ubuntu2_arm64.deb",
+			"version": "255.2-3ubuntu2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "liblz4-1_1.9.4-1_arm64",
+			"name": "liblz4-1",
+			"sha256": "3ca249f3f32308f8465b9c7447517b1e860539609e590d98b45c1878fad83c55",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/l/lz4/liblz4-1_1.9.4-1_arm64.deb",
+			"version": "1.9.4-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgcrypt20_1.10.3-2_arm64",
+			"name": "libgcrypt20",
+			"sha256": "fc9bf9dc690198d52aab5cbd325ce9b7f6ff2060cea320e35e5be741bcdbd863",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libg/libgcrypt20/libgcrypt20_1.10.3-2_arm64.deb",
+			"version": "1.10.3-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgpg-error0_1.47-3build1_arm64",
+			"name": "libgpg-error0",
+			"sha256": "431841c82321886700592874b5042f64908e53bb9560eff351664a9c38a22eaf",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libg/libgpg-error/libgpg-error0_1.47-3build1_arm64.deb",
+			"version": "1.47-3build1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libcap2_1-2.66-5ubuntu1_arm64",
+			"name": "libcap2",
+			"sha256": "f9e54bda3c9b38cdd95dccfaca37ba2a46220414116506f256e235307d5b7209",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libc/libcap2/libcap2_2.66-5ubuntu1_arm64.deb",
+			"version": "1:2.66-5ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libstdc-p--p-6_14-20240221-2.1ubuntu1_arm64",
+			"name": "libstdc++6",
+			"sha256": "538f5a9f9b7bfdff1e0317b6d1e21a7b6fdef8d82d07036c89716e35266a4cbf",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gcc-14/libstdc++6_14-20240221-2.1ubuntu1_arm64.deb",
+			"version": "14-20240221-2.1ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libseccomp2_2.5.5-1ubuntu1_arm64",
+			"name": "libseccomp2",
+			"sha256": "b11084b3907453470014cc95d30e3217c0c655b2c4a29891a3ab27ebfeaa9674",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libs/libseccomp/libseccomp2_2.5.5-1ubuntu1_arm64.deb",
+			"version": "2.5.5-1ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgnutls30_3.8.3-1ubuntu1_arm64",
+			"name": "libgnutls30",
+			"sha256": "5cd70f6fa56513bb91144bb3877d20315cd01ab57d1ff862762983b4dae3e9ed",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gnutls28/libgnutls30_3.8.3-1ubuntu1_arm64.deb",
+			"version": "3.8.3-1ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libunistring5_1.1-2_arm64",
+			"name": "libunistring5",
+			"sha256": "caf4c2c543f9204ff05308966440030d0878ab639ffbbbd667d160b64e1ee645",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libu/libunistring/libunistring5_1.1-2_arm64.deb",
+			"version": "1.1-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libtasn1-6_4.19.0-3_arm64",
+			"name": "libtasn1-6",
+			"sha256": "6ee67d52a802f55d419b52125796407d36a6e731f21f8f5d29101a2086d521bd",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libt/libtasn1-6/libtasn1-6_4.19.0-3_arm64.deb",
+			"version": "4.19.0-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libp11-kit0_0.25.3-4ubuntu1_arm64",
+			"name": "libp11-kit0",
+			"sha256": "1d2e7b8b7755f3a0fccec3d5ef0248a98f17cef0e352f2ff4a2f00a8fe30561e",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/p11-kit/libp11-kit0_0.25.3-4ubuntu1_arm64.deb",
+			"version": "0.25.3-4ubuntu1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libffi8_3.4.6-1_arm64",
+			"name": "libffi8",
+			"sha256": "420c53c1715064d8dd8c04805d43e9ed422455d09185aecc77ec45295d326bcc",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libf/libffi/libffi8_3.4.6-1_arm64.deb",
+			"version": "3.4.6-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnettle8_3.9.1-2_arm64",
+			"name": "libnettle8",
+			"sha256": "0d8860e05b6d440b34edbf46e88db2bfc6298063285b3f9eab567f8aa1af7983",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/nettle/libnettle8_3.9.1-2_arm64.deb",
+			"version": "3.9.1-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libidn2-0_2.3.7-2_arm64",
+			"name": "libidn2-0",
+			"sha256": "68e9d51078a345540829cd4ae4d95912f1c3ec3aaf454984e3393081d8d92e6f",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/libi/libidn2/libidn2-0_2.3.7-2_arm64.deb",
+			"version": "2.3.7-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libhogweed6_3.9.1-2_arm64",
+			"name": "libhogweed6",
+			"sha256": "6b378b847a96dd187789c02a314ea6aa02a9894f53fcbcf166b1f4a7383d596a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/nettle/libhogweed6_3.9.1-2_arm64.deb",
+			"version": "3.9.1-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "ubuntu-keyring_2023.11.28.1_arm64",
+			"name": "ubuntu-keyring",
+			"sha256": "36de43b15853ccae0028e9a767613770c704833f82586f28eb262f0311adb8a8",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/u/ubuntu-keyring/ubuntu-keyring_2023.11.28.1_all.deb",
+			"version": "2023.11.28.1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libapt-pkg6.0_2.7.12_arm64",
+			"name": "libapt-pkg6.0",
+			"sha256": "74a6337693c313bb4b563fcf829b06b5e209827bf91ed202e5407490e0ec5d26",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/a/apt/libapt-pkg6.0_2.7.12_arm64.deb",
+			"version": "2.7.12"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libxxhash0_0.8.2-2_arm64",
+			"name": "libxxhash0",
+			"sha256": "24c2da6d81871201d5a1e0bf5e718314438cad697d5f445bf579c37120331896",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/x/xxhash/libxxhash0_0.8.2-2_arm64.deb",
+			"version": "0.8.2-2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libudev1_255.2-3ubuntu2_arm64",
+			"name": "libudev1",
+			"sha256": "db9af267ca5e6148c9b6328dcb98643e0e7729f208e95916042aa87f363c2078",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/s/systemd/libudev1_255.2-3ubuntu2_arm64.deb",
+			"version": "255.2-3ubuntu2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "gpgv_2.4.4-2ubuntu7_arm64",
+			"name": "gpgv",
+			"sha256": "0b536711c2b86f7f793626df517eae887c9ac4c0582f3f50966ac5fa3ac62fb5",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gnupg2/gpgv_2.4.4-2ubuntu7_arm64.deb",
+			"version": "2.4.4-2ubuntu7"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libnpth0_1.6-3build2_arm64",
+			"name": "libnpth0",
+			"sha256": "433259a1f7ef32e9dcc83c5e2c596cae5571eefd0131e3c44c52fb58f81d6b7c",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/n/npth/libnpth0_1.6-3build2_arm64.deb",
+			"version": "1.6-3build2"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libassuan0_2.5.6-1_arm64",
+			"name": "libassuan0",
+			"sha256": "b93a9d3e3351269fb4e612e5a4b42b14f068514be40897e484170ac82bb6d7b7",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/liba/libassuan/libassuan0_2.5.6-1_arm64.deb",
+			"version": "2.5.6-1"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [
+				{
+					"key": "libperl5.38_5.38.2-3_arm64",
+					"name": "libperl5.38",
+					"version": "5.38.2-3"
+				},
+				{
+					"key": "perl-modules-5.38_5.38.2-3_arm64",
+					"name": "perl-modules-5.38",
+					"version": "5.38.2-3"
+				},
+				{
+					"key": "perl-base_5.38.2-3_arm64",
+					"name": "perl-base",
+					"version": "5.38.2-3"
+				},
+				{
+					"key": "dpkg_1.22.4ubuntu5_arm64",
+					"name": "dpkg",
+					"version": "1.22.4ubuntu5"
+				},
+				{
+					"key": "tar_1.35-p-dfsg-3_arm64",
+					"name": "tar",
+					"version": "1.35+dfsg-3"
+				},
+				{
+					"key": "libselinux1_3.5-2build1_arm64",
+					"name": "libselinux1",
+					"version": "3.5-2build1"
+				},
+				{
+					"key": "libpcre2-8-0_10.42-4ubuntu1_arm64",
+					"name": "libpcre2-8-0",
+					"version": "10.42-4ubuntu1"
+				},
+				{
+					"key": "libc6_2.39-0ubuntu2_arm64",
+					"name": "libc6",
+					"version": "2.39-0ubuntu2"
+				},
+				{
+					"key": "libgcc-s1_14-20240221-2.1ubuntu1_arm64",
+					"name": "libgcc-s1",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "gcc-14-base_14-20240221-2.1ubuntu1_arm64",
+					"name": "gcc-14-base",
+					"version": "14-20240221-2.1ubuntu1"
+				},
+				{
+					"key": "libacl1_2.3.2-1_arm64",
+					"name": "libacl1",
+					"version": "2.3.2-1"
+				},
+				{
+					"key": "zlib1g_1-1.3.dfsg-3ubuntu1_arm64",
+					"name": "zlib1g",
+					"version": "1:1.3.dfsg-3ubuntu1"
+				},
+				{
+					"key": "libzstd1_1.5.5-p-dfsg2-2_arm64",
+					"name": "libzstd1",
+					"version": "1.5.5+dfsg2-2"
+				},
+				{
+					"key": "libmd0_1.1.0-2_arm64",
+					"name": "libmd0",
+					"version": "1.1.0-2"
+				},
+				{
+					"key": "liblzma5_5.4.5-0.3_arm64",
+					"name": "liblzma5",
+					"version": "5.4.5-0.3"
+				},
+				{
+					"key": "libbz2-1.0_1.0.8-5ubuntu1_arm64",
+					"name": "libbz2-1.0",
+					"version": "1.0.8-5ubuntu1"
+				},
+				{
+					"key": "libcrypt1_1-4.4.36-4_arm64",
+					"name": "libcrypt1",
+					"version": "1:4.4.36-4"
+				},
+				{
+					"key": "libgdbm6_1.23-5_arm64",
+					"name": "libgdbm6",
+					"version": "1.23-5"
+				},
+				{
+					"key": "libgdbm-compat4_1.23-5_arm64",
+					"name": "libgdbm-compat4",
+					"version": "1.23-5"
+				},
+				{
+					"key": "libdb5.3_5.3.28-p-dfsg2-4_arm64",
+					"name": "libdb5.3",
+					"version": "5.3.28+dfsg2-4"
+				}
+			],
+			"key": "perl_5.38.2-3_arm64",
+			"name": "perl",
+			"sha256": "649812e92fd35d1cd3d8b71233a7fda8e56fb7da761376904607d8233a37cbac",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl_5.38.2-3_arm64.deb",
+			"version": "5.38.2-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libperl5.38_5.38.2-3_arm64",
+			"name": "libperl5.38",
+			"sha256": "c6256802c884974ed62e3e11bbee7c36cc0075679c5f7b6289692a7ed036476a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/libperl5.38_5.38.2-3_arm64.deb",
+			"version": "5.38.2-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "perl-modules-5.38_5.38.2-3_arm64",
+			"name": "perl-modules-5.38",
+			"sha256": "127dd76635d1d3d135caa5bbc4d5ae96a1c88a36c21313602c4c416270040849",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl-modules-5.38_5.38.2-3_all.deb",
+			"version": "5.38.2-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "perl-base_5.38.2-3_arm64",
+			"name": "perl-base",
+			"sha256": "b502331d6d9198caec0df1230980cbb2a0ee8b08edbf1a73f776d87f2377c293",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/p/perl/perl-base_5.38.2-3_arm64.deb",
+			"version": "5.38.2-3"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgdbm6_1.23-5_arm64",
+			"name": "libgdbm6",
+			"sha256": "ef9cecd3ce774b709a226f234eaf11b66a9a1aeae96f5d14600882192aab304a",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gdbm/libgdbm6_1.23-5_arm64.deb",
+			"version": "1.23-5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libgdbm-compat4_1.23-5_arm64",
+			"name": "libgdbm-compat4",
+			"sha256": "eb0ada72e019ce958cc01c09419a61215f6c9ffb468eed59944dce21060f6354",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/g/gdbm/libgdbm-compat4_1.23-5_arm64.deb",
+			"version": "1.23-5"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "libdb5.3_5.3.28-p-dfsg2-4_arm64",
+			"name": "libdb5.3",
+			"sha256": "522c7f6719d3e950eb6e7809af4c072a137c2c29927a0167745a997582ea7cde",
+			"url": "https://snapshot.ubuntu.com/ubuntu/20240301T030400Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg2-4_arm64.deb",
+			"version": "5.3.28+dfsg2-4"
+		}
+	],
+	"version": 1
 }


### PR DESCRIPTION
[ci: update ci and exclude windows (#82)](https://github.com/GoogleContainerTools/rules_distroless/commit/7cb92b772a54346fe3f314110ee767230a4f1b00) added `target_compatible_with` arguments to some of the tests restricting them to linux but it also forced amd64 instead of allowing the tests to run in both linux/amd64 and linux/arm64.

Before this fix, I would get `SKIPPED` tests when testing on linux/arm64 and now all the tests run.

I've also noticed that the locks were not updated and would produce side-effects so I've added a separate `chore` commit to make sure there's "no noise" in the commit and/or when running the tests or other code in the repo.