### PR TITLE
document that `cacerts()` requires `SSL_CERT_FILE` set in the environment

### DIFF
--- a/distroless/private/cacerts.bzl
+++ b/distroless/private/cacerts.bzl
@@ -30,7 +30,19 @@ cacerts(
     package = "@ca-certificates//:data.tar.xz",
 )
 ```
+
+To use the generated certificate bundle for SSL, **you must set SSL_CERT_FILE in the
+environment**. You can set it on the oci image like so:
+```starlark
+oci_image(
+    name = "my-image",
+    env = {
+        "SSL_CERT_FILE": "/etc/ssl/certs/ca-certificates.crt",
+    }
+)
+```
 """
+
 
 def _cacerts_impl(ctx):
     bsdtar = ctx.toolchains[tar_lib.TOOLCHAIN_TYPE]

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -39,6 +39,17 @@ cacerts(
 )
 ```
 
+To use the generated certificate bundle for SSL, **you must set SSL_CERT_FILE in the
+environment**. You can set it on the oci image like so:
+```starlark
+oci_image(
+    name = "my-image",
+    env = {
+        "SSL_CERT_FILE": "/etc/ssl/certs/ca-certificates.crt",
+    }
+)
+```
+
 
 **ATTRIBUTES**
 

--- a/examples/debian_snapshot/BUILD.bazel
+++ b/examples/debian_snapshot/BUILD.bazel
@@ -63,6 +63,7 @@ PACKAGES = [
     "@bullseye//dpkg",
     "@bullseye//apt",
     "@bullseye//perl",
+    "@bullseye//openssl",
     "@bullseye//nvidia-kernel-common",
 ]
 
@@ -104,6 +105,10 @@ oci_image(
             for package in PACKAGES
         ],
     }),
+    env = {
+        # Required to use the SSL certs from `cacerts()`
+        "SSL_CERT_FILE": "/etc/ssl/certs/ca-certificates.crt",
+    }
 )
 
 oci_load(

--- a/examples/debian_snapshot/test_linux_amd64.yaml
+++ b/examples/debian_snapshot/test_linux_amd64.yaml
@@ -26,3 +26,7 @@ commandTests:
     command: "head"
     args: ["-1", "/etc/ssl/certs/ca-certificates.crt"]
     expectedOutput: [-----BEGIN CERTIFICATE-----]
+  - name: "in depth ca-certs check"
+    command: "/usr/bin/openssl"
+    args: ["s_client", "-connect", "www.google.com:443"]
+    expectedOutput: ["Verify return code: 0 .ok."]

--- a/examples/debian_snapshot/test_linux_arm64.yaml
+++ b/examples/debian_snapshot/test_linux_arm64.yaml
@@ -26,3 +26,7 @@ commandTests:
     command: "head"
     args: ["-1", "/etc/ssl/certs/ca-certificates.crt"]
     expectedOutput: [-----BEGIN CERTIFICATE-----]
+  - name: "in depth ca-certs check"
+    command: "/usr/bin/openssl"
+    args: ["s_client", "-connect", "www.google.com:443"]
+    expectedOutput: ["Verify return code: 0 .ok."]


### PR DESCRIPTION
Document that the `SSL_CERT_FILE` environment variable is required when using `cacerts()` as discussed in [PR71](https://github.com/GoogleContainerTools/rules_distroless/pull/71)