### PR TITLE
fix: apt_deb_repository bzl_library missing dep

### DIFF
--- a/apt/private/BUILD.bazel
+++ b/apt/private/BUILD.bazel
@@ -44,7 +44,10 @@ bzl_library(
     name = "apt_deb_repository",
     srcs = ["apt_deb_repository.bzl"],
     visibility = ["//apt:__subpackages__"],
-    deps = [":util"],
+    deps = [
+        ":util",
+        ":version_constraint",
+    ],
 )
 
 bzl_library(


### PR DESCRIPTION
45509b0 added `version_constraint` to `apt_deb_repository.bzl` dependencies but it was missing from its `bzl_library` `deps`.