### PR TITLE
refactor: package_index

### DIFF
--- a/apt/private/BUILD.bazel
+++ b/apt/private/BUILD.bazel
@@ -47,7 +47,7 @@ bzl_library(
     srcs = ["apt_deb_repository.bzl"],
     visibility = ["//apt:__subpackages__"],
     deps = [
-        ":util",
+        ":nested_dict",
         ":version_constraint",
     ],
 )
@@ -105,5 +105,11 @@ bzl_library(
 bzl_library(
     name = "util",
     srcs = ["util.bzl"],
+    visibility = ["//apt:__subpackages__"],
+)
+
+bzl_library(
+    name = "nested_dict",
+    srcs = ["nested_dict.bzl"],
     visibility = ["//apt:__subpackages__"],
 )

--- a/apt/private/BUILD.bazel
+++ b/apt/private/BUILD.bazel
@@ -70,6 +70,7 @@ bzl_library(
         ":apt_deb_repository",
         ":apt_dep_resolver",
         ":lockfile",
+        ":util",
         "@aspect_bazel_lib//lib:repo_utils",
     ],
 )

--- a/apt/private/apt_deb_repository.bzl
+++ b/apt/private/apt_deb_repository.bzl
@@ -3,9 +3,7 @@
 load(":util.bzl", "util")
 load(":version_constraint.bzl", "version_constraint")
 
-def _fetch_package_index(rctx, url, dist, comp, arch, integrity):
-    target_triple = "{dist}/{comp}/{arch}".format(dist = dist, comp = comp, arch = arch)
-
+def _fetch_package_index(rctx, url, dist, comp, arch):
     # See https://linux.die.net/man/1/xz , https://linux.die.net/man/1/gzip , and https://linux.die.net/man/1/bzip2
     #  --keep       -> keep the original file (Bazel might be still committing the output to the cache)
     #  --force      -> overwrite the output if it exists
@@ -15,47 +13,72 @@ def _fetch_package_index(rctx, url, dist, comp, arch, integrity):
         ".xz": ["xz", "--decompress", "--keep", "--force"],
         ".gz": ["gzip", "--decompress", "--keep", "--force"],
         ".bz2": ["bzip2", "--decompress", "--keep", "--force"],
-        "": ["true"],
+        "": None,
     }
 
     failed_attempts = []
 
-    for (ext, cmd) in supported_extensions.items():
-        output = "{}/Packages{}".format(target_triple, ext)
-        dist_url = "{}/dists/{}/{}/binary-{}/Packages{}".format(url, dist, comp, arch, ext)
+    for ext, cmd in supported_extensions.items():
+        index = "Packages"
+        index_full = "{}{}".format(index, ext) if ext else index
+
+        output = "{dist}/{comp}/{arch}/{index}".format(
+            dist = dist,
+            comp = comp,
+            arch = arch,
+            index = index,
+        )
+        output_full = "{}{}".format(output, ext) if ext else output
+
+        index_url = "{url}/dists/{dist}/{comp}/binary-{arch}/{index_full}".format(
+            url = url,
+            dist = dist,
+            comp = comp,
+            arch = arch,
+            index_full = index_full,
+        )
+
         download = rctx.download(
-            url = dist_url,
-            output = output,
-            integrity = integrity,
+            url = index_url,
+            output = output_full,
             allow_fail = True,
         )
-        decompress_r = None
-        if download.success:
-            decompress_r = rctx.execute(cmd + [output])
-            if decompress_r.return_code == 0:
-                integrity = download.integrity
-                break
 
-        failed_attempts.append((dist_url, download, decompress_r))
+        if not download.success:
+            reason = "Download failed. See warning above for details."
+            failed_attempts.append((index_url, reason))
+            continue
+
+        if cmd == None:
+            # index is already decompressed
+            break
+
+        decompress_cmd = cmd + [output_full]
+        decompress_res = rctx.execute(decompress_cmd)
+
+        if decompress_res.return_code == 0:
+            break
+
+        reason = "'{cmd}' returned a non-zero exit code: {return_code}"
+        reason += "\n\n{stderr}\n{stdout}"
+        reason = reason.format(
+            cmd = decompress_cmd,
+            return_code = decompress_res.return_code,
+            stderr = decompress_res.stderr,
+            stdout = decompress_res.stdout,
+        )
+
+        failed_attempts.append((index_url, reason))
 
     if len(failed_attempts) == len(supported_extensions):
-        attempt_messages = []
-        for (url, download, decompress) in failed_attempts:
-            reason = "unknown"
-            if not download.success:
-                reason = "Download failed. See warning above for details."
-            elif decompress.return_code != 0:
-                reason = "Decompression failed with non-zero exit code.\n\n{}\n{}".format(decompress.stderr, decompress.stdout)
+        attempt_messages = [
+            "\n  * '{}' FAILED:\n\n  {}".format(url, reason)
+            for url, reason in failed_attempts
+        ]
 
-            attempt_messages.append("""\n*) Failed '{}'\n\n{}""".format(url, reason))
+        fail("Failed to fetch packages index:\n" + "\n".join(attempt_messages))
 
-        fail("""
-** Tried to download {} different package indices and all failed. 
-
-{}
-        """.format(len(failed_attempts), "\n".join(attempt_messages)))
-
-    return ("{}/Packages".format(target_triple), integrity)
+    return rctx.read(output)
 
 def _parse_repository(state, contents, root):
     last_key = ""
@@ -125,12 +148,13 @@ def _create(rctx, sources, archs):
             # on misconfigured HTTP servers)
             url = url.rstrip("/")
 
-            rctx.report_progress("Fetching package index: {}/{} for {}".format(dist, comp, arch))
-            (output, _) = _fetch_package_index(rctx, url, dist, comp, arch, "")
+            index = "{}/{} for {}".format(dist, comp, arch)
 
-            # TODO: this is expensive to perform.
-            rctx.report_progress("Parsing package index: {}/{} for {}".format(dist, comp, arch))
-            _parse_repository(state, rctx.read(output), url)
+            rctx.report_progress("Fetching package index: %s" % index)
+            output = _fetch_package_index(rctx, url, dist, comp, arch)
+
+            rctx.report_progress("Parsing package index: %s" % index)
+            _parse_repository(state, output, url)
 
     return struct(
         package_versions = lambda **kwargs: _package_versions(state, **kwargs),

--- a/apt/private/apt_deb_repository.bzl
+++ b/apt/private/apt_deb_repository.bzl
@@ -124,16 +124,16 @@ def _add_package(state, package):
         vp.append((provides, package))
         util.set_dict(state.virtual_packages, vp, (package["Architecture"], provides["name"]))
 
-def _virtual_packages(state, name, arch):
+def _virtual_packages(state, arch, name):
     return util.get_dict(state.virtual_packages, [arch, name], [])
 
-def _package_versions(state, name, arch):
+def _package_versions(state, arch, name):
     return util.get_dict(state.packages, [arch, name], {}).keys()
 
-def _package(state, name, version, arch):
+def _package(state, arch, name, version):
     return util.get_dict(state.packages, keys = (arch, name, version))
 
-def _create(rctx, sources, archs):
+def _new(rctx, sources, archs):
     state = struct(
         packages = dict(),
         virtual_packages = dict(),
@@ -157,13 +157,13 @@ def _create(rctx, sources, archs):
             _parse_repository(state, output, url)
 
     return struct(
-        package_versions = lambda **kwargs: _package_versions(state, **kwargs),
-        virtual_packages = lambda **kwargs: _virtual_packages(state, **kwargs),
-        package = lambda **kwargs: _package(state, **kwargs),
+        package_versions = lambda arch, name: _package_versions(state, arch, name),
+        virtual_packages = lambda arch, name: _virtual_packages(state, arch, name),
+        package = lambda arch, name, version: _package(state, arch, name, version),
     )
 
 deb_repository = struct(
-    new = _create,
+    new = _new,
 )
 
 # TESTONLY: DO NOT DEPEND ON THIS
@@ -174,9 +174,9 @@ def _create_test_only():
     )
 
     return struct(
-        package_versions = lambda **kwargs: _package_versions(state, **kwargs),
-        virtual_packages = lambda **kwargs: _virtual_packages(state, **kwargs),
-        package = lambda **kwargs: _package(state, **kwargs),
+        package_versions = lambda arch, name: _package_versions(state, arch, name),
+        virtual_packages = lambda arch, name: _virtual_packages(state, arch, name),
+        package = lambda arch, name, version: _package(state, arch, name, version),
         parse_repository = lambda contents: _parse_repository(state, contents, "http://nowhere"),
         packages = state.packages,
         reset = lambda: state.packages.clear(),

--- a/apt/private/apt_deb_repository.bzl
+++ b/apt/private/apt_deb_repository.bzl
@@ -122,7 +122,7 @@ def _add_package(state, package):
 
     # https://www.debian.org/doc/debian-policy/ch-relationships.html#virtual-packages-provides
     if "Provides" in package:
-        provides = version_constraint.parse_dep(package["Provides"])
+        provides = version_constraint.parse_provides(package["Provides"])
 
         state.virtual_packages.add(
             keys = (package["Architecture"], provides["name"]),

--- a/apt/private/apt_deb_repository.bzl
+++ b/apt/private/apt_deb_repository.bzl
@@ -1,6 +1,6 @@
 "https://wiki.debian.org/DebianRepository"
 
-load(":util.bzl", "util")
+load(":nested_dict.bzl", "nested_dict")
 load(":version_constraint.bzl", "version_constraint")
 
 def _fetch_package_index(rctx, url, dist, comp, arch):
@@ -115,28 +115,24 @@ def _parse_repository(state, contents, root):
             pkg = {}
 
 def _add_package(state, package):
-    util.set_dict(state.packages, value = package, keys = (package["Architecture"], package["Package"], package["Version"]))
+    state.packages.set(
+        keys = (package["Architecture"], package["Package"], package["Version"]),
+        value = package,
+    )
 
     # https://www.debian.org/doc/debian-policy/ch-relationships.html#virtual-packages-provides
     if "Provides" in package:
         provides = version_constraint.parse_dep(package["Provides"])
-        vp = util.get_dict(state.virtual_packages, (package["Architecture"], provides["name"]), [])
-        vp.append((provides, package))
-        util.set_dict(state.virtual_packages, vp, (package["Architecture"], provides["name"]))
 
-def _virtual_packages(state, arch, name):
-    return util.get_dict(state.virtual_packages, [arch, name], [])
-
-def _package_versions(state, arch, name):
-    return util.get_dict(state.packages, [arch, name], {}).keys()
-
-def _package(state, arch, name, version):
-    return util.get_dict(state.packages, keys = (arch, name, version))
+        state.virtual_packages.add(
+            keys = (package["Architecture"], provides["name"]),
+            value = (provides, package),
+        )
 
 def _new(rctx, sources, archs):
     state = struct(
-        packages = dict(),
-        virtual_packages = dict(),
+        packages = nested_dict.new(),
+        virtual_packages = nested_dict.new(),
     )
 
     for arch in archs:
@@ -157,9 +153,9 @@ def _new(rctx, sources, archs):
             _parse_repository(state, output, url)
 
     return struct(
-        package_versions = lambda arch, name: _package_versions(state, arch, name),
-        virtual_packages = lambda arch, name: _virtual_packages(state, arch, name),
-        package = lambda arch, name, version: _package(state, arch, name, version),
+        package_versions = lambda arch, name: state.packages.get((arch, name), {}).keys(),
+        virtual_packages = lambda arch, name: state.virtual_packages.get((arch, name), []),
+        package = lambda arch, name, version: state.packages.get((arch, name, version)),
     )
 
 deb_repository = struct(
@@ -169,14 +165,14 @@ deb_repository = struct(
 # TESTONLY: DO NOT DEPEND ON THIS
 def _create_test_only():
     state = struct(
-        packages = dict(),
-        virtual_packages = dict(),
+        packages = nested_dict.new(),
+        virtual_packages = nested_dict.new(),
     )
 
     return struct(
-        package_versions = lambda arch, name: _package_versions(state, arch, name),
-        virtual_packages = lambda arch, name: _virtual_packages(state, arch, name),
-        package = lambda arch, name, version: _package(state, arch, name, version),
+        package_versions = lambda arch, name: state.packages.get((arch, name), {}).keys(),
+        virtual_packages = lambda arch, name: state.virtual_packages.get((arch, name), []),
+        package = lambda arch, name, version: state.packages.get((arch, name, version)),
         parse_repository = lambda contents: _parse_repository(state, contents, "http://nowhere"),
         packages = state.packages,
         reset = lambda: state.packages.clear(),

--- a/apt/private/apt_deb_repository.bzl
+++ b/apt/private/apt_deb_repository.bzl
@@ -165,23 +165,3 @@ deb_repository = struct(
         _parse_package_index = _parse_package_index,
     ),
 )
-
-# TESTONLY: DO NOT DEPEND ON THIS
-def _create_test_only():
-    state = struct(
-        packages = nested_dict.new(),
-        virtual_packages = nested_dict.new(),
-    )
-
-    return struct(
-        package_versions = lambda arch, name: state.packages.get((arch, name), {}).keys(),
-        virtual_packages = lambda arch, name: state.virtual_packages.get((arch, name), []),
-        package = lambda arch, name, version: state.packages.get((arch, name, version)),
-        parse_package_index = lambda contents: _parse_package_index(state, contents, "http://nowhere"),
-        packages = state.packages,
-        reset = lambda: state.packages.clear(),
-    )
-
-DO_NOT_DEPEND_ON_THIS_TEST_ONLY = struct(
-    new = _create_test_only,
-)

--- a/apt/private/apt_deb_repository.bzl
+++ b/apt/private/apt_deb_repository.bzl
@@ -80,7 +80,7 @@ def _fetch_package_index(rctx, url, dist, comp, arch):
 
     return rctx.read(output)
 
-def _parse_repository(state, contents, root):
+def _parse_package_index(state, contents, root):
     last_key = ""
     pkg = {}
     for group in contents.split("\n\n"):
@@ -150,7 +150,7 @@ def _new(rctx, sources, archs):
             output = _fetch_package_index(rctx, url, dist, comp, arch)
 
             rctx.report_progress("Parsing package index: %s" % index)
-            _parse_repository(state, output, url)
+            _parse_package_index(state, output, url)
 
     return struct(
         package_versions = lambda arch, name: state.packages.get((arch, name), {}).keys(),
@@ -160,6 +160,10 @@ def _new(rctx, sources, archs):
 
 deb_repository = struct(
     new = _new,
+    __test__ = struct(
+        _fetch_package_index = _fetch_package_index,
+        _parse_package_index = _parse_package_index,
+    ),
 )
 
 # TESTONLY: DO NOT DEPEND ON THIS
@@ -173,7 +177,7 @@ def _create_test_only():
         package_versions = lambda arch, name: state.packages.get((arch, name), {}).keys(),
         virtual_packages = lambda arch, name: state.virtual_packages.get((arch, name), []),
         package = lambda arch, name, version: state.packages.get((arch, name, version)),
-        parse_repository = lambda contents: _parse_repository(state, contents, "http://nowhere"),
+        parse_package_index = lambda contents: _parse_package_index(state, contents, "http://nowhere"),
         packages = state.packages,
         reset = lambda: state.packages.clear(),
     )

--- a/apt/private/apt_dep_resolver.bzl
+++ b/apt/private/apt_dep_resolver.bzl
@@ -24,13 +24,17 @@ def _resolve_package(repository, name, version, arch):
     selected_version = None
 
     if version:
-        for av in versions:
-            if version_constraint.relop(av, version[1], version[0]):
-                selected_version = av
+        op, vb = version
+        for va in versions:
+            if version_lib.compare(va, op, vb):
+                selected_version = va
 
-                # Since versions are ordered by hight to low, the first satisfied version will be
-                # the highest version and rules_distroless ignores Priority field so it's safe.
-                # TODO: rethink this `break` with https://github.com/GoogleContainerTools/rules_distroless/issues/34
+                # Since versions are ordered from high to low and
+                # rules_distroless ignores Priority, the first satisfied
+                # version will be the highest version.
+
+                # TODO: FR: support package priorities
+                # https://github.com/GoogleContainerTools/rules_distroless/issues/34
                 break
     elif len(versions) > 0:
         # First element in the versions list is the latest version.

--- a/apt/private/apt_dep_resolver.bzl
+++ b/apt/private/apt_dep_resolver.bzl
@@ -4,13 +4,16 @@ load(":version.bzl", version_lib = "version")
 load(":version_constraint.bzl", "version_constraint")
 
 def _resolve_package(repository, arch, name, version):
-    # First check if the constraint is satisfied by a virtual package
-    virtual_packages = repository.virtual_packages(arch, name)
-    for (provides, package) in virtual_packages:
-        provided_version = provides["version"]
-        if not provided_version and version:
-            continue
-        if provided_version and version:
+    if version:
+        # First check if the constraint is satisfied by a virtual package
+        virtual_packages = repository.virtual_packages(arch, name)
+
+        for provides, package in virtual_packages:
+            provided_version = provides["version"]
+
+            if not provided_version:
+                continue
+
             if version_constraint.is_satisfied_by(version, provided_version):
                 return package
 

--- a/apt/private/apt_dep_resolver.bzl
+++ b/apt/private/apt_dep_resolver.bzl
@@ -3,9 +3,9 @@
 load(":version.bzl", version_lib = "version")
 load(":version_constraint.bzl", "version_constraint")
 
-def _resolve_package(repository, name, version, arch):
+def _resolve_package(repository, arch, name, version):
     # First check if the constraint is satisfied by a virtual package
-    virtual_packages = repository.virtual_packages(name = name, arch = arch)
+    virtual_packages = repository.virtual_packages(arch, name)
     for (provides, package) in virtual_packages:
         provided_version = provides["version"]
         if not provided_version and version:
@@ -15,8 +15,8 @@ def _resolve_package(repository, name, version, arch):
                 return package
 
     # Get available versions of the package
-    versions_by_arch = repository.package_versions(name = name, arch = arch)
-    versions_by_any_arch = repository.package_versions(name = name, arch = "all")
+    versions_by_arch = repository.package_versions(arch, name)
+    versions_by_any_arch = repository.package_versions("all", name)
 
     # Order packages by highest to lowest
     versions = version_lib.sort(versions_by_arch + versions_by_any_arch, reverse = True)
@@ -40,9 +40,9 @@ def _resolve_package(repository, name, version, arch):
         # First element in the versions list is the latest version.
         selected_version = versions[0]
 
-    package = repository.package(name = name, version = selected_version, arch = arch)
+    package = repository.package(arch, name, selected_version)
     if not package:
-        package = repository.package(name = name, version = selected_version, arch = "all")
+        package = repository.package("all", name, selected_version)
 
     return package
 
@@ -51,9 +51,10 @@ _ITERATION_MAX_ = 2147483646
 # For future: unfortunately this function uses a few state variables to track
 # certain conditions and package dependency groups.
 # TODO: Try to simplify it in the future.
-def _resolve_all(repository, name, version, arch, include_transitive = True):
+def _resolve(repository, arch, name, version, include_transitive):
+    root_package_name = name
     root_package = None
-    unmet_dependencies = []
+    unresolved_dependencies = []
     dependencies = []
 
     # state variables
@@ -65,27 +66,32 @@ def _resolve_all(repository, name, version, arch, include_transitive = True):
         if not len(stack):
             break
         if i == _ITERATION_MAX_:
-            fail("resolve_all exhausted")
+            msg = "Reached _ITERATION_MAX_ trying to resolve %s"
+            fail(msg % root_package_name)
 
         (name, version, dependency_group_idx) = stack.pop()
 
-        # If this iteration is part of a dependency group, and the dependency group is already met, then skip this iteration.
+        # If this iteration is part of a dependency group, and the dependency
+        # group is already met, then skip this iteration.
         if dependency_group_idx > -1 and dependency_group[dependency_group_idx]:
             continue
 
-        package = _resolve_package(repository, name, version, arch)
+        package = _resolve_package(repository, arch, name, version)
 
-        # If this package is not found and is part of a dependency group, then just skip it.
+        # If this package is not found and is part of a dependency group, then
+        # just skip it.
         if not package and dependency_group_idx > -1:
             continue
 
-        # If this package is not found but is not part of a dependency group, then add it to unmet dependencies.
+        # If this package is not found but is not part of a dependency group,
+        # then add it to unresolved_dependencies.
         if not package:
             key = "%s~~%s" % (name, version[1] if version else "")
-            unmet_dependencies.append((name, version))
+            unresolved_dependencies.append((name, version))
             continue
 
-        # If this package was requested as part of a dependency group, then mark it's group as `dependency met`
+        # If this package was requested as part of a dependency group, then
+        # mark it's group as resolved.
         if dependency_group_idx > -1:
             dependency_group[dependency_group_idx] = True
 
@@ -126,11 +132,17 @@ def _resolve_all(repository, name, version, arch, include_transitive = True):
                 # TODO: arch
                 stack.append((dep["name"], dep["version"], -1))
 
-    return (root_package, dependencies, unmet_dependencies)
+    return root_package, dependencies, unresolved_dependencies
 
 def _new(repository):
     return struct(
-        resolve_all = lambda **kwargs: _resolve_all(repository, **kwargs),
+        resolve = lambda arch, name, version, include_transitive = True: _resolve(
+            repository,
+            arch,
+            name,
+            version,
+            include_transitive,
+        ),
     )
 
 dependency_resolver = struct(

--- a/apt/private/deb_resolve.bzl
+++ b/apt/private/deb_resolve.bzl
@@ -64,10 +64,10 @@ def internal_resolve(rctx, yq_toolchain_prefix, manifest, include_transitive):
             constraint = version_constraint.parse_depends(dep_constraint).pop()
 
             rctx.report_progress("Resolving %s" % dep_constraint)
-            (package, dependencies, unmet_dependencies) = resolver.resolve_all(
-                name = constraint["name"],
-                version = constraint["version"],
-                arch = arch,
+            package, dependencies, unmet_dependencies = resolver.resolve(
+                arch,
+                constraint["name"],
+                constraint["version"],
                 include_transitive = include_transitive,
             )
 

--- a/apt/private/nested_dict.bzl
+++ b/apt/private/nested_dict.bzl
@@ -1,0 +1,45 @@
+"nested dict"
+
+def _set(store, keys, value, add = False):
+    for key in keys[:-1]:
+        if key not in store:
+            store[key] = {}
+        store = store[key]
+
+    if add:
+        if keys[-1] not in store:
+            store[keys[-1]] = []
+
+        store[keys[-1]].append(value)
+    else:
+        store[keys[-1]] = value
+
+def _get(store, keys, default_value):
+    if not keys:
+        return default_value
+
+    value = store
+
+    for k in keys:
+        if k in value:
+            value = value[k]
+        else:
+            value = default_value
+            break
+
+    return value
+
+def _new():
+    store = {}
+
+    return struct(
+        set = lambda keys, value: _set(store, keys, value),
+        add = lambda keys, value: _set(store, keys, value, add = True),
+        get = lambda keys, default_value = None: _get(store, keys, default_value),
+        has = lambda keys: _get(store, keys, default_value = None) != None,
+        clear = lambda: store.clear(),
+    )
+
+nested_dict = struct(
+    new = _new,
+)

--- a/apt/private/util.bzl
+++ b/apt/private/util.bzl
@@ -1,25 +1,5 @@
 "utilities"
 
-def _set_dict(struct, value = None, keys = []):
-    klen = len(keys)
-    for i in range(klen - 1):
-        k = keys[i]
-        if not k in struct:
-            struct[k] = {}
-        struct = struct[k]
-
-    struct[keys[-1]] = value
-
-def _get_dict(struct, keys = [], default_value = None):
-    value = struct
-    for k in keys:
-        if k in value:
-            value = value[k]
-        else:
-            value = default_value
-            break
-    return value
-
 def _sanitize(str):
     return str.replace("+", "-p-").replace(":", "-").replace("~", "_")
 
@@ -36,8 +16,6 @@ def _warning(rctx, message):
 
 util = struct(
     sanitize = _sanitize,
-    set_dict = _set_dict,
-    get_dict = _get_dict,
     warning = _warning,
     get_repo_name = _get_repo_name,
 )

--- a/apt/private/version.bzl
+++ b/apt/private/version.bzl
@@ -114,6 +114,14 @@ def _version_cmp_part(va, vb):
                 return res
     return 0
 
+VERSION_OPERATORS = {
+    ">>": lambda v: v == 1,
+    ">=": lambda v: v >= 0,
+    "<<": lambda v: v == -1,
+    "<=": lambda v: v <= 0,
+    "=": lambda v: v == 0,
+}
+
 def _compare_version(va, vb):
     vap = _parse_version(va)
     vbp = _parse_version(vb)
@@ -131,6 +139,16 @@ def _compare_version(va, vb):
     # compare debian revision
     return _version_cmp_part(vap[2] or "0", vbp[2] or "0")
 
+def _compare(va, op, vb):
+    if op not in VERSION_OPERATORS:
+        fail("unknown version operator: '%s'" % op)
+
+    res = _compare_version(va, vb)
+
+    operator = VERSION_OPERATORS[op]
+
+    return operator(res)
+
 def _sort(versions, reverse = False):
     vr = versions
     for i in range(len(vr)):
@@ -145,12 +163,8 @@ def _sort(versions, reverse = False):
     return vr
 
 version = struct(
+    VERSION_OPERATORS = VERSION_OPERATORS.keys(),
     parse = _parse_version,
-    cmp = lambda va, vb: _compare_version(va, vb),
-    gt = lambda va, vb: _compare_version(va, vb) == 1,
-    gte = lambda va, vb: _compare_version(va, vb) >= 0,
-    lt = lambda va, vb: _compare_version(va, vb) == -1,
-    lte = lambda va, vb: _compare_version(va, vb) <= 0,
-    eq = lambda va, vb: _compare_version(va, vb) == 0,
+    compare = _compare,
     sort = lambda versions, reverse = False: _sort(versions, reverse = reverse),
 )

--- a/apt/private/version_constraint.bzl
+++ b/apt/private/version_constraint.bzl
@@ -57,27 +57,13 @@ def _parse_depends(depends_raw):
 
     return depends
 
-def _version_relop(va, vb, op):
-    if op == "<<":
-        return version_lib.lt(va, vb)
-    elif op == ">>":
-        return version_lib.gt(va, vb)
-    elif op == "<=":
-        return version_lib.lte(va, vb)
-    elif op == ">=":
-        return version_lib.gte(va, vb)
-    elif op == "=":
-        return version_lib.eq(va, vb)
-    fail("unknown op %s" % op)
-
 def _is_satisfied_by(va, vb):
     if vb[0] != "=":
         fail("Per https://www.debian.org/doc/debian-policy/ch-relationships.html only = is allowed for Provides field.")
 
-    return _version_relop(va[1], vb[1], va[0])
+    return version_lib.compare(va[1], va[0], vb[1])
 
 version_constraint = struct(
-    relop = _version_relop,
     is_satisfied_by = _is_satisfied_by,
     parse_version_constraint = _parse_version_constraint,
     parse_depends = _parse_depends,

--- a/apt/private/version_constraint.bzl
+++ b/apt/private/version_constraint.bzl
@@ -74,9 +74,24 @@ def _is_satisfied_by(va, vb):
 
     return version_lib.compare(va[1], va[0], vb[1])
 
+def _parse_provides(provides_raw):
+    provides = _parse_dep(provides_raw)
+
+    if not provides["version"]:
+        return provides
+
+    op, version = provides["version"]
+
+    if op != "=":
+        msg = "Invalid constraint: {}. Only '=' is allowed in 'Provides', see "
+        msg += "https://www.debian.org/doc/debian-policy/ch-relationships.html"
+        fail(msg.format(op))
+
+    return provides
+
 version_constraint = struct(
     is_satisfied_by = _is_satisfied_by,
     parse_version_constraint = _parse_version_constraint,
     parse_depends = _parse_depends,
-    parse_dep = _parse_dep,
+    parse_provides = _parse_provides,
 )

--- a/apt/private/version_constraint.bzl
+++ b/apt/private/version_constraint.bzl
@@ -2,11 +2,22 @@
 
 load(":version.bzl", version_lib = "version")
 
-def _parse_version_constraint(rawv):
-    vconst_i = rawv.find(" ")
-    if vconst_i == -1:
-        fail('invalid version string %s expected a version constraint ">=", "=", ">=", "<<", ">>"' % rawv)
-    return (rawv[:vconst_i], rawv[vconst_i + 1:])
+def _parse_version_constraint(version_and_constraint):
+    chunks = version_and_constraint.split(" ")
+
+    if len(chunks) != 2:
+        fail("Invalid version constraint %s" % version_and_constraint)
+
+    version_constraint = chunks[0]
+    if version_constraint not in version_lib.VERSION_OPERATORS:
+        msg = "Invalid version constraint: %s\nValid constraints are: %s"
+        fail(msg % (version_constraint, version_lib.VERSION_OPERATORS))
+
+    version = chunks[1]
+
+    version_lib.parse(version)  # parsing version to validate it
+
+    return version_constraint, version
 
 def _parse_dep(raw):
     raw = raw.strip()  # remove leading & trailing whitespace

--- a/apt/tests/BUILD.bazel
+++ b/apt/tests/BUILD.bazel
@@ -1,6 +1,7 @@
 load(":apt_deb_repository_test.bzl", "apt_deb_repository_tests")
 load(":apt_dep_resolver_test.bzl", "apt_dep_resolver_tests")
 load(":nested_dict_test.bzl", "nested_dict_tests")
+load(":util_test.bzl", "util_tests")
 load(":version_constraint_test.bzl", "version_constraint_tests")
 load(":version_test.bzl", "version_tests")
 
@@ -9,6 +10,8 @@ apt_deb_repository_tests()
 apt_dep_resolver_tests()
 
 nested_dict_tests()
+
+util_tests()
 
 version_tests()
 

--- a/apt/tests/BUILD.bazel
+++ b/apt/tests/BUILD.bazel
@@ -1,8 +1,11 @@
 load(":apt_dep_resolver_test.bzl", "apt_dep_resolver_tests")
+load(":nested_dict_test.bzl", "nested_dict_tests")
 load(":version_constraint_test.bzl", "version_constraint_tests")
 load(":version_test.bzl", "version_tests")
 
 apt_dep_resolver_tests()
+
+nested_dict_tests()
 
 version_tests()
 

--- a/apt/tests/BUILD.bazel
+++ b/apt/tests/BUILD.bazel
@@ -1,6 +1,9 @@
 load(":resolution_test.bzl", "resolution_tests")
+load(":version_constraint_test.bzl", "version_constraint_tests")
 load(":version_test.bzl", "version_tests")
 
 version_tests()
+
+version_constraint_tests()
 
 resolution_tests()

--- a/apt/tests/BUILD.bazel
+++ b/apt/tests/BUILD.bazel
@@ -1,9 +1,9 @@
-load(":resolution_test.bzl", "resolution_tests")
+load(":apt_dep_resolver_test.bzl", "apt_dep_resolver_tests")
 load(":version_constraint_test.bzl", "version_constraint_tests")
 load(":version_test.bzl", "version_tests")
+
+apt_dep_resolver_tests()
 
 version_tests()
 
 version_constraint_tests()
-
-resolution_tests()

--- a/apt/tests/BUILD.bazel
+++ b/apt/tests/BUILD.bazel
@@ -1,7 +1,10 @@
+load(":apt_deb_repository_test.bzl", "apt_deb_repository_tests")
 load(":apt_dep_resolver_test.bzl", "apt_dep_resolver_tests")
 load(":nested_dict_test.bzl", "nested_dict_tests")
 load(":version_constraint_test.bzl", "version_constraint_tests")
 load(":version_test.bzl", "version_tests")
+
+apt_deb_repository_tests()
 
 apt_dep_resolver_tests()
 

--- a/apt/tests/apt_deb_repository_test.bzl
+++ b/apt/tests/apt_deb_repository_test.bzl
@@ -1,0 +1,119 @@
+"unit tests for debian repositories"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//apt/private:apt_deb_repository.bzl", "deb_repository")
+load("//apt/private:nested_dict.bzl", "nested_dict")
+load("//apt/tests:mocks.bzl", "mock")
+load("//apt/tests:util.bzl", "test_util")
+
+_TEST_SUITE_PREFIX = "apt_deb_repository/"
+
+def new_setup(pkgs = None):
+    if pkgs:
+        arch = pkgs[0]["Architecture"]
+        name = pkgs[0]["Version"]
+        versions = [pkg["Version"] for pkg in pkgs]
+    else:
+        arch = "arm64"
+        name = "foo"
+        versions = ["0.3.20-1~bullseye.1", "1.5.1", "1.5.2"]
+
+        pkgs = [
+            mock.pkg(package = name, architecture = arch, version = v)
+            for v in versions
+        ]
+
+    packages_index_content = mock.packages_index_content(*pkgs)
+
+    mock_rctx = mock.rctx(
+        read = mock.read(packages_index_content),
+        download = mock.download(success = True),
+        execute = mock.execute([struct(return_code = 0)]),
+    )
+
+    return struct(
+        url = mock.URL,
+        dist = "bullseye",
+        comp = "main",
+        pkgs = pkgs,
+        pkg = pkgs[0],
+        arch = arch,
+        name = name,
+        versions = versions,
+        version = versions[0],
+        packages_index_content = packages_index_content,
+        mock_rctx = mock_rctx,
+    )
+
+def _fetch_package_index_test(ctx):
+    env = unittest.begin(ctx)
+
+    setup = new_setup()
+
+    actual = deb_repository.__test__._fetch_package_index(
+        setup.mock_rctx,
+        setup.url,
+        setup.dist,
+        setup.comp,
+        setup.arch,
+    )
+
+    asserts.equals(env, setup.packages_index_content, actual)
+
+    return unittest.end(env)
+
+fetch_package_index_test = unittest.make(_fetch_package_index_test)
+
+def _parse_package_index_test(ctx):
+    env = unittest.begin(ctx)
+
+    setup = new_setup()
+
+    state = struct(
+        packages = nested_dict.new(),
+        virtual_packages = nested_dict.new(),
+    )
+
+    deb_repository.__test__._parse_package_index(
+        state,
+        setup.packages_index_content,
+        setup.url,
+    )
+
+    actual_pkg = state.packages.get((setup.arch, setup.name, setup.version))
+
+    test_util.asserts.dict_equals(env, setup.pkg, actual_pkg)
+
+    return unittest.end(env)
+
+parse_package_index_test = unittest.make(_parse_package_index_test)
+
+def _new_test(ctx):
+    env = unittest.begin(ctx)
+
+    setup = new_setup()
+
+    repository = deb_repository.new(
+        setup.mock_rctx,
+        sources = [(setup.url, setup.dist, setup.comp)],
+        archs = [setup.arch],
+    )
+
+    actual_versions = repository.package_versions(setup.arch, setup.name)
+    asserts.equals(env, setup.versions, actual_versions)
+
+    for expected_pkg in setup.pkgs:
+        version = expected_pkg["Version"]
+
+        actual_pkg = repository.package(setup.arch, setup.name, version)
+
+        test_util.asserts.dict_equals(env, expected_pkg, actual_pkg)
+
+    return unittest.end(env)
+
+new_test = unittest.make(_new_test)
+
+def apt_deb_repository_tests():
+    fetch_package_index_test(name = _TEST_SUITE_PREFIX + "_fetch_package_index")
+    parse_package_index_test(name = _TEST_SUITE_PREFIX + "_parse_package_index")
+    new_test(name = _TEST_SUITE_PREFIX + "new")

--- a/apt/tests/apt_dep_resolver_test.bzl
+++ b/apt/tests/apt_dep_resolver_test.bzl
@@ -15,7 +15,7 @@ def _make_index():
         kwargs["architecture"] = kwargs.get("architecture", _test_arch)
         kwargs["version"] = kwargs.get("version", _test_version)
         r = "\n".join(["{}: {}".format(item[0].title(), item[1]) for item in kwargs.items()])
-        idx.parse_repository(r)
+        idx.parse_package_index(r)
 
     return struct(
         add_package = lambda **kwargs: _add_package(idx, **kwargs),

--- a/apt/tests/apt_dep_resolver_test.bzl
+++ b/apt/tests/apt_dep_resolver_test.bzl
@@ -120,9 +120,9 @@ def _resolve_aliases(ctx):
 
 resolve_aliases_test = unittest.make(_resolve_aliases)
 
-_TEST_SUITE_PREFIX = "package_resolution/"
+_TEST_SUITE_PREFIX = "apt_dep_resolver/"
 
-def resolution_tests():
+def apt_dep_resolver_tests():
     resolve_optionals_test(name = _TEST_SUITE_PREFIX + "resolve_optionals")
     resolve_architecture_specific_packages_test(name = _TEST_SUITE_PREFIX + "resolve_architectures_specific")
     resolve_aliases_test(name = _TEST_SUITE_PREFIX + "resolve_aliases")

--- a/apt/tests/apt_dep_resolver_test.bzl
+++ b/apt/tests/apt_dep_resolver_test.bzl
@@ -1,41 +1,57 @@
 "unit tests for resolution of package dependencies"
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//apt/private:apt_deb_repository.bzl", deb_repository = "DO_NOT_DEPEND_ON_THIS_TEST_ONLY")
+load("//apt/private:apt_deb_repository.bzl", "deb_repository")
 load("//apt/private:apt_dep_resolver.bzl", "dependency_resolver")
+load("//apt/tests:apt_deb_repository_test.bzl", idx_mock_setup = "new_setup")
+load("//apt/tests:mocks.bzl", "mock")
 
-_test_version = "2.38.1-5"
-_test_arch = "amd64"
+_TEST_SUITE_PREFIX = "apt_dep_resolver/"
 
-def _make_index():
-    idx = deb_repository.new()
-    resolution = dependency_resolver.new(idx)
+def _pkg(name, **kwargs):
+    pkg_ = {
+        "package": name,
+        "architecture": "amd64",
+        "version": "2.38.1-5",
+    }
 
-    def _add_package(idx, **kwargs):
-        kwargs["architecture"] = kwargs.get("architecture", _test_arch)
-        kwargs["version"] = kwargs.get("version", _test_version)
-        r = "\n".join(["{}: {}".format(item[0].title(), item[1]) for item in kwargs.items()])
-        idx.parse_package_index(r)
+    pkg_ |= kwargs
+
+    return mock.pkg(**pkg_)
+
+def _setup(pkgs):
+    setup = idx_mock_setup(pkgs)
+
+    idx_mock = deb_repository.new(
+        setup.mock_rctx,
+        sources = [(setup.url, setup.dist, setup.comp)],
+        archs = [setup.arch],
+    )
+
+    resolution = dependency_resolver.new(idx_mock)
 
     return struct(
-        add_package = lambda **kwargs: _add_package(idx, **kwargs),
+        idx_mock = idx_mock,
         resolution = resolution,
-        reset = lambda: idx.reset(),
+        arch = setup.arch,
+        version = setup.version,
     )
 
 def _resolve_optionals_test(ctx):
     env = unittest.begin(ctx)
 
-    idx = _make_index()
-
     # Should pick the first alternative
-    idx.add_package(package = "libc6-dev")
-    idx.add_package(package = "eject", depends = "libc6-dev | libc-dev")
+    pkgs = [
+        _pkg("libc6-dev"),
+        _pkg("eject", depends = "libc6-dev | libc-dev"),
+    ]
 
-    root_package, dependencies, unresolved_deps = idx.resolution.resolve(
-        arch = _test_arch,
+    setup = _setup(pkgs)
+
+    root_package, dependencies, unresolved_deps = setup.resolution.resolve(
+        arch = setup.arch,
         name = "eject",
-        version = ("=", _test_version),
+        version = ("=", setup.version),
     )
     asserts.equals(env, "eject", root_package["Package"])
     asserts.equals(env, "libc6-dev", dependencies[0]["Package"])
@@ -49,18 +65,20 @@ resolve_optionals_test = unittest.make(_resolve_optionals_test)
 def _resolve_arch_specific_packages_test(ctx):
     env = unittest.begin(ctx)
 
-    idx = _make_index()
-
     #  Should pick bar for amd64 and foo for i386
-    idx.add_package(package = "foo", architecture = "i386")
-    idx.add_package(package = "bar", architecture = "amd64")
-    idx.add_package(package = "glibc", architecture = "all", depends = "foo [i386], bar [amd64]")
+    pkgs = [
+        _pkg("foo", architecture = "i386"),
+        _pkg("bar", architecture = "amd64"),
+        _pkg("glibc", architecture = "all", depends = "foo [i386], bar [amd64]"),
+    ]
+
+    setup = _setup(pkgs)
 
     # bar for amd64
-    root_package, dependencies, unresolved_deps = idx.resolution.resolve(
+    root_package, dependencies, unresolved_deps = setup.resolution.resolve(
         arch = "amd64",
         name = "glibc",
-        version = ("=", _test_version),
+        version = ("=", setup.version),
     )
     asserts.equals(env, "glibc", root_package["Package"])
     asserts.equals(env, "all", root_package["Architecture"])
@@ -69,10 +87,10 @@ def _resolve_arch_specific_packages_test(ctx):
     asserts.equals(env, 1, len(unresolved_deps))
 
     # foo for i386
-    root_package, dependencies, unresolved_deps = idx.resolution.resolve(
+    root_package, dependencies, unresolved_deps = setup.resolution.resolve(
         arch = "i386",
         name = "glibc",
-        version = ("=", _test_version),
+        version = ("=", setup.version),
     )
     asserts.equals(env, "glibc", root_package["Package"])
     asserts.equals(env, "all", root_package["Architecture"])
@@ -84,37 +102,21 @@ def _resolve_arch_specific_packages_test(ctx):
 
 resolve_arch_specific_packages_test = unittest.make(_resolve_arch_specific_packages_test)
 
-def _resolve_aliases(ctx):
+def _resolve_aliases_1(ctx):
     env = unittest.begin(ctx)
 
-    idx = _make_index()
+    pkgs = [
+        _pkg("foo", depends = "bar (>= 1.0)"),
+        _pkg("bar", version = "0.9"),
+        _pkg("bar-plus", provides = "bar (= 1.0)"),
+    ]
 
-    idx.add_package(package = "foo", depends = "bar (>= 1.0)")
-    idx.add_package(package = "bar", version = "0.9")
-    idx.add_package(package = "bar-plus", provides = "bar (= 1.0)")
+    setup = _setup(pkgs)
 
-    root_package, dependencies, unresolved_deps = idx.resolution.resolve(
+    root_package, dependencies, unresolved_deps = setup.resolution.resolve(
         arch = "amd64",
         name = "foo",
-        version = ("=", _test_version),
-    )
-    asserts.equals(env, "foo", root_package["Package"])
-    asserts.equals(env, "amd64", root_package["Architecture"])
-    asserts.equals(env, "bar-plus", dependencies[0]["Package"])
-    asserts.equals(env, 1, len(dependencies))
-    asserts.equals(env, 0, len(unresolved_deps))
-
-    idx.reset()
-
-    idx.add_package(package = "foo", depends = "bar (>= 1.0)")
-    idx.add_package(package = "bar", version = "0.9")
-    idx.add_package(package = "bar-plus", provides = "bar (= 1.0)")
-    idx.add_package(package = "bar-clone", provides = "bar")
-
-    root_package, dependencies, unresolved_deps = idx.resolution.resolve(
-        arch = "amd64",
-        name = "foo",
-        version = ("=", _test_version),
+        version = ("=", setup.version),
     )
     asserts.equals(env, "foo", root_package["Package"])
     asserts.equals(env, "amd64", root_package["Architecture"])
@@ -124,11 +126,37 @@ def _resolve_aliases(ctx):
 
     return unittest.end(env)
 
-resolve_aliases_test = unittest.make(_resolve_aliases)
+resolve_aliases_1_test = unittest.make(_resolve_aliases_1)
 
-_TEST_SUITE_PREFIX = "apt_dep_resolver/"
+def _resolve_aliases_2(ctx):
+    env = unittest.begin(ctx)
+
+    pkgs = [
+        _pkg("foo", depends = "bar (>= 1.0)"),
+        _pkg("bar", version = "0.9"),
+        _pkg("bar-plus", provides = "bar (= 1.0)"),
+        _pkg("bar-clone", provides = "bar"),
+    ]
+
+    setup = _setup(pkgs)
+
+    root_package, dependencies, unresolved_deps = setup.resolution.resolve(
+        arch = "amd64",
+        name = "foo",
+        version = ("=", setup.version),
+    )
+    asserts.equals(env, "foo", root_package["Package"])
+    asserts.equals(env, "amd64", root_package["Architecture"])
+    asserts.equals(env, "bar-plus", dependencies[0]["Package"])
+    asserts.equals(env, 1, len(dependencies))
+    asserts.equals(env, 0, len(unresolved_deps))
+
+    return unittest.end(env)
+
+resolve_aliases_2_test = unittest.make(_resolve_aliases_2)
 
 def apt_dep_resolver_tests():
     resolve_optionals_test(name = _TEST_SUITE_PREFIX + "resolve_optionals")
     resolve_arch_specific_packages_test(name = _TEST_SUITE_PREFIX + "resolve_arch_specific")
-    resolve_aliases_test(name = _TEST_SUITE_PREFIX + "resolve_aliases")
+    resolve_aliases_1_test(name = _TEST_SUITE_PREFIX + "resolve_aliases_1")
+    resolve_aliases_2_test(name = _TEST_SUITE_PREFIX + "resolve_aliases_2")

--- a/apt/tests/mocks.bzl
+++ b/apt/tests/mocks.bzl
@@ -1,0 +1,55 @@
+"mocks for unit tests"
+
+URL = "http://nowhere"
+
+def _execute(arguments = None, **kwargs):
+    return lambda *args, **kwargs: arguments.pop() if arguments else None
+
+def _report_progress():
+    return lambda msg: None
+
+def _read(read_output = None):
+    return lambda filename: read_output
+
+def _download(success):
+    return lambda *args, **kwargs: struct(success = success)
+
+def _rctx(**kwargs):
+    if "execute" not in kwargs:
+        kwargs["execute"] = _execute([])
+
+    if "report_progress" not in kwargs:
+        kwargs["report_progress"] = _report_progress()
+
+    return struct(**kwargs)
+
+def _pkg(package, **kwargs):
+    defaults = {
+        "Package": package,
+        "Root": URL,
+    }
+
+    pkg = {k.title().replace("_", "-"): v for k, v in kwargs.items()}
+
+    return defaults | pkg
+
+def _pkg_index(pkg):
+    return "\n".join([
+        "{}: {}".format(k, v)
+        for k, v in pkg.items()
+    ]) + "\n\n"
+
+def _packages_index_content(*pkgs):
+    return "".join([_pkg_index(pkg) for pkg in pkgs])
+
+mock = struct(
+    URL = URL,
+    execute = _execute,
+    rctx = _rctx,
+    report_progress = _report_progress,
+    read = _read,
+    download = _download,
+    pkg = _pkg,
+    pkg_index = _pkg_index,
+    packages_index_content = _packages_index_content,
+)

--- a/apt/tests/nested_dict_test.bzl
+++ b/apt/tests/nested_dict_test.bzl
@@ -1,0 +1,87 @@
+"unit tests for nested dict"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//apt/private:nested_dict.bzl", "nested_dict")
+
+_TEST_SUITE_PREFIX = "nested_dict/"
+
+def _get_empty_test(ctx):
+    env = unittest.begin(ctx)
+
+    nd = nested_dict.new()
+
+    asserts.equals(env, None, nd.get(keys = []))
+
+    return unittest.end(env)
+
+get_empty_test = unittest.make(_get_empty_test)
+
+def _set_get_test(ctx, nd = None):
+    env = unittest.begin(ctx)
+
+    nd = nd or nested_dict.new()
+
+    keys = ["foo", "bar", 42]
+    value = 31415927
+
+    nd.set(keys = keys, value = value)
+
+    asserts.true(env, nd.has(keys))
+    asserts.equals(env, value, nd.get(keys))
+
+    other_keys = ["foo", "bar", 43]
+    asserts.equals(env, False, nd.has(other_keys))
+
+    return unittest.end(env)
+
+set_get_test = unittest.make(_set_get_test)
+
+def _add_get_test(ctx, nd = None):
+    env = unittest.begin(ctx)
+
+    nd = nd or nested_dict.new()
+
+    keys = ["foobar", "baz"]
+
+    values = [1, 2, 3]
+
+    for value in values:
+        nd.add(keys = keys, value = value)
+
+    asserts.true(env, nd.has(keys))
+    asserts.equals(env, values, nd.get(keys))
+
+    return unittest.end(env)
+
+add_get_test = unittest.make(_add_get_test)
+
+def _clear_test(ctx):
+    env = unittest.begin(ctx)
+
+    nd = nested_dict.new()
+
+    _set_get_test(ctx, nd)
+    _add_get_test(ctx, nd)
+
+    all_keys = [
+        ["foobar", "baz"],
+        ["foo", "bar", 42],
+    ]
+
+    for keys in all_keys:
+        asserts.true(env, nd.has(keys))
+
+    nd.clear()
+
+    for keys in all_keys:
+        asserts.equals(env, False, nd.has(keys))
+
+    return unittest.end(env)
+
+clear_test = unittest.make(_clear_test)
+
+def nested_dict_tests():
+    get_empty_test(name = _TEST_SUITE_PREFIX + "get_empty")
+    set_get_test(name = _TEST_SUITE_PREFIX + "set_get")
+    add_get_test(name = _TEST_SUITE_PREFIX + "add_get")
+    clear_test(name = _TEST_SUITE_PREFIX + "clear")

--- a/apt/tests/resolution_test.bzl
+++ b/apt/tests/resolution_test.bzl
@@ -3,107 +3,6 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//apt/private:apt_deb_repository.bzl", deb_repository = "DO_NOT_DEPEND_ON_THIS_TEST_ONLY")
 load("//apt/private:apt_dep_resolver.bzl", "dependency_resolver")
-load("//apt/private:version_constraint.bzl", "version_constraint")
-
-def _parse_depends_test(ctx):
-    env = unittest.begin(ctx)
-
-    parameters = {
-        " | ".join([
-            "libc6 (>= 2.2.1), default-mta",
-            "mail-transport-agent",
-        ]): [
-            {"name": "libc6", "version": (">=", "2.2.1"), "arch": None},
-            [
-                {"name": "default-mta", "version": None, "arch": None},
-                {"name": "mail-transport-agent", "version": None, "arch": None},
-            ],
-        ],
-        ", ".join([
-            "libluajit5.1-dev [i386 amd64 powerpc mips]",
-            "liblua5.1-dev [hurd-i386 ia64 s390x sparc]",
-        ]): [
-            {
-                "name": "libluajit5.1-dev",
-                "version": None,
-                "arch": ["i386", "amd64", "powerpc", "mips"],
-            },
-            {
-                "name": "liblua5.1-dev",
-                "version": None,
-                "arch": ["hurd-i386", "ia64", "s390x", "sparc"],
-            },
-        ],
-        " | ".join([
-            "emacs",
-            "emacsen, make, debianutils (>= 1.7)",
-        ]): [
-            [
-                {"name": "emacs", "version": None, "arch": None},
-                {"name": "emacsen", "version": None, "arch": None},
-            ],
-            {"name": "make", "version": None, "arch": None},
-            {"name": "debianutils", "version": (">=", "1.7"), "arch": None},
-        ],
-        ", ".join([
-            "libcap-dev [!kfreebsd-i386 !hurd-i386]",
-            "autoconf",
-            "debhelper (>> 5.0.0)",
-            "file",
-            "libc6 (>= 2.7-1)",
-            "libpaper1",
-            "psutils",
-        ]): [
-            {"name": "libcap-dev", "version": None, "arch": ["!kfreebsd-i386", "!hurd-i386"]},
-            {"name": "autoconf", "version": None, "arch": None},
-            {"name": "debhelper", "version": (">>", "5.0.0"), "arch": None},
-            {"name": "file", "version": None, "arch": None},
-            {"name": "libc6", "version": (">=", "2.7-1"), "arch": None},
-            {"name": "libpaper1", "version": None, "arch": None},
-            {"name": "psutils", "version": None, "arch": None},
-        ],
-        "python3:any": [
-            {"name": "python3", "version": None, "arch": ["any"]},
-        ],
-        " | ".join([
-            "gcc-i686-linux-gnu (>= 4:10.2)",
-            "gcc:i386, g++-i686-linux-gnu (>= 4:10.2)",
-            "g++:i386, dpkg-cross",
-        ]): [
-            [
-                {"name": "gcc-i686-linux-gnu", "version": (">=", "4:10.2"), "arch": None},
-                {"name": "gcc", "version": None, "arch": ["i386"]},
-            ],
-            [
-                {"name": "g++-i686-linux-gnu", "version": (">=", "4:10.2"), "arch": None},
-                {"name": "g++", "version": None, "arch": ["i386"]},
-            ],
-            {"name": "dpkg-cross", "version": None, "arch": None},
-        ],
-        " | ".join([
-            "gcc-x86-64-linux-gnu (>= 4:10.2)",
-            "gcc:amd64, g++-x86-64-linux-gnu (>= 4:10.2)",
-            "g++:amd64, dpkg-cross",
-        ]): [
-            [
-                {"name": "gcc-x86-64-linux-gnu", "version": (">=", "4:10.2"), "arch": None},
-                {"name": "gcc", "version": None, "arch": ["amd64"]},
-            ],
-            [
-                {"name": "g++-x86-64-linux-gnu", "version": (">=", "4:10.2"), "arch": None},
-                {"name": "g++", "version": None, "arch": ["amd64"]},
-            ],
-            {"name": "dpkg-cross", "version": None, "arch": None},
-        ],
-    }
-
-    for deps, expected in parameters.items():
-        actual = version_constraint.parse_depends(deps)
-        asserts.equals(env, expected, actual)
-
-    return unittest.end(env)
-
-parse_depends_test = unittest.make(_parse_depends_test)
 
 _test_version = "2.38.1-5"
 _test_arch = "amd64"
@@ -224,7 +123,6 @@ resolve_aliases_test = unittest.make(_resolve_aliases)
 _TEST_SUITE_PREFIX = "package_resolution/"
 
 def resolution_tests():
-    parse_depends_test(name = _TEST_SUITE_PREFIX + "parse_depends")
     resolve_optionals_test(name = _TEST_SUITE_PREFIX + "resolve_optionals")
     resolve_architecture_specific_packages_test(name = _TEST_SUITE_PREFIX + "resolve_architectures_specific")
     resolve_aliases_test(name = _TEST_SUITE_PREFIX + "resolve_aliases")

--- a/apt/tests/util.bzl
+++ b/apt/tests/util.bzl
@@ -1,0 +1,16 @@
+"test utilities"
+
+load("@bazel_skylib//lib:sets.bzl", "sets")
+load("@bazel_skylib//lib:unittest.bzl", "asserts")
+
+def _asserts_dict_equals(env, edict, adict):
+    asserts.set_equals(env, sets.make(edict.keys()), sets.make(adict.keys()))
+
+    for key in edict.keys():
+        asserts.equals(env, edict[key], adict[key])
+
+test_util = struct(
+    asserts = struct(
+        dict_equals = _asserts_dict_equals,
+    ),
+)

--- a/apt/tests/util_test.bzl
+++ b/apt/tests/util_test.bzl
@@ -1,0 +1,26 @@
+"unit tests for util"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//apt/private:util.bzl", "util")
+
+_TEST_SUITE_PREFIX = "util/"
+
+def _sanitize_test(ctx):
+    env = unittest.begin(ctx)
+
+    parameters = {
+        "3.0.6+dfsg-4": "3.0.6-p-dfsg-4",
+        "8.8.1+ds+~cs25.17.7-2": "8.8.1-p-ds-p-_cs25.17.7-2",
+        "1:2020.1commit85143dcb-4": "1-2020.1commit85143dcb-4",
+    }
+
+    for s, expected in parameters.items():
+        actual = util.sanitize(s)
+        asserts.equals(env, expected, actual)
+
+    return unittest.end(env)
+
+sanitize_test = unittest.make(_sanitize_test)
+
+def util_tests():
+    sanitize_test(name = _TEST_SUITE_PREFIX + "sanitize")

--- a/apt/tests/version_constraint_test.bzl
+++ b/apt/tests/version_constraint_test.bzl
@@ -1,0 +1,151 @@
+"unit tests for version constraint"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//apt/private:version_constraint.bzl", "version_constraint")
+
+_TEST_SUITE_PREFIX = "version_constraint/"
+
+def _parse_version_constraint_test(ctx):
+    parameters = {
+        ">= 1.4.1": (">=", "1.4.1"),
+        "<< 7.1.ds-1": ("<<", "7.1.ds-1"),
+    }
+
+    env = unittest.begin(ctx)
+
+    for vac, expected in parameters.items():
+        actual = version_constraint.parse_version_constraint(vac)
+        asserts.equals(env, actual, expected)
+
+    return unittest.end(env)
+
+parse_version_constraint_test = unittest.make(_parse_version_constraint_test)
+
+def _parse_depends_test(ctx):
+    env = unittest.begin(ctx)
+
+    parameters = {
+        " | ".join([
+            "libc6 (>= 2.2.1), default-mta",
+            "mail-transport-agent",
+        ]): [
+            {"name": "libc6", "version": (">=", "2.2.1"), "arch": None},
+            [
+                {"name": "default-mta", "version": None, "arch": None},
+                {"name": "mail-transport-agent", "version": None, "arch": None},
+            ],
+        ],
+        ", ".join([
+            "libluajit5.1-dev [i386 amd64 powerpc mips]",
+            "liblua5.1-dev [hurd-i386 ia64 s390x sparc]",
+        ]): [
+            {
+                "name": "libluajit5.1-dev",
+                "version": None,
+                "arch": ["i386", "amd64", "powerpc", "mips"],
+            },
+            {
+                "name": "liblua5.1-dev",
+                "version": None,
+                "arch": ["hurd-i386", "ia64", "s390x", "sparc"],
+            },
+        ],
+        " | ".join([
+            "emacs",
+            "emacsen, make, debianutils (>= 1.7)",
+        ]): [
+            [
+                {"name": "emacs", "version": None, "arch": None},
+                {"name": "emacsen", "version": None, "arch": None},
+            ],
+            {"name": "make", "version": None, "arch": None},
+            {"name": "debianutils", "version": (">=", "1.7"), "arch": None},
+        ],
+        ", ".join([
+            "libcap-dev [!kfreebsd-i386 !hurd-i386]",
+            "autoconf",
+            "debhelper (>> 5.0.0)",
+            "file",
+            "libc6 (>= 2.7-1)",
+            "libpaper1",
+            "psutils",
+        ]): [
+            {"name": "libcap-dev", "version": None, "arch": ["!kfreebsd-i386", "!hurd-i386"]},
+            {"name": "autoconf", "version": None, "arch": None},
+            {"name": "debhelper", "version": (">>", "5.0.0"), "arch": None},
+            {"name": "file", "version": None, "arch": None},
+            {"name": "libc6", "version": (">=", "2.7-1"), "arch": None},
+            {"name": "libpaper1", "version": None, "arch": None},
+            {"name": "psutils", "version": None, "arch": None},
+        ],
+        "python3:any": [
+            {"name": "python3", "version": None, "arch": ["any"]},
+        ],
+        " | ".join([
+            "gcc-i686-linux-gnu (>= 4:10.2)",
+            "gcc:i386, g++-i686-linux-gnu (>= 4:10.2)",
+            "g++:i386, dpkg-cross",
+        ]): [
+            [
+                {"name": "gcc-i686-linux-gnu", "version": (">=", "4:10.2"), "arch": None},
+                {"name": "gcc", "version": None, "arch": ["i386"]},
+            ],
+            [
+                {"name": "g++-i686-linux-gnu", "version": (">=", "4:10.2"), "arch": None},
+                {"name": "g++", "version": None, "arch": ["i386"]},
+            ],
+            {"name": "dpkg-cross", "version": None, "arch": None},
+        ],
+        " | ".join([
+            "gcc-x86-64-linux-gnu (>= 4:10.2)",
+            "gcc:amd64, g++-x86-64-linux-gnu (>= 4:10.2)",
+            "g++:amd64, dpkg-cross",
+        ]): [
+            [
+                {"name": "gcc-x86-64-linux-gnu", "version": (">=", "4:10.2"), "arch": None},
+                {"name": "gcc", "version": None, "arch": ["amd64"]},
+            ],
+            [
+                {"name": "g++-x86-64-linux-gnu", "version": (">=", "4:10.2"), "arch": None},
+                {"name": "g++", "version": None, "arch": ["amd64"]},
+            ],
+            {"name": "dpkg-cross", "version": None, "arch": None},
+        ],
+    }
+
+    for deps, expected in parameters.items():
+        actual = version_constraint.parse_depends(deps)
+        asserts.equals(env, expected, actual)
+
+    return unittest.end(env)
+
+parse_depends_test = unittest.make(_parse_depends_test)
+
+def _is_satisfied_by_test(ctx):
+    parameters = [
+        (">= 1.1", "= 1.1", True),
+        ("<= 1.1", "= 1.1", True),
+        (">> 1.1", "= 1.1", False),
+    ]
+
+    env = unittest.begin(ctx)
+    for va, vb, expected in parameters:
+        asserts.equals(
+            env,
+            expected,
+            version_constraint.is_satisfied_by(
+                version_constraint.parse_version_constraint(va),
+                version_constraint.parse_version_constraint(vb),
+            ),
+        )
+
+    return unittest.end(env)
+
+is_satisfied_by_test = unittest.make(_is_satisfied_by_test)
+
+def version_constraint_tests():
+    parse_version_constraint_test(
+        name = _TEST_SUITE_PREFIX + "parse_version_constraint_test",
+    )
+    parse_depends_test(name = _TEST_SUITE_PREFIX + "parse_depends")
+    is_satisfied_by_test(name = _TEST_SUITE_PREFIX + "is_satisfied_by")

--- a/apt/tests/version_test.bzl
+++ b/apt/tests/version_test.bzl
@@ -2,7 +2,6 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//apt/private:version.bzl", "version")
-load("//apt/private:version_constraint.bzl", "version_constraint")
 
 _TEST_SUITE_PREFIX = "version/"
 
@@ -95,30 +94,7 @@ def _sort_test(ctx):
 
 sort_test = unittest.make(_sort_test)
 
-def _is_satisfied_by_test(ctx):
-    parameters = [
-        (">= 1.1", "= 1.1", True),
-        ("<= 1.1", "= 1.1", True),
-        (">> 1.1", "= 1.1", False),
-    ]
-
-    env = unittest.begin(ctx)
-    for va, vb, expected in parameters:
-        asserts.equals(
-            env,
-            expected,
-            version_constraint.is_satisfied_by(
-                version_constraint.parse_version_constraint(va),
-                version_constraint.parse_version_constraint(vb),
-            ),
-        )
-
-    return unittest.end(env)
-
-is_satisfied_by_test = unittest.make(_is_satisfied_by_test)
-
 def version_tests():
     parse_test(name = _TEST_SUITE_PREFIX + "parse")
     compare_test(name = _TEST_SUITE_PREFIX + "compare")
     sort_test(name = _TEST_SUITE_PREFIX + "sort")
-    is_satisfied_by_test(name = _TEST_SUITE_PREFIX + "is_satisfied_by")

--- a/apt/tests/version_test.bzl
+++ b/apt/tests/version_test.bzl
@@ -39,37 +39,37 @@ def _parse_test(ctx):
 
 parse_test = unittest.make(_parse_test)
 
-def _operators_test(ctx):
+def _compare_test(ctx):
     parameters = [
-        ("0", version.lt, "a"),
-        ("1.0", version.lt, "1.1"),
-        ("1.2", version.lt, "1.11"),
-        ("1.0-0.1", version.lt, "1.1"),
-        ("1.0-0.1", version.lt, "1.0-1"),
-        ("1.0", version.eq, "1.0"),
-        ("1.0-0.1", version.eq, "1.0-0.1"),
-        ("1:1.0-0.1", version.eq, "1:1.0-0.1"),
-        ("1:1.0", version.eq, "1:1.0"),
-        ("1.0-0.1", version.lt, "1.0-1"),
-        ("1.0final-5sarge1", version.gt, "1.0final-5"),
-        ("1.0final-5", version.gt, "1.0a7-2"),
-        ("0.9.2-5", version.lt, "0.9.2+cvs.1.0.dev.2004.07.28-1.5"),
-        ("1:500", version.lt, "1:5000"),
-        ("100:500", version.gt, "11:5000"),
-        ("1.0.4-2", version.gt, "1.0pre7-2"),
-        ("1.5~rc1", version.lt, "1.5"),
-        ("1.5~rc1", version.lt, "1.5+b1"),
-        ("1.5~rc1", version.lt, "1.5~rc2"),
-        ("1.5~rc1", version.gt, "1.5~dev0"),
+        ("0", "<<", "a"),
+        ("1.0", "<<", "1.1"),
+        ("1.2", "<<", "1.11"),
+        ("1.0-0.1", "<<", "1.1"),
+        ("1.0-0.1", "<<", "1.0-1"),
+        ("1.0", "=", "1.0"),
+        ("1.0-0.1", "=", "1.0-0.1"),
+        ("1:1.0-0.1", "=", "1:1.0-0.1"),
+        ("1:1.0", "=", "1:1.0"),
+        ("1.0-0.1", "<<", "1.0-1"),
+        ("1.0final-5sarge1", ">>", "1.0final-5"),
+        ("1.0final-5", ">>", "1.0a7-2"),
+        ("0.9.2-5", "<<", "0.9.2+cvs.1.0.dev.2004.07.28-1.5"),
+        ("1:500", "<<", "1:5000"),
+        ("100:500", ">>", "11:5000"),
+        ("1.0.4-2", ">>", "1.0pre7-2"),
+        ("1.5~rc1", "<<", "1.5"),
+        ("1.5~rc1", "<<", "1.5+b1"),
+        ("1.5~rc1", "<<", "1.5~rc2"),
+        ("1.5~rc1", ">>", "1.5~dev0"),
     ]
 
     env = unittest.begin(ctx)
-    for va, version_op, vb in parameters:
-        asserts.true(env, version_op(va, vb))
+    for va, op, vb in parameters:
+        asserts.true(env, version.compare(va, op, vb))
 
     return unittest.end(env)
 
-operators_test = unittest.make(_operators_test)
+compare_test = unittest.make(_compare_test)
 
 def _sort_test(ctx):
     parameters = [
@@ -118,7 +118,7 @@ def _is_satisfied_by_test(ctx):
 is_satisfied_by_test = unittest.make(_is_satisfied_by_test)
 
 def version_tests():
-    operators_test(name = _TEST_SUITE_PREFIX + "operators")
     parse_test(name = _TEST_SUITE_PREFIX + "parse")
+    compare_test(name = _TEST_SUITE_PREFIX + "compare")
     sort_test(name = _TEST_SUITE_PREFIX + "sort")
     is_satisfied_by_test(name = _TEST_SUITE_PREFIX + "is_satisfied_by")


### PR DESCRIPTION
> [!NOTE]  
>  Stacked on top of #92

### refactor: `apt_dep_resolver_test`
Cleanup `apt_dep_resolver_test` removing the `apt_deb_repository mock`, it's not really needed once we have proper testing and mocking of `apt_deb_repository` that we can reuse.

### test: `apt_deb_repository`
* Add testing for apt_deb_repository mocking the external / side effects (downloads, decompression, etc).
* Rename _parse_repository back to _parse_package_index

### refactor: cleanup `_resolve_package` `virtual_package` logic
* Refactor the `virtual_package` loop moving `if version` to the outside

### feat: add `parse_provides`
* Add a `parse_provides` method which parses and validates 'Provides'

### refactor: `nested_dict` `struct`
* Add a helper `nested_dict` `struct` that encapsulates the get-set logic
* Remove all the (now) unnecessary wrappers like `_package_versions`, `_virtual_packages`, etc.
* Fix `get()` method to return default_value if no keys are given
* Add `add()` to `nested_dict` `struct` so that we can simplify the virtual package logic in `apt_deb_repository.bzl` `_add_package`

### refactor: `_resolve_all`
* Add assertions for unresolved_deps in apt_dep_resolver_test
* Rename `resolve_all` to `resolve`
* Reorder `(name, version, arch)` args to match the order of the index keys `(arch, name, version)`
* Break up the long lines in comments
* Improve `_ITERATION_MAX_` fail message

### refactor: `_parse_version_constraint`
Cleanup the version constraint parsing using the `VERSION_OPERATORS` that we now have in the version `struct` plus also validating the version being parsed.

### chore: mv resolution_test to `apt_dep_resolver_test`
Tests should match the file they are testing

### chore: move `version_constraint` tests to their own test file
    
`version_constraint.bzl` is a bunch of utils for package version dependency. Either it has enough entity to stand by itself or the functionality should be folded into `version.bzl` and `package_index.bzl` and/or `package_resolution.bzl`.

### refactor: `_version_relop`
Refactor `_version_relop` into a compare method in `version.bzl` plus a `VERSION_OPERATORS` `dict` so that (1) we use the operator strings everywhere and (2) we can use the keys to validate the operators.

### refactor: _fetch_package_index
    
While working with some flaky mirrors and trying to figure out why they were failing I found the `_fetch_package_index` code a bit hard to follow so here's my attempt at streamlining it a bit:
    
* Change the general flow of the for-loop so that we can directly set the reasons for failure in failed_attempts
* Remove both integrity as an argument and as a return value since neither is ever used.
* return the content of the Packages index instead of the path so that (1) we don't need `rctx` anywhere else and (2) is easier to mock.
* Reword failure messages adding more context and debug information
* Shorter lines and templated strings, trying to make the code easier to read and follow.

### refactor: apt_dep_resolver
* Remove unnecessary `state` `struct`, just pass the `repository` `struct` to the resolver methods
* Remove unused `resolve_package` from the public API