### PR TITLE
refactor: testing

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -37,6 +37,16 @@ load("@bullseye//:packages.bzl", "bullseye_packages")
 bullseye_packages()
 
 deb_index(
+    name = "bullseye_nolock",
+    manifest = "//examples/debian_snapshot:bullseye_nolock.yaml",
+    nolock = True,
+)
+
+load("@bullseye_nolock//:packages.bzl", "bullseye_nolock_packages")
+
+bullseye_nolock_packages()
+
+deb_index(
     name = "apt_security",
     manifest = "//examples/debian_snapshot_security:security.yaml",
     nolock = True,

--- a/apt/tests/BUILD.bazel
+++ b/apt/tests/BUILD.bazel
@@ -1,10 +1,6 @@
-load(":package_resolution_test.bzl", "version_depends_test")
-load(":version_test.bzl", "version_compare_test", "version_parse_test", "version_sort_test")
+load(":package_resolution_test.bzl", "package_resolution_tests")
+load(":version_test.bzl", "version_tests")
 
-version_compare_test(name = "version_compare_test")
+package_resolution_tests()
 
-version_parse_test(name = "version_parse_test")
-
-version_depends_test(name = "version_depends")
-
-version_sort_test(name = "version_sort_test")
+version_tests()

--- a/apt/tests/package_resolution_test.bzl
+++ b/apt/tests/package_resolution_test.bzl
@@ -3,29 +3,41 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//apt/private:package_resolution.bzl", "package_resolution")
 
+_TEST_SUITE_PREFIX = "package_resolution/"
+
 def _parse_depends_test(ctx):
     env = unittest.begin(ctx)
-    asserts.equals(
-        env,
-        [
+
+    parameters = {
+        " | ".join([
+            "libc6 (>= 2.2.1), default-mta",
+            "mail-transport-agent",
+        ]): [
             {"name": "libc6", "version": (">=", "2.2.1"), "arch": None},
-            [{"name": "default-mta", "version": None, "arch": None}, {"name": "mail-transport-agent", "version": None, "arch": None}],
+            [
+                {"name": "default-mta", "version": None, "arch": None},
+                {"name": "mail-transport-agent", "version": None, "arch": None},
+            ],
         ],
-        package_resolution.parse_depends("libc6 (>= 2.2.1), default-mta | mail-transport-agent"),
-    )
-
-    asserts.equals(
-        env,
-        [
-            {"name": "libluajit5.1-dev", "version": None, "arch": ["i386", "amd64", "kfreebsd-i386", "armel", "armhf", "powerpc", "mips"]},
-            {"name": "liblua5.1-dev", "version": None, "arch": ["hurd-i386", "ia64", "kfreebsd-amd64", "s390x", "sparc"]},
+        ", ".join([
+            "libluajit5.1-dev [i386 amd64 powerpc mips]",
+            "liblua5.1-dev [hurd-i386 ia64 s390x sparc]",
+        ]): [
+            {
+                "name": "libluajit5.1-dev",
+                "version": None,
+                "arch": ["i386", "amd64", "powerpc", "mips"],
+            },
+            {
+                "name": "liblua5.1-dev",
+                "version": None,
+                "arch": ["hurd-i386", "ia64", "s390x", "sparc"],
+            },
         ],
-        package_resolution.parse_depends("libluajit5.1-dev [i386 amd64 kfreebsd-i386 armel armhf powerpc mips], liblua5.1-dev [hurd-i386 ia64 kfreebsd-amd64 s390x sparc]"),
-    )
-
-    asserts.equals(
-        env,
-        [
+        " | ".join([
+            "emacs",
+            "emacsen, make, debianutils (>= 1.7)",
+        ]): [
             [
                 {"name": "emacs", "version": None, "arch": None},
                 {"name": "emacsen", "version": None, "arch": None},
@@ -33,13 +45,16 @@ def _parse_depends_test(ctx):
             {"name": "make", "version": None, "arch": None},
             {"name": "debianutils", "version": (">=", "1.7"), "arch": None},
         ],
-        package_resolution.parse_depends("emacs | emacsen, make, debianutils (>= 1.7)"),
-    )
-
-    asserts.equals(
-        env,
-        [
-            {"name": "libcap-dev", "version": None, "arch": ["!kfreebsd-i386", "!kfreebsd-amd64", "!hurd-i386"]},
+        ", ".join([
+            "libcap-dev [!kfreebsd-i386 !hurd-i386]",
+            "autoconf",
+            "debhelper (>> 5.0.0)",
+            "file",
+            "libc6 (>= 2.7-1)",
+            "libpaper1",
+            "psutils",
+        ]): [
+            {"name": "libcap-dev", "version": None, "arch": ["!kfreebsd-i386", "!hurd-i386"]},
             {"name": "autoconf", "version": None, "arch": None},
             {"name": "debhelper", "version": (">>", "5.0.0"), "arch": None},
             {"name": "file", "version": None, "arch": None},
@@ -47,20 +62,14 @@ def _parse_depends_test(ctx):
             {"name": "libpaper1", "version": None, "arch": None},
             {"name": "psutils", "version": None, "arch": None},
         ],
-        package_resolution.parse_depends("libcap-dev [!kfreebsd-i386 !kfreebsd-amd64 !hurd-i386], autoconf, debhelper (>> 5.0.0), file, libc6 (>= 2.7-1), libpaper1, psutils"),
-    )
-
-    asserts.equals(
-        env,
-        [
+        "python3:any": [
             {"name": "python3", "version": None, "arch": ["any"]},
         ],
-        package_resolution.parse_depends("python3:any"),
-    )
-
-    asserts.equals(
-        env,
-        [
+        " | ".join([
+            "gcc-i686-linux-gnu (>= 4:10.2)",
+            "gcc:i386, g++-i686-linux-gnu (>= 4:10.2)",
+            "g++:i386, dpkg-cross",
+        ]): [
             [
                 {"name": "gcc-i686-linux-gnu", "version": (">=", "4:10.2"), "arch": None},
                 {"name": "gcc", "version": None, "arch": ["i386"]},
@@ -71,12 +80,11 @@ def _parse_depends_test(ctx):
             ],
             {"name": "dpkg-cross", "version": None, "arch": None},
         ],
-        package_resolution.parse_depends("gcc-i686-linux-gnu (>= 4:10.2) | gcc:i386, g++-i686-linux-gnu (>= 4:10.2) | g++:i386, dpkg-cross"),
-    )
-
-    asserts.equals(
-        env,
-        [
+        " | ".join([
+            "gcc-x86-64-linux-gnu (>= 4:10.2)",
+            "gcc:amd64, g++-x86-64-linux-gnu (>= 4:10.2)",
+            "g++:amd64, dpkg-cross",
+        ]): [
             [
                 {"name": "gcc-x86-64-linux-gnu", "version": (">=", "4:10.2"), "arch": None},
                 {"name": "gcc", "version": None, "arch": ["amd64"]},
@@ -87,9 +95,15 @@ def _parse_depends_test(ctx):
             ],
             {"name": "dpkg-cross", "version": None, "arch": None},
         ],
-        package_resolution.parse_depends("gcc-x86-64-linux-gnu (>= 4:10.2) | gcc:amd64, g++-x86-64-linux-gnu (>= 4:10.2) | g++:amd64, dpkg-cross"),
-    )
+    }
+
+    for deps, expected in parameters.items():
+        actual = package_resolution.parse_depends(deps)
+        asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 
-version_depends_test = unittest.make(_parse_depends_test)
+parse_depends_test = unittest.make(_parse_depends_test)
+
+def package_resolution_tests():
+    parse_depends_test(name = _TEST_SUITE_PREFIX + "parse_depends")

--- a/apt/tests/version_test.bzl
+++ b/apt/tests/version_test.bzl
@@ -3,61 +3,98 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//apt/private:version.bzl", "version")
 
-def _parse_version_test(ctx):
+_TEST_SUITE_PREFIX = "version/"
+
+def _parse_test(ctx):
+    parameters = {
+        "1:1.4.1-1": ("1", "1.4.1", "1"),
+        "7.1.ds-1": (None, "7.1.ds", "1"),
+        "10.11.1.3-2": (None, "10.11.1.3", "2"),
+        "4.0.1.3.dfsg.1-2": (None, "4.0.1.3.dfsg.1", "2"),
+        "0.4.23debian1": (None, "0.4.23debian1", None),
+        "1.2.10+cvs20060429-1": (None, "1.2.10+cvs20060429", "1"),
+        "0.2.0-1+b1": (None, "0.2.0", "1+b1"),
+        "4.3.90.1svn-r21976-1": (None, "4.3.90.1svn-r21976", "1"),
+        "1.5+E-14": (None, "1.5+E", "14"),
+        "20060611-0.0": (None, "20060611", "0.0"),
+        "0.52.2-5.1": (None, "0.52.2", "5.1"),
+        "7.0-035+1": (None, "7.0", "035+1"),
+        "1.1.0+cvs20060620-1+2.6.15-8": (None, "1.1.0+cvs20060620-1+2.6.15", "8"),
+        "1.1.0+cvs20060620-1+1.0": (None, "1.1.0+cvs20060620", "1+1.0"),
+        "4.2.0a+stable-2sarge1": (None, "4.2.0a+stable", "2sarge1"),
+        "1.8RC4b": (None, "1.8RC4b", None),
+        "0.9~rc1-1": (None, "0.9~rc1", "1"),
+        "2:1.0.4+svn26-1ubuntu1": ("2", "1.0.4+svn26", "1ubuntu1"),
+        "2:1.0.4~rc2-1": ("2", "1.0.4~rc2", "1"),
+    }
+
     env = unittest.begin(ctx)
-    asserts.equals(env, version.parse("1:1.4.1-1"), ("1", "1.4.1", "1"))
-    asserts.equals(env, version.parse("7.1.ds-1"), (None, "7.1.ds", "1"))
-    asserts.equals(env, version.parse("10.11.1.3-2"), (None, "10.11.1.3", "2"))
-    asserts.equals(env, version.parse("4.0.1.3.dfsg.1-2"), (None, "4.0.1.3.dfsg.1", "2"))
-    asserts.equals(env, version.parse("0.4.23debian1"), (None, "0.4.23debian1", None))
-    asserts.equals(env, version.parse("1.2.10+cvs20060429-1"), (None, "1.2.10+cvs20060429", "1"))
-    asserts.equals(env, version.parse("0.2.0-1+b1"), (None, "0.2.0", "1+b1"))
-    asserts.equals(env, version.parse("4.3.90.1svn-r21976-1"), (None, "4.3.90.1svn-r21976", "1"))
-    asserts.equals(env, version.parse("1.5+E-14"), (None, "1.5+E", "14"))
-    asserts.equals(env, version.parse("20060611-0.0"), (None, "20060611", "0.0"))
-    asserts.equals(env, version.parse("0.52.2-5.1"), (None, "0.52.2", "5.1"))
-    asserts.equals(env, version.parse("7.0-035+1"), (None, "7.0", "035+1"))
-    asserts.equals(env, version.parse("1.1.0+cvs20060620-1+2.6.15-8"), (None, "1.1.0+cvs20060620-1+2.6.15", "8"))
-    asserts.equals(env, version.parse("1.1.0+cvs20060620-1+1.0"), (None, "1.1.0+cvs20060620", "1+1.0"))
-    asserts.equals(env, version.parse("4.2.0a+stable-2sarge1"), (None, "4.2.0a+stable", "2sarge1"))
-    asserts.equals(env, version.parse("1.8RC4b"), (None, "1.8RC4b", None))
-    asserts.equals(env, version.parse("0.9~rc1-1"), (None, "0.9~rc1", "1"))
-    asserts.equals(env, version.parse("2:1.0.4+svn26-1ubuntu1"), ("2", "1.0.4+svn26", "1ubuntu1"))
-    asserts.equals(env, version.parse("2:1.0.4~rc2-1"), ("2", "1.0.4~rc2", "1"))
+
+    for v, expected in parameters.items():
+        actual = version.parse(v)
+        asserts.equals(env, actual, expected)
+
     return unittest.end(env)
 
-version_parse_test = unittest.make(_parse_version_test)
+parse_test = unittest.make(_parse_test)
 
-def _version_compare_test(ctx):
+def _operators_test(ctx):
+    parameters = [
+        ("0", version.lt, "a"),
+        ("1.0", version.lt, "1.1"),
+        ("1.2", version.lt, "1.11"),
+        ("1.0-0.1", version.lt, "1.1"),
+        ("1.0-0.1", version.lt, "1.0-1"),
+        ("1.0", version.eq, "1.0"),
+        ("1.0-0.1", version.eq, "1.0-0.1"),
+        ("1:1.0-0.1", version.eq, "1:1.0-0.1"),
+        ("1:1.0", version.eq, "1:1.0"),
+        ("1.0-0.1", version.lt, "1.0-1"),
+        ("1.0final-5sarge1", version.gt, "1.0final-5"),
+        ("1.0final-5", version.gt, "1.0a7-2"),
+        ("0.9.2-5", version.lt, "0.9.2+cvs.1.0.dev.2004.07.28-1.5"),
+        ("1:500", version.lt, "1:5000"),
+        ("100:500", version.gt, "11:5000"),
+        ("1.0.4-2", version.gt, "1.0pre7-2"),
+        ("1.5~rc1", version.lt, "1.5"),
+        ("1.5~rc1", version.lt, "1.5+b1"),
+        ("1.5~rc1", version.lt, "1.5~rc2"),
+        ("1.5~rc1", version.gt, "1.5~dev0"),
+    ]
+
     env = unittest.begin(ctx)
-    asserts.true(env, version.lt("0", "a"))
-    asserts.true(env, version.lt("1.0", "1.1"))
-    asserts.true(env, version.lt("1.2", "1.11"))
-    asserts.true(env, version.lt("1.0-0.1", "1.1"))
-    asserts.true(env, version.lt("1.0-0.1", "1.0-1"))
-    asserts.true(env, version.eq("1.0", "1.0"))
-    asserts.true(env, version.eq("1.0-0.1", "1.0-0.1"))
-    asserts.true(env, version.eq("1:1.0-0.1", "1:1.0-0.1"))
-    asserts.true(env, version.eq("1:1.0", "1:1.0"))
-    asserts.true(env, version.lt("1.0-0.1", "1.0-1"))
-    asserts.true(env, version.gt("1.0final-5sarge1", "1.0final-5"))
-    asserts.true(env, version.gt("1.0final-5", "1.0a7-2"))
-    asserts.true(env, version.lt("0.9.2-5", "0.9.2+cvs.1.0.dev.2004.07.28-1.5"))
-    asserts.true(env, version.lt("1:500", "1:5000"))
-    asserts.true(env, version.gt("100:500", "11:5000"))
-    asserts.true(env, version.gt("1.0.4-2", "1.0pre7-2"))
-    asserts.true(env, version.lt("1.5~rc1", "1.5"))
-    asserts.true(env, version.lt("1.5~rc1", "1.5+b1"))
-    asserts.true(env, version.lt("1.5~rc1", "1.5~rc2"))
-    asserts.true(env, version.gt("1.5~rc1", "1.5~dev0"))
+    for va, version_op, vb in parameters:
+        asserts.true(env, version_op(va, vb))
+
     return unittest.end(env)
 
-version_compare_test = unittest.make(_version_compare_test)
+operators_test = unittest.make(_operators_test)
 
-def _version_sort_test(ctx):
+def _sort_test(ctx):
+    parameters = [
+        (
+            ["1.5~rc2", "1.0.4-2", "1.5~rc1"],
+            ["1.0.4-2", "1.5~rc1", "1.5~rc2"],
+            False,
+        ),
+        (
+            ["1.0a7-2", "1.0final-5sarge1", "1.0final-5"],
+            ["1.0final-5sarge1", "1.0final-5", "1.0a7-2"],
+            True,
+        ),
+    ]
+
     env = unittest.begin(ctx)
-    asserts.equals(env, version.sort(["1.5~rc2", "1.0.4-2", "1.5~rc1"]), ["1.0.4-2", "1.5~rc1", "1.5~rc2"])
-    asserts.equals(env, version.sort(["1.0a7-2", "1.0final-5sarge1", "1.0final-5"], reverse = True), ["1.0final-5sarge1", "1.0final-5", "1.0a7-2"])
+
+    for to_sort, expected, reversed in parameters:
+        actual = version.sort(to_sort, reverse = reversed)
+        asserts.equals(env, expected, actual)
+
     return unittest.end(env)
 
-version_sort_test = unittest.make(_version_sort_test)
+sort_test = unittest.make(_sort_test)
+
+def version_tests():
+    operators_test(name = _TEST_SUITE_PREFIX + "operators")
+    parse_test(name = _TEST_SUITE_PREFIX + "parse")
+    sort_test(name = _TEST_SUITE_PREFIX + "sort")

--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -58,7 +58,7 @@ PACKAGES = [
     "@bullseye//ncurses-base",
     "@bullseye//libncurses6",
     "@bullseye//tzdata",
-    "@bullseye//bash",
+    "@bullseye_nolock//bash",
     "@bullseye//coreutils",
     "@bullseye//dpkg",
     "@bullseye//apt",

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -62,3 +62,13 @@ deb_index(
 load("@bullseye//:packages.bzl", "bullseye_packages")
 
 bullseye_packages()
+
+deb_index(
+    name = "bullseye_nolock",
+    manifest = "//:bullseye.yaml",
+    nolock = True,
+)
+
+load("@bullseye_nolock//:packages.bzl", "bullseye_nolock_packages")
+
+bullseye_nolock_packages()

--- a/examples/debian_snapshot/BUILD.bazel
+++ b/examples/debian_snapshot/BUILD.bazel
@@ -58,7 +58,7 @@ PACKAGES = [
     "@bullseye//ncurses-base",
     "@bullseye//libncurses6",
     "@bullseye//tzdata",
-    "@bullseye//bash",
+    "@bullseye_nolock//bash",
     "@bullseye//coreutils",
     "@bullseye//dpkg",
     "@bullseye//apt",

--- a/examples/debian_snapshot/bullseye.lock.json
+++ b/examples/debian_snapshot/bullseye.lock.json
@@ -102,69 +102,6 @@
 			"arch": "amd64",
 			"dependencies": [
 				{
-					"key": "debianutils_4.11.2_amd64",
-					"name": "debianutils",
-					"version": "4.11.2"
-				},
-				{
-					"key": "libc6_2.31-13-p-deb11u8_amd64",
-					"name": "libc6",
-					"version": "2.31-13+deb11u8"
-				},
-				{
-					"key": "libcrypt1_1-4.4.18-4_amd64",
-					"name": "libcrypt1",
-					"version": "1:4.4.18-4"
-				},
-				{
-					"key": "libgcc-s1_10.2.1-6_amd64",
-					"name": "libgcc-s1",
-					"version": "10.2.1-6"
-				},
-				{
-					"key": "gcc-10-base_10.2.1-6_amd64",
-					"name": "gcc-10-base",
-					"version": "10.2.1-6"
-				},
-				{
-					"key": "base-files_11.1-p-deb11u9_amd64",
-					"name": "base-files",
-					"version": "11.1+deb11u9"
-				},
-				{
-					"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
-					"name": "libtinfo6",
-					"version": "6.2+20201114-2+deb11u2"
-				}
-			],
-			"key": "bash_5.1-2-p-deb11u1_amd64",
-			"name": "bash",
-			"sha256": "f702ef058e762d7208a9c83f6f6bbf02645533bfd615c54e8cdcce842cd57377",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_amd64.deb",
-			"version": "5.1-2+deb11u1"
-		},
-		{
-			"arch": "amd64",
-			"dependencies": [],
-			"key": "debianutils_4.11.2_amd64",
-			"name": "debianutils",
-			"sha256": "83d21669c5957e3eaee20096a7d8c596bd07f57f1e95dc74f192b3fb7bb2e6a9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_amd64.deb",
-			"version": "4.11.2"
-		},
-		{
-			"arch": "amd64",
-			"dependencies": [],
-			"key": "base-files_11.1-p-deb11u9_amd64",
-			"name": "base-files",
-			"sha256": "1ff08cf6e1b97af1e37cda830f3658f9af43a906abb80a21951c81aea02ce230",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_amd64.deb",
-			"version": "11.1+deb11u9"
-		},
-		{
-			"arch": "amd64",
-			"dependencies": [
-				{
 					"key": "libselinux1_3.1-3_amd64",
 					"name": "libselinux1",
 					"version": "3.1-3"
@@ -1296,69 +1233,6 @@
 			"sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
 			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
 			"version": "2024a-0+deb11u1"
-		},
-		{
-			"arch": "arm64",
-			"dependencies": [
-				{
-					"key": "debianutils_4.11.2_arm64",
-					"name": "debianutils",
-					"version": "4.11.2"
-				},
-				{
-					"key": "libc6_2.31-13-p-deb11u8_arm64",
-					"name": "libc6",
-					"version": "2.31-13+deb11u8"
-				},
-				{
-					"key": "libcrypt1_1-4.4.18-4_arm64",
-					"name": "libcrypt1",
-					"version": "1:4.4.18-4"
-				},
-				{
-					"key": "libgcc-s1_10.2.1-6_arm64",
-					"name": "libgcc-s1",
-					"version": "10.2.1-6"
-				},
-				{
-					"key": "gcc-10-base_10.2.1-6_arm64",
-					"name": "gcc-10-base",
-					"version": "10.2.1-6"
-				},
-				{
-					"key": "base-files_11.1-p-deb11u9_arm64",
-					"name": "base-files",
-					"version": "11.1+deb11u9"
-				},
-				{
-					"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
-					"name": "libtinfo6",
-					"version": "6.2+20201114-2+deb11u2"
-				}
-			],
-			"key": "bash_5.1-2-p-deb11u1_arm64",
-			"name": "bash",
-			"sha256": "d7c7af5d86f43a885069408a89788f67f248e8124c682bb73936f33874e0611b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb",
-			"version": "5.1-2+deb11u1"
-		},
-		{
-			"arch": "arm64",
-			"dependencies": [],
-			"key": "debianutils_4.11.2_arm64",
-			"name": "debianutils",
-			"sha256": "6543b2b1a61b4b7b4b55b4bd25162309d7d23d14d3303649aee84ad314c30e02",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_arm64.deb",
-			"version": "4.11.2"
-		},
-		{
-			"arch": "arm64",
-			"dependencies": [],
-			"key": "base-files_11.1-p-deb11u9_arm64",
-			"name": "base-files",
-			"sha256": "c40dc4d5c6b82f5cfe75efa1a12bd09b9d5b9b8446ea045a991896a1ead8b02c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_arm64.deb",
-			"version": "11.1+deb11u9"
 		},
 		{
 			"arch": "arm64",

--- a/examples/debian_snapshot/bullseye.yaml
+++ b/examples/debian_snapshot/bullseye.yaml
@@ -25,7 +25,6 @@ packages:
   - "ncurses-base"
   - "libncurses6"
   - "tzdata"
-  - "bash"
   - "coreutils" # for commands like `ls`
   # for apt list --installed
   - "dpkg"

--- a/examples/debian_snapshot/bullseye_nolock.yaml
+++ b/examples/debian_snapshot/bullseye_nolock.yaml
@@ -1,0 +1,12 @@
+version: 1
+
+sources:
+  - channel: bullseye main
+    url: https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z
+
+archs:
+  - "amd64"
+  - "arm64"
+
+packages:
+  - "bash"


### PR DESCRIPTION
> [!NOTE]  
>  Stacked on top of #88 

## refactor: apt/tests
* make apt/tests more readable by factoring out the parameters

* add a "test suite macro" in each test file that group all of the unit tests in the file and prepends a "test suite prefix". IMHO this is  better than using `unittest.suite` because we provide better naming than the automated `_test<NUMBER>` plus these better names are actual targets that can be executed one-by-one by name.

## test: add a bullseye_nolock package to the tests
Add other nolock tests to exercise the package repos (the templates, etc).