### PR TITLE
chore: ignore MODULE.bazel.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# ignoring e2e MODULE.bazel.lock for the time being
+# ignoring MODULE.bazel.lock for the time being
 # see https://github.com/bazelbuild/bazel/issues/20369
+MODULE.bazel.lock
 e2e/smoke/MODULE.bazel.lock
 bazel-*
 .bazelrc.user


### PR DESCRIPTION
27242f41 pushed lock version to `12` (my guess is Bazel 8?) plus other changes that e.g. don't match running with `.bazelversion`'s `7.3.1`.

Regardless, the `MODULE.bazel.lock` file is still not stable and e.g. just running it in another operating system causes things to change... so let's just ignore it like I did for the `e2e` tests in 70c14c01