### PR TITLE
fix: use last_rc

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,7 +2,8 @@ bcr_test_module:
   module_path: "e2e/smoke"
   matrix:
     platform: ["debian10", "macos", "ubuntu2004"]
-    bazel: ["7.x", "8.x"]
+    # last_rc is to get latest 8.x release. Replace with 8.x when available.
+    bazel: [7.x, last_rc]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
8.x is not available yet. As per https://github.com/GoogleContainerTools/rules_distroless/pull/118#issuecomment-2507371326