### PR TITLE
test modified at timestamps

### DIFF
--- a/examples/debian_snapshot/test_linux_amd64.yaml
+++ b/examples/debian_snapshot/test_linux_amd64.yaml
@@ -19,6 +19,10 @@ commandTests:
       - perl/now 5\.32\.1-4\+deb11u3 amd64 \[installed,local\]
       - tzdata/now 2024a-0\+deb11u1 all \[installed,local\]
       - nvidia-kernel-common/now 20151021\+13 amd64 \[installed,local\]
+  - name: "stat dpkg status"
+    command: "stat"
+    args: [ "-c", "%Y", "/var/lib/dpkg/status" ]
+    expectedOutput: ["1672560000"]
   - name: "whoami"
     command: "whoami"
     expectedOutput: [r00t]
@@ -26,3 +30,11 @@ commandTests:
     command: "head"
     args: ["-1", "/etc/ssl/certs/ca-certificates.crt"]
     expectedOutput: [-----BEGIN CERTIFICATE-----]
+
+fileExistenceTests:
+  - name: 'dpkg status exists'
+    path: '/var/lib/dpkg/status'
+    shouldExist: true
+    permissions: '-rw-r--r--'
+    uid: 0
+    gid: 0

--- a/examples/debian_snapshot/test_linux_arm64.yaml
+++ b/examples/debian_snapshot/test_linux_arm64.yaml
@@ -19,6 +19,10 @@ commandTests:
       - perl/now 5\.32\.1-4\+deb11u3 arm64 \[installed,local\]
       - tzdata/now 2024a-0\+deb11u1 all \[installed,local\]
       - nvidia-kernel-common/now 20151021\+13 arm64 \[installed,local\]
+  - name: "stat dpkg status"
+    command: "stat"
+    args: [ "-c", "%Y", "/var/lib/dpkg/status" ]
+    expectedOutput: [ "1672560000" ]
   - name: "whoami"
     command: "whoami"
     expectedOutput: [r00t]
@@ -26,3 +30,11 @@ commandTests:
     command: "head"
     args: ["-1", "/etc/ssl/certs/ca-certificates.crt"]
     expectedOutput: [-----BEGIN CERTIFICATE-----]
+
+fileExistenceTests:
+  - name: 'dpkg status exists'
+    path: '/var/lib/dpkg/status'
+    shouldExist: true
+    permissions: '-rw-r--r--'
+    uid: 0
+    gid: 0

--- a/examples/ubuntu_snapshot/test_linux_amd64.yaml
+++ b/examples/ubuntu_snapshot/test_linux_amd64.yaml
@@ -18,6 +18,18 @@ commandTests:
       - ncurses-base/now 6\.4\+20240113\-1ubuntu1 all \[installed,local\]
       - perl/now 5\.38\.2\-3 amd64 \[installed,local\]
       - tzdata/now 2024a\-1ubuntu1 all \[installed,local\]
+  - name: "stat dpkg status"
+    command: "stat"
+    args: [ "-c", "%Y", "/var/lib/dpkg/status" ]
+    expectedOutput: [ "1672560000" ]
   - name: "whoami"
     command: "whoami"
     expectedOutput: [r00t]
+
+fileExistenceTests:
+  - name: 'dpkg status exists'
+    path: '/var/lib/dpkg/status'
+    shouldExist: true
+    permissions: '-rw-r--r--'
+    uid: 0
+    gid: 0

--- a/examples/ubuntu_snapshot/test_linux_arm64.yaml
+++ b/examples/ubuntu_snapshot/test_linux_arm64.yaml
@@ -18,6 +18,25 @@ commandTests:
       - ncurses-base/now 6\.4\+20240113\-1ubuntu1 all \[installed,local\]
       - perl/now 5\.38\.2\-3 arm64 \[installed,local\]
       - tzdata/now 2024a\-1ubuntu1 all \[installed,local\]
+  - name: "stat dpkg status"
+    command: "stat"
+    args: [ "-c", "%Y", "/var/lib/dpkg/status" ]
+    expectedOutput: [ "1672560000" ]
   - name: "whoami"
     command: "whoami"
     expectedOutput: [r00t]
+
+fileExistenceTests:
+  - name: 'dpkg status exists'
+    path: '/var/lib/dpkg/status'
+    shouldExist: true
+    permissions: '-rw-r--r--'
+    uid: 0
+    gid: 0
+fileExistenceTests:
+  - name: 'dpkg status exists'
+    path: '/var/lib/dpkg/status'
+    shouldExist: true
+    permissions: '-rw-r--r--'
+    uid: 0
+    gid: 0


### PR DESCRIPTION
@alexeagle I added some tests to the debian and ubuntu examples, if you want them. Unfortunately, container structure test doesn't let you check the modified at timestamps, so it requires a heavier command test. 