### PR TITLE
Avoid stamping /var/lib/dpkg/status with the current time

### DIFF
--- a/apt/private/dpkg_status.sh
+++ b/apt/private/dpkg_status.sh
@@ -18,7 +18,7 @@ while  (( $# > 0 )); do
 done
 
 echo "#mtree
-./var/lib/dpkg/status type=file uid=0 gid=0 mode=0644 contents=$tmp_out
+./var/lib/dpkg/status type=file uid=0 gid=0 time=0 mode=0644 contents=$tmp_out
 " | "$bsdtar" $@ -cf "$out" "@-"
 
 rm $tmp_out


### PR DESCRIPTION
bsdtar is sneakily smuggling in the current time here, resulting in image layers that aren't identical between runs.