### PR TITLE
feat: support multiple URLs in sources

### DIFF
--- a/apt/extensions.bzl
+++ b/apt/extensions.bzl
@@ -35,7 +35,7 @@ def _distroless_extension(module_ctx):
 
                 deb_import(
                     name = "%s_%s" % (install.name, package_key),
-                    urls = [package["url"]],
+                    urls = package["urls"],
                     sha256 = package["sha256"],
                 )
 

--- a/apt/private/apt_deb_repository.bzl
+++ b/apt/private/apt_deb_repository.bzl
@@ -3,7 +3,7 @@
 load(":util.bzl", "util")
 load(":version_constraint.bzl", "version_constraint")
 
-def _fetch_package_index(rctx, url, dist, comp, arch, integrity):
+def _fetch_package_index(rctx, urls, dist, comp, arch, integrity):
     target_triple = "{dist}/{comp}/{arch}".format(dist = dist, comp = comp, arch = arch)
 
     # See https://linux.die.net/man/1/xz , https://linux.die.net/man/1/gzip , and https://linux.die.net/man/1/bzip2
@@ -20,34 +20,40 @@ def _fetch_package_index(rctx, url, dist, comp, arch, integrity):
 
     failed_attempts = []
 
-    for (ext, cmd) in supported_extensions:
-        output = "{}/Packages{}".format(target_triple, ext)
-        dist_url = "{}/dists/{}/{}/binary-{}/Packages{}".format(url, dist, comp, arch, ext)
-        download = rctx.download(
-            url = dist_url,
-            output = output,
-            integrity = integrity,
-            allow_fail = True,
-        )
-        decompress_r = None
+    url = None
+    for url in urls:
+        download = None
+        for (ext, cmd) in supported_extensions:
+            output = "{}/Packages{}".format(target_triple, ext)
+            dist_url = "{}/dists/{}/{}/binary-{}/Packages{}".format(url, dist, comp, arch, ext)
+            download = rctx.download(
+                url = dist_url,
+                output = output,
+                integrity = integrity,
+                allow_fail = True,
+            )
+            decompress_r = None
+            if download.success:
+                decompress_r = rctx.execute(cmd + [output])
+                if decompress_r.return_code == 0:
+                    integrity = download.integrity
+                    break
+
+            failed_attempts.append((dist_url, download, decompress_r))
+
         if download.success:
-            decompress_r = rctx.execute(cmd + [output])
-            if decompress_r.return_code == 0:
-                integrity = download.integrity
-                break
+            break
 
-        failed_attempts.append((dist_url, download, decompress_r))
-
-    if len(failed_attempts) == len(supported_extensions):
+    if len(failed_attempts) == len(supported_extensions) * len(urls):
         attempt_messages = []
-        for (url, download, decompress) in failed_attempts:
+        for (failed_url, download, decompress) in failed_attempts:
             reason = "unknown"
             if not download.success:
                 reason = "Download failed. See warning above for details."
             elif decompress.return_code != 0:
                 reason = "Decompression failed with non-zero exit code.\n\n{}\n{}".format(decompress.stderr, decompress.stdout)
 
-            attempt_messages.append("""\n*) Failed '{}'\n\n{}""".format(url, reason))
+            attempt_messages.append("""\n*) Failed '{}'\n\n{}""".format(failed_url, reason))
 
         fail("""
 ** Tried to download {} different package indices and all failed. 
@@ -55,9 +61,9 @@ def _fetch_package_index(rctx, url, dist, comp, arch, integrity):
 {}
         """.format(len(failed_attempts), "\n".join(attempt_messages)))
 
-    return ("{}/Packages".format(target_triple), integrity)
+    return ("{}/Packages".format(target_triple), url, integrity)
 
-def _parse_repository(state, contents, root):
+def _parse_repository(state, contents, roots):
     last_key = ""
     pkg = {}
     for group in contents.split("\n\n"):
@@ -86,7 +92,7 @@ def _parse_repository(state, contents, root):
             pkg[key] = value
 
         if len(pkg.keys()) != 0:
-            pkg["Root"] = root
+            pkg["Roots"] = roots
             _add_package(state, pkg)
             last_key = ""
             pkg = {}
@@ -117,20 +123,20 @@ def _create(rctx, sources, archs):
     )
 
     for arch in archs:
-        for (url, dist, comp) in sources:
+        for (urls, dist, comp) in sources:
             # We assume that `url` does not contain a trailing forward slash when passing to
             # functions below. If one is present, remove it. Some HTTP servers do not handle
             # redirects properly when a path contains "//"
             # (ie. https://mymirror.com/ubuntu//dists/noble/stable/... may return a 404
             # on misconfigured HTTP servers)
-            url = url.rstrip("/")
+            urls = [url.rstrip("/") for url in urls]
 
             rctx.report_progress("Fetching package index: {}/{} for {}".format(dist, comp, arch))
-            (output, _) = _fetch_package_index(rctx, url, dist, comp, arch, "")
+            (output, _, _) = _fetch_package_index(rctx, urls, dist, comp, arch, "")
 
             # TODO: this is expensive to perform.
             rctx.report_progress("Parsing package index: {}/{} for {}".format(dist, comp, arch))
-            _parse_repository(state, rctx.read(output), url)
+            _parse_repository(state, rctx.read(output), urls)
 
     return struct(
         package_versions = lambda **kwargs: _package_versions(state, **kwargs),

--- a/apt/private/deb_resolve.bzl
+++ b/apt/private/deb_resolve.bzl
@@ -44,8 +44,16 @@ def internal_resolve(rctx, yq_toolchain_prefix, manifest, include_transitive):
     for src in manifest["sources"]:
         distr, components = src["channel"].split(" ", 1)
         for comp in components.split(" "):
+            # TODO: only support urls before 1.0
+            if "urls" in src:
+                urls = src["urls"]
+            elif "url" in src:
+                urls = [src["url"]]
+            else:
+                fail("Source missing 'url' or 'urls' field")
+
             sources.append((
-                src["url"],
+                urls,
                 distr,
                 comp,
             ))

--- a/apt/private/deb_translate_lock.bzl
+++ b/apt/private/deb_translate_lock.bzl
@@ -168,7 +168,7 @@ def _deb_translate_lock_impl(rctx):
                 _DEB_IMPORT_TMPL.format(
                     name = "%s_%s" % (rctx.attr.name, package_key),
                     package_name = package["name"],
-                    urls = [package["url"]],
+                    urls = package["urls"],
                     sha256 = package["sha256"],
                 ),
             )
@@ -184,7 +184,7 @@ def _deb_translate_lock_impl(rctx):
                     "//%s/%s" % (dep["name"], package["arch"])
                     for dep in package["dependencies"]
                 ]),
-                urls = [package["url"]],
+                urls = package["urls"],
                 name = package["name"],
                 arch = package["arch"],
                 sha256 = package["sha256"],

--- a/apt/private/lockfile.bzl
+++ b/apt/private/lockfile.bzl
@@ -20,7 +20,10 @@ def _add_package(lock, package, arch):
         "key": k,
         "name": package["Package"],
         "version": package["Version"],
-        "url": "%s/%s" % (package["Root"], package["Filename"]),
+        "urls": [
+            "%s/%s" % (root, package["Filename"])
+            for root in package["Roots"]
+        ],
         "sha256": package["SHA256"],
         "arch": arch,
         "dependencies": [],
@@ -71,6 +74,10 @@ def _from_json(rctx, content):
         fast_package_lookup = dict(),
     )
     for (i, package) in enumerate(lock.packages):
+        # TODO: only support urls before 1.0
+        if "url" in package:
+            package["urls"] = [package.pop("url")]
+
         lock.packages[i] = package
         lock.fast_package_lookup[package["key"]] = i
     return _create(rctx, lock)

--- a/e2e/smoke/bullseye.lock.json
+++ b/e2e/smoke/bullseye.lock.json
@@ -6,7 +6,10 @@
 			"key": "ncurses-base_6.2-p-20201114-2-p-deb11u2_amd64",
 			"name": "ncurses-base",
 			"sha256": "a55a5f94299448279da6a6c2031a9816dc768cd300668ff82ecfc6480bbfc83d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -41,7 +44,10 @@
 			"key": "libncurses6_6.2-p-20201114-2-p-deb11u2_amd64",
 			"name": "libncurses6",
 			"sha256": "5b75c540d26d0525f231d39e5cf27ea7919d57305ba7101ea430c975369095eb",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_amd64.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -50,7 +56,10 @@
 			"key": "libc6_2.31-13-p-deb11u8_amd64",
 			"name": "libc6",
 			"sha256": "d55d9c9769336f9b8516c20bd8364ce90746fb860ae3dda242f421e711af3d1a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_amd64.deb"
+			],
 			"version": "2.31-13+deb11u8"
 		},
 		{
@@ -59,7 +68,10 @@
 			"key": "libcrypt1_1-4.4.18-4_amd64",
 			"name": "libcrypt1",
 			"sha256": "f617952df0c57b4ee039448e3941bccd3f97bfff71e9b0f87ca6dae15cb3f5ef",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb"
+			],
 			"version": "1:4.4.18-4"
 		},
 		{
@@ -68,7 +80,10 @@
 			"key": "libgcc-s1_10.2.1-6_amd64",
 			"name": "libgcc-s1",
 			"sha256": "e478f2709d8474165bb664de42e16950c391f30eaa55bc9b3573281d83a29daf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -77,7 +92,10 @@
 			"key": "gcc-10-base_10.2.1-6_amd64",
 			"name": "gcc-10-base",
 			"sha256": "be65535e94f95fbf04b104e8ab36790476f063374430f7dfc6c516cbe2d2cd1e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -86,7 +104,10 @@
 			"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
 			"name": "libtinfo6",
 			"sha256": "96ed58b8fd656521e08549c763cd18da6cff1b7801a3a22f29678701a95d7e7b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_amd64.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -166,7 +187,10 @@
 			"key": "tzdata_2024a-0-p-deb11u1_amd64",
 			"name": "tzdata",
 			"sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb"
+			],
 			"version": "2024a-0+deb11u1"
 		},
 		{
@@ -175,7 +199,10 @@
 			"key": "debconf_1.5.77_amd64",
 			"name": "debconf",
 			"sha256": "d9ee4dff77aaad12674eed3ccefdcccd332424c9e2ac2ac00a37a1e06c84ab70",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb"
+			],
 			"version": "1.5.77"
 		},
 		{
@@ -184,7 +211,10 @@
 			"key": "perl-base_5.32.1-4-p-deb11u3_amd64",
 			"name": "perl-base",
 			"sha256": "94c6299552866aadc58acb8ec5111a74b17bcb453f6e2f45ea5f7c4f42580d13",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_amd64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -249,7 +279,10 @@
 			"key": "dpkg_1.20.13_amd64",
 			"name": "dpkg",
 			"sha256": "eb2b7ba3a3c4e905a380045a2d1cd219d2d45755aba5966d6c804b79400beb05",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb"
+			],
 			"version": "1.20.13"
 		},
 		{
@@ -258,7 +291,10 @@
 			"key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
 			"name": "tar",
 			"sha256": "41c9c31f67a76b3532036f09ceac1f40a9224f1680395d120a8b24eae60dd54a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_amd64.deb"
+			],
 			"version": "1.34+dfsg-1+deb11u1"
 		},
 		{
@@ -267,7 +303,10 @@
 			"key": "libselinux1_3.1-3_amd64",
 			"name": "libselinux1",
 			"sha256": "339f5ede10500c16dd7192d73169c31c4b27ab12130347275f23044ec8c7d897",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb"
+			],
 			"version": "3.1-3"
 		},
 		{
@@ -276,7 +315,10 @@
 			"key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
 			"name": "libpcre2-8-0",
 			"sha256": "ee192c8d22624eb9d0a2ae95056bad7fb371e5abc17e23e16b1de3ddb17a1064",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb"
+			],
 			"version": "10.36-2+deb11u1"
 		},
 		{
@@ -285,7 +327,10 @@
 			"key": "libacl1_2.2.53-10_amd64",
 			"name": "libacl1",
 			"sha256": "aa18d721be8aea50fbdb32cd9a319cb18a3f111ea6ad17399aa4ba9324c8e26a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb"
+			],
 			"version": "2.2.53-10"
 		},
 		{
@@ -294,7 +339,9 @@
 			"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
 			"name": "zlib1g",
 			"sha256": "03d2ab2174af76df6f517b854b77460fbdafc3dac0dca979317da67538159a3e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_amd64.deb"
+			],
 			"version": "1:1.2.11.dfsg-2+deb11u2"
 		},
 		{
@@ -303,7 +350,9 @@
 			"key": "liblzma5_5.2.5-2.1_deb11u1_amd64",
 			"name": "liblzma5",
 			"sha256": "1c79a02415ca5ee7234ac60502fb33ee94fa70b02d1c329a6a14178f8329c435",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_amd64.deb"
+			],
 			"version": "5.2.5-2.1~deb11u1"
 		},
 		{
@@ -312,7 +361,10 @@
 			"key": "libbz2-1.0_1.0.8-4_amd64",
 			"name": "libbz2-1.0",
 			"sha256": "16e27c3ebd97981e70db3733f899963362748f178a62644df69d1f247e741379",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb"
+			],
 			"version": "1.0.8-4"
 		},
 		{
@@ -367,7 +419,10 @@
 			"key": "coreutils_8.32-4-p-b1_amd64",
 			"name": "coreutils",
 			"sha256": "3558a412ab51eee4b60641327cb145bb91415f127769823b68f9335585b308d4",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4+b1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4+b1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4+b1_amd64.deb"
+			],
 			"version": "8.32-4+b1"
 		},
 		{
@@ -376,7 +431,10 @@
 			"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
 			"name": "libgmp10",
 			"sha256": "fc117ccb084a98d25021f7e01e4dfedd414fa2118fdd1e27d2d801d7248aebbc",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb"
+			],
 			"version": "2:6.2.1+dfsg-1+deb11u1"
 		},
 		{
@@ -385,7 +443,10 @@
 			"key": "libattr1_1-2.4.48-6_amd64",
 			"name": "libattr1",
 			"sha256": "af3c3562eb2802481a2b9558df1b389f3c6d9b1bf3b4219e000e05131372ebaf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_amd64.deb"
+			],
 			"version": "1:2.4.48-6"
 		},
 		{
@@ -680,7 +741,10 @@
 			"key": "apt_2.2.4_amd64",
 			"name": "apt",
 			"sha256": "75f07c4965ff0813f26623a1164e162538f5e94defba6961347527ed71bc4f3d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_amd64.deb"
+			],
 			"version": "2.2.4"
 		},
 		{
@@ -689,7 +753,9 @@
 			"key": "libsystemd0_247.3-7-p-deb11u4_amd64",
 			"name": "libsystemd0",
 			"sha256": "e6f3e65e388196a399c1a36564c38ad987337350358732056227db1b6e708878",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_amd64.deb"
+			],
 			"version": "247.3-7+deb11u4"
 		},
 		{
@@ -698,7 +764,10 @@
 			"key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
 			"name": "libzstd1",
 			"sha256": "5dcadfbb743bfa1c1c773bff91c018f835e8e8c821d423d3836f3ab84773507b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_amd64.deb"
+			],
 			"version": "1.4.8+dfsg-2.1"
 		},
 		{
@@ -707,7 +776,10 @@
 			"key": "liblz4-1_1.9.3-2_amd64",
 			"name": "liblz4-1",
 			"sha256": "79ac6e9ca19c483f2e8effcc3401d723dd9dbb3a4ae324714de802adb21a8117",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_amd64.deb"
+			],
 			"version": "1.9.3-2"
 		},
 		{
@@ -716,7 +788,10 @@
 			"key": "libgcrypt20_1.8.7-6_amd64",
 			"name": "libgcrypt20",
 			"sha256": "7a2e0eef8e0c37f03f3a5fcf7102a2e3dc70ba987f696ab71949f9abf36f35ef",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb"
+			],
 			"version": "1.8.7-6"
 		},
 		{
@@ -725,7 +800,10 @@
 			"key": "libgpg-error0_1.38-2_amd64",
 			"name": "libgpg-error0",
 			"sha256": "16a507fb20cc58b5a524a0dc254a9cb1df02e1ce758a2d8abde0bc4a3c9b7c26",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb"
+			],
 			"version": "1.38-2"
 		},
 		{
@@ -734,7 +812,10 @@
 			"key": "libstdc-p--p-6_10.2.1-6_amd64",
 			"name": "libstdc++6",
 			"sha256": "5c155c58935870bf3b4bfe769116841c0d286a74f59eccfd5645693ac23f06b1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -743,7 +824,10 @@
 			"key": "libseccomp2_2.5.1-1-p-deb11u1_amd64",
 			"name": "libseccomp2",
 			"sha256": "2617fc8b99dca0fa8ed466ee0f5fe087aa4e8413b88ca45d717290f4a0551e36",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_amd64.deb"
+			],
 			"version": "2.5.1-1+deb11u1"
 		},
 		{
@@ -752,7 +836,10 @@
 			"key": "libgnutls30_3.7.1-5-p-deb11u4_amd64",
 			"name": "libgnutls30",
 			"sha256": "b2fa128881a16c2196caddb551d3577baa296a7bc5d38109a978e8e69fdb5c94",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_amd64.deb"
+			],
 			"version": "3.7.1-5+deb11u4"
 		},
 		{
@@ -761,7 +848,10 @@
 			"key": "libunistring2_0.9.10-4_amd64",
 			"name": "libunistring2",
 			"sha256": "654433ad02d3a8b05c1683c6c29a224500bf343039c34dcec4e5e9515345e3d4",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_amd64.deb"
+			],
 			"version": "0.9.10-4"
 		},
 		{
@@ -770,7 +860,10 @@
 			"key": "libtasn1-6_4.16.0-2-p-deb11u1_amd64",
 			"name": "libtasn1-6",
 			"sha256": "6ebb579337cdc9d6201237a66578425a7a221db622524354e27c0c1bcb6dd7ca",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_amd64.deb"
+			],
 			"version": "4.16.0-2+deb11u1"
 		},
 		{
@@ -779,7 +872,10 @@
 			"key": "libp11-kit0_0.23.22-1_amd64",
 			"name": "libp11-kit0",
 			"sha256": "bfef5f31ee1c730e56e16bb62cc5ff8372185106c75bf1ed1756c96703019457",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_amd64.deb"
+			],
 			"version": "0.23.22-1"
 		},
 		{
@@ -788,7 +884,10 @@
 			"key": "libffi7_3.3-6_amd64",
 			"name": "libffi7",
 			"sha256": "30ca89bfddae5fa6e0a2a044f22b6e50cd17c4bc6bc850c579819aeab7101f0f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb"
+			],
 			"version": "3.3-6"
 		},
 		{
@@ -797,7 +896,10 @@
 			"key": "libnettle8_3.7.3-1_amd64",
 			"name": "libnettle8",
 			"sha256": "e4f8ec31ed14518b241eb7b423ad5ed3f4a4e8ac50aae72c9fd475c569582764",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb"
+			],
 			"version": "3.7.3-1"
 		},
 		{
@@ -806,7 +908,10 @@
 			"key": "libidn2-0_2.3.0-5_amd64",
 			"name": "libidn2-0",
 			"sha256": "cb80cd769171537bafbb4a16c12ec427065795946b3415781bc9792e92d60b59",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_amd64.deb"
+			],
 			"version": "2.3.0-5"
 		},
 		{
@@ -815,7 +920,10 @@
 			"key": "libhogweed6_3.7.3-1_amd64",
 			"name": "libhogweed6",
 			"sha256": "6aab2e892cdb2dfba45707601bc6c3b19aa228f70ae5841017f14c3b0ca3d22f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb"
+			],
 			"version": "3.7.3-1"
 		},
 		{
@@ -824,7 +932,10 @@
 			"key": "debian-archive-keyring_2021.1.1-p-deb11u1_amd64",
 			"name": "debian-archive-keyring",
 			"sha256": "28ca7749ab7978f3c571732c3aa1c56e3ad1d5db3c915293763d4f6cb8fcce89",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb"
+			],
 			"version": "2021.1.1+deb11u1"
 		},
 		{
@@ -833,7 +944,10 @@
 			"key": "libapt-pkg6.0_2.2.4_amd64",
 			"name": "libapt-pkg6.0",
 			"sha256": "4ae47bedf773ad1342e5aae8fa6275f864cfc87a45f4472775f5a9cdd60abbbf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_amd64.deb"
+			],
 			"version": "2.2.4"
 		},
 		{
@@ -842,7 +956,10 @@
 			"key": "libxxhash0_0.8.0-2_amd64",
 			"name": "libxxhash0",
 			"sha256": "3fb82550a71d27d05672472508548576dfb34486847bc860d3066cda5aaf186f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_amd64.deb"
+			],
 			"version": "0.8.0-2"
 		},
 		{
@@ -851,7 +968,9 @@
 			"key": "libudev1_247.3-7-p-deb11u4_amd64",
 			"name": "libudev1",
 			"sha256": "9274ca1aa37fcdf5895dad1de0895162351099ef8dff8a62f2f4c9eb181a8fce",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_amd64.deb"
+			],
 			"version": "247.3-7+deb11u4"
 		},
 		{
@@ -860,7 +979,10 @@
 			"key": "gpgv1_1.4.23-1.1_amd64",
 			"name": "gpgv1",
 			"sha256": "90b29048ca3a5dce708b1c0ed27522fcda9e946c0a2ff8117724f440f853adcf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_amd64.deb"
+			],
 			"version": "1.4.23-1.1"
 		},
 		{
@@ -869,7 +991,10 @@
 			"key": "adduser_3.118-p-deb11u1_amd64",
 			"name": "adduser",
 			"sha256": "1478a610fd50e190882ff41e16c57b628a508bcf5b5ac5313affb49d20818e0a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb"
+			],
 			"version": "3.118+deb11u1"
 		},
 		{
@@ -878,7 +1003,10 @@
 			"key": "passwd_1-4.8.1-1_amd64",
 			"name": "passwd",
 			"sha256": "542593f26502e87b4276fa778e6e3ae52e66b973979986fff77803d9fcb2c2e8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_amd64.deb"
+			],
 			"version": "1:4.8.1-1"
 		},
 		{
@@ -887,7 +1015,10 @@
 			"key": "libpam-modules_1.4.0-9-p-deb11u1_amd64",
 			"name": "libpam-modules",
 			"sha256": "ca1e121700bf4b3eb33e30e0774d3e63e1adae9d4b6a940ea3501225db3cc287",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_amd64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -896,7 +1027,10 @@
 			"key": "libpam-modules-bin_1.4.0-9-p-deb11u1_amd64",
 			"name": "libpam-modules-bin",
 			"sha256": "abbbd181329c236676222d3e912df13f8d1d90a117559edd997d90006369e5c8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_amd64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -905,7 +1039,10 @@
 			"key": "libpam0g_1.4.0-9-p-deb11u1_amd64",
 			"name": "libpam0g",
 			"sha256": "496771218fb585bb716fdae6ef8824dbfb5d544b4fa2f3cd4d0e4d7158ae2220",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_amd64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -914,7 +1051,10 @@
 			"key": "libaudit1_1-3.0-2_amd64",
 			"name": "libaudit1",
 			"sha256": "e3aa1383e387dc077a1176f7f3cbfdbc084bcc270a8938f598d5cb119773b268",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_amd64.deb"
+			],
 			"version": "1:3.0-2"
 		},
 		{
@@ -923,7 +1063,10 @@
 			"key": "libcap-ng0_0.7.9-2.2-p-b1_amd64",
 			"name": "libcap-ng0",
 			"sha256": "d34e29769b8ef23e9b9920814afb7905b8ee749db0814e6a8d937ccc4f309830",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_amd64.deb"
+			],
 			"version": "0.7.9-2.2+b1"
 		},
 		{
@@ -932,7 +1075,10 @@
 			"key": "libaudit-common_1-3.0-2_amd64",
 			"name": "libaudit-common",
 			"sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb"
+			],
 			"version": "1:3.0-2"
 		},
 		{
@@ -941,7 +1087,9 @@
 			"key": "libtirpc3_1.3.1-1-p-deb11u1_amd64",
 			"name": "libtirpc3",
 			"sha256": "86b216d59b6efcd07d56d14b8f4281d5c47f24e9c962f46bbaf02fce762c5e6a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_amd64.deb"
+			],
 			"version": "1.3.1-1+deb11u1"
 		},
 		{
@@ -950,7 +1098,9 @@
 			"key": "libtirpc-common_1.3.1-1-p-deb11u1_amd64",
 			"name": "libtirpc-common",
 			"sha256": "b2f10cb79e7d7a2f9b30bcdf036127df55cd4a34688547bc2886fa38f4969f77",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb"
+			],
 			"version": "1.3.1-1+deb11u1"
 		},
 		{
@@ -959,7 +1109,10 @@
 			"key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_amd64",
 			"name": "libgssapi-krb5-2",
 			"sha256": "037cc4bb34a6cd0d7a6e83bdcae6d68e0d0f9218eb7dedafc8099c8c0be491a2",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_amd64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -968,7 +1121,10 @@
 			"key": "libkrb5support0_1.18.3-6-p-deb11u4_amd64",
 			"name": "libkrb5support0",
 			"sha256": "da8d022e3dd7f4a72ea32e328b3ac382dbe6bdb91606c5738fe17a29f8ea8080",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_amd64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -977,7 +1133,10 @@
 			"key": "libkrb5-3_1.18.3-6-p-deb11u4_amd64",
 			"name": "libkrb5-3",
 			"sha256": "b785fa324cf27e6bf7f97fc0279470e6ce8a8cc54f8ccc6c9b24c8111ba5c952",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_amd64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -986,7 +1145,10 @@
 			"key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
 			"name": "libssl1.1",
 			"sha256": "aadf8b4b197335645b230c2839b4517aa444fd2e8f434e5438c48a18857988f7",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb"
+			],
 			"version": "1.1.1w-0+deb11u1"
 		},
 		{
@@ -995,7 +1157,10 @@
 			"key": "libkeyutils1_1.6.1-2_amd64",
 			"name": "libkeyutils1",
 			"sha256": "f01060b434d8cad3c58d5811d2082389f11b3db8152657d6c22c1d298953f2a5",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_amd64.deb"
+			],
 			"version": "1.6.1-2"
 		},
 		{
@@ -1004,7 +1169,10 @@
 			"key": "libk5crypto3_1.18.3-6-p-deb11u4_amd64",
 			"name": "libk5crypto3",
 			"sha256": "f635062bcbfe2eef5a83fcba7d1a8ae343fc7c779cae88b11cae90fd6845a744",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_amd64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -1013,7 +1181,10 @@
 			"key": "libcom-err2_1.46.2-2_amd64",
 			"name": "libcom-err2",
 			"sha256": "d478f132871f4ab8352d39becf936d0ad74db905398bf98465d8fe3da6fb1126",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_amd64.deb"
+			],
 			"version": "1.46.2-2"
 		},
 		{
@@ -1022,7 +1193,10 @@
 			"key": "libnsl2_1.3.0-2_amd64",
 			"name": "libnsl2",
 			"sha256": "c0d83437fdb016cb289436f49f28a36be44b3e8f1f2498c7e3a095f709c0d6f8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb"
+			],
 			"version": "1.3.0-2"
 		},
 		{
@@ -1031,7 +1205,10 @@
 			"key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
 			"name": "libdb5.3",
 			"sha256": "00b9e63e287f45300d4a4f59b6b88e25918443c932ae3e5845d5761ae193c530",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb"
+			],
 			"version": "5.3.28+dfsg1-0.8"
 		},
 		{
@@ -1040,7 +1217,10 @@
 			"key": "libsemanage1_3.1-1-p-b2_amd64",
 			"name": "libsemanage1",
 			"sha256": "d8f2835b22df58ba45d52eb3aab224190f193576caf05e3f80deb2e4f927fad6",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_amd64.deb"
+			],
 			"version": "3.1-1+b2"
 		},
 		{
@@ -1049,7 +1229,10 @@
 			"key": "libsepol1_3.1-1_amd64",
 			"name": "libsepol1",
 			"sha256": "b6057dc6806a6dfaef74b09d84d1f18716d7a6d2f1da30520cef555210c6af62",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_amd64.deb"
+			],
 			"version": "3.1-1"
 		},
 		{
@@ -1058,7 +1241,10 @@
 			"key": "libsemanage-common_3.1-1_amd64",
 			"name": "libsemanage-common",
 			"sha256": "d319a026ecd02e2f605c52350949279f3c331a19380f8b6888ce5b9ef0d31349",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb"
+			],
 			"version": "3.1-1"
 		},
 		{
@@ -1158,7 +1344,10 @@
 			"key": "perl_5.32.1-4-p-deb11u3_amd64",
 			"name": "perl",
 			"sha256": "d5f710c7db9fcd6d9d6f119cd0dea64a4f765867447dd97b24ab44be1de7c60f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_amd64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -1167,7 +1356,10 @@
 			"key": "libperl5.32_5.32.1-4-p-deb11u3_amd64",
 			"name": "libperl5.32",
 			"sha256": "078487a45916167e3e4ee2e584c50306c84368dd06dae276604861ca0426c34e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_amd64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -1176,7 +1368,10 @@
 			"key": "perl-modules-5.32_5.32.1-4-p-deb11u3_amd64",
 			"name": "perl-modules-5.32",
 			"sha256": "9a5cb99d0f33cb11c7f535aaebfb569c6b6f97a75d748a9a52ea3afed5bd3960",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -1185,7 +1380,10 @@
 			"key": "libgdbm6_1.19-2_amd64",
 			"name": "libgdbm6",
 			"sha256": "e54cfe4d8b8f209bb7df31a404ce040f7c2f9b1045114a927a7e1061cdf90727",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_amd64.deb"
+			],
 			"version": "1.19-2"
 		},
 		{
@@ -1194,7 +1392,10 @@
 			"key": "libgdbm-compat4_1.19-2_amd64",
 			"name": "libgdbm-compat4",
 			"sha256": "e62caed68b0ffaa03b5fa539d6fdc08c4151f66236d5878949bead0b71b7bb09",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_amd64.deb"
+			],
 			"version": "1.19-2"
 		},
 		{
@@ -1284,7 +1485,10 @@
 			"key": "ca-certificates_20210119_amd64",
 			"name": "ca-certificates",
 			"sha256": "b2d488ad4d8d8adb3ba319fc9cb2cf9909fc42cb82ad239a26c570a2e749c389",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb"
+			],
 			"version": "20210119"
 		},
 		{
@@ -1293,7 +1497,10 @@
 			"key": "openssl_1.1.1w-0-p-deb11u1_amd64",
 			"name": "openssl",
 			"sha256": "04873d74cbe86bad3a9901f6e57f1150040eba9891b443c5c975a72a97238e35",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_amd64.deb"
+			],
 			"version": "1.1.1w-0+deb11u1"
 		},
 		{
@@ -1302,7 +1509,10 @@
 			"key": "nvidia-kernel-common_20151021-p-13_amd64",
 			"name": "nvidia-kernel-common",
 			"sha256": "fa4b007bf64cf8cf0e9b3aaae5dd388fcec3a589ce2475f16d64347945691533",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_amd64.deb"
+			],
 			"version": "20151021+13"
 		},
 		{
@@ -1347,7 +1557,10 @@
 			"key": "bash_5.1-2-p-deb11u1_amd64",
 			"name": "bash",
 			"sha256": "f702ef058e762d7208a9c83f6f6bbf02645533bfd615c54e8cdcce842cd57377",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_amd64.deb"
+			],
 			"version": "5.1-2+deb11u1"
 		},
 		{
@@ -1356,7 +1569,10 @@
 			"key": "debianutils_4.11.2_amd64",
 			"name": "debianutils",
 			"sha256": "83d21669c5957e3eaee20096a7d8c596bd07f57f1e95dc74f192b3fb7bb2e6a9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_amd64.deb"
+			],
 			"version": "4.11.2"
 		},
 		{
@@ -1365,7 +1581,10 @@
 			"key": "base-files_11.1-p-deb11u9_amd64",
 			"name": "base-files",
 			"sha256": "1ff08cf6e1b97af1e37cda830f3658f9af43a906abb80a21951c81aea02ce230",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_amd64.deb"
+			],
 			"version": "11.1+deb11u9"
 		},
 		{
@@ -1775,7 +1994,9 @@
 			"key": "nginx-full_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "nginx-full",
 			"sha256": "4049950f648478009faeaf028ab7287240ebd28c27799a5b128a1623290b3e44",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2120,7 +2341,9 @@
 			"key": "nginx-core_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "nginx-core",
 			"sha256": "3d36d36ee74a62037159aeae87c51d2535bf7195a0fb325bde90a325034fc152",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2129,7 +2352,10 @@
 			"key": "libpcre3_2-8.39-13_amd64",
 			"name": "libpcre3",
 			"sha256": "48efcf2348967c211cd9408539edf7ec3fa9d800b33041f6511ccaecc1ffa9d0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_amd64.deb"
+			],
 			"version": "2:8.39-13"
 		},
 		{
@@ -2138,7 +2364,10 @@
 			"key": "iproute2_5.10.0-4_amd64",
 			"name": "iproute2",
 			"sha256": "bad652452612c81b8cfdca1411a036a768f5fa3461a04d6662f1ee0807ea3791",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_amd64.deb"
+			],
 			"version": "5.10.0-4"
 		},
 		{
@@ -2147,7 +2376,10 @@
 			"key": "libcap2-bin_1-2.44-1_amd64",
 			"name": "libcap2-bin",
 			"sha256": "a5b9717d8455cf8517c4c5f29aa04a4dec973430f0d3c1232f652abb9a4d93cc",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_amd64.deb"
+			],
 			"version": "1:2.44-1"
 		},
 		{
@@ -2156,7 +2388,10 @@
 			"key": "libcap2_1-2.44-1_amd64",
 			"name": "libcap2",
 			"sha256": "7a3ae3e97d0d403a4c54663c0bb48e9341d98822420a4ab808c6dc8e8474558f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_amd64.deb"
+			],
 			"version": "1:2.44-1"
 		},
 		{
@@ -2165,7 +2400,10 @@
 			"key": "libxtables12_1.8.7-1_amd64",
 			"name": "libxtables12",
 			"sha256": "9702a4be6f267b58c8fc1cfa0747bbefccb8b9a9af2a3547535533fbf2a7c14d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_amd64.deb"
+			],
 			"version": "1.8.7-1"
 		},
 		{
@@ -2174,7 +2412,10 @@
 			"key": "libmnl0_1.0.4-3_amd64",
 			"name": "libmnl0",
 			"sha256": "4581f42e3373cb72f9ea4e88163b17873afca614a6c6f54637e95aa75983ea7c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_amd64.deb"
+			],
 			"version": "1.0.4-3"
 		},
 		{
@@ -2183,7 +2424,10 @@
 			"key": "libelf1_0.183-1_amd64",
 			"name": "libelf1",
 			"sha256": "e1ad132d502b255023c222d0cae1d02ca941f6b68fd0e9b908c6004cc326592c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_amd64.deb"
+			],
 			"version": "0.183-1"
 		},
 		{
@@ -2192,7 +2436,10 @@
 			"key": "libbsd0_0.11.3-1-p-deb11u1_amd64",
 			"name": "libbsd0",
 			"sha256": "6ec5a08a4bb32c0dc316617f4bbefa8654c472d1cd4412ab8995f3955491f4a8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_amd64.deb"
+			],
 			"version": "0.11.3-1+deb11u1"
 		},
 		{
@@ -2201,7 +2448,10 @@
 			"key": "libmd0_1.0.3-3_amd64",
 			"name": "libmd0",
 			"sha256": "9e425b3c128b69126d95e61998e1b5ef74e862dd1fc953d91eebcc315aea62ea",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_amd64.deb"
+			],
 			"version": "1.0.3-3"
 		},
 		{
@@ -2210,7 +2460,10 @@
 			"key": "libbpf0_1-0.3-2_amd64",
 			"name": "libbpf0",
 			"sha256": "21775f2ae3e1221dab6b9cbb7743df54f751b831e89e005a6f3ce951ba3a30b9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_amd64.deb"
+			],
 			"version": "1:0.3-2"
 		},
 		{
@@ -2219,7 +2472,9 @@
 			"key": "nginx-common_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "nginx-common",
 			"sha256": "bfd22beb7bd248db58eee6e6434a7c500f6e98e264219b3832f248696cd58f67",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2228,7 +2483,10 @@
 			"key": "lsb-base_11.1.0_amd64",
 			"name": "lsb-base",
 			"sha256": "89ed6332074d827a65305f9a51e591dff20641d61ff5e11f4e1822a9987e96fe",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb"
+			],
 			"version": "11.1.0"
 		},
 		{
@@ -2237,7 +2495,9 @@
 			"key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-stream-geoip",
 			"sha256": "b1b22074e8586b9c2fa48fdd460fb43f719e4305a89209cd151102a012af4772",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2246,7 +2506,9 @@
 			"key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-stream",
 			"sha256": "1fbc038483013a78f884314a274bafa221000c8d6cddfd76fd217d23bf26b8d0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2255,7 +2517,10 @@
 			"key": "libgeoip1_1.6.12-7_amd64",
 			"name": "libgeoip1",
 			"sha256": "d4d6076106a6f522144e8071baf6d5fdbd415035f51e081075053ca8223cad51",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_amd64.deb"
+			],
 			"version": "1.6.12-7"
 		},
 		{
@@ -2264,7 +2529,9 @@
 			"key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-mail",
 			"sha256": "3d401417fc74090544c8cd8586add33cbd2f8d88437072233bca9547922f3384",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2273,7 +2540,9 @@
 			"key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-xslt-filter",
 			"sha256": "e51af1373b99ce692dfcb11f185ceb4664b6009a50b4d92773af2c74601d2d4a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2282,7 +2551,9 @@
 			"key": "libxslt1.1_1.1.34-4-p-deb11u1_amd64",
 			"name": "libxslt1.1",
 			"sha256": "e6109d282ad9a330856b88944a953e86329b2c07d8b0f378a2fd0493f27352c8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_amd64.deb"
+			],
 			"version": "1.1.34-4+deb11u1"
 		},
 		{
@@ -2291,7 +2562,9 @@
 			"key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_amd64",
 			"name": "libxml2",
 			"sha256": "b29ea9026561ef0019a57b8b192bf08f725976cd1dddd3fc6bcf876840350989",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_amd64.deb"
+			],
 			"version": "2.9.10+dfsg-6.7+deb11u4"
 		},
 		{
@@ -2300,7 +2573,10 @@
 			"key": "libicu67_67.1-7_amd64",
 			"name": "libicu67",
 			"sha256": "2bf5c46254f527865bfd6368e1120908755fa57d83634bd7d316c9b3cfd57303",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_amd64.deb"
+			],
 			"version": "67.1-7"
 		},
 		{
@@ -2309,7 +2585,9 @@
 			"key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-image-filter",
 			"sha256": "811bae64a056aeb4d68329296b0d5f96749a688285977fd2b192f8c81f623304",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2318,7 +2596,10 @@
 			"key": "libgd3_2.3.0-2_amd64",
 			"name": "libgd3",
 			"sha256": "fadaa01272200dcaa476c6b8908e1faa93d6840610beca909099647829f3fdc1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_amd64.deb"
+			],
 			"version": "2.3.0-2"
 		},
 		{
@@ -2327,7 +2608,9 @@
 			"key": "libxpm4_1-3.5.12-1.1-p-deb11u1_amd64",
 			"name": "libxpm4",
 			"sha256": "349a5a8cf0de6cb33c199027abfbd6b7a13f5160948e6db066a96080c61e4819",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_amd64.deb"
+			],
 			"version": "1:3.5.12-1.1+deb11u1"
 		},
 		{
@@ -2336,7 +2619,9 @@
 			"key": "libx11-6_2-1.7.2-1-p-deb11u2_amd64",
 			"name": "libx11-6",
 			"sha256": "2b3b959cb10c07be065eb638a8577fe20f282045aaef76425dbd7310d1244b8c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_amd64.deb"
+			],
 			"version": "2:1.7.2-1+deb11u2"
 		},
 		{
@@ -2345,7 +2630,9 @@
 			"key": "libx11-data_2-1.7.2-1-p-deb11u2_amd64",
 			"name": "libx11-data",
 			"sha256": "9db24e1e7ed3cd738b503e7df5c1b9b52b1eadcb55019cd63b1409e578565d29",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb"
+			],
 			"version": "2:1.7.2-1+deb11u2"
 		},
 		{
@@ -2354,7 +2641,10 @@
 			"key": "libxcb1_1.14-3_amd64",
 			"name": "libxcb1",
 			"sha256": "d5e0f047ed766f45eb7473947b70f9e8fddbe45ef22ecfd92ab712c0671a93ac",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_amd64.deb"
+			],
 			"version": "1.14-3"
 		},
 		{
@@ -2363,7 +2653,10 @@
 			"key": "libxdmcp6_1-1.1.2-3_amd64",
 			"name": "libxdmcp6",
 			"sha256": "ecb8536f5fb34543b55bb9dc5f5b14c9dbb4150a7bddb3f2287b7cab6e9d25ef",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb"
+			],
 			"version": "1:1.1.2-3"
 		},
 		{
@@ -2372,7 +2665,10 @@
 			"key": "libxau6_1-1.0.9-1_amd64",
 			"name": "libxau6",
 			"sha256": "679db1c4579ec7c61079adeaae8528adeb2e4bf5465baa6c56233b995d714750",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb"
+			],
 			"version": "1:1.0.9-1"
 		},
 		{
@@ -2381,7 +2677,9 @@
 			"key": "libwebp6_0.6.1-2.1-p-deb11u2_amd64",
 			"name": "libwebp6",
 			"sha256": "8abc2b1ca77a458bbbcdeb6af5d85316260977370fa2518d017222b3584d9653",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_amd64.deb"
+			],
 			"version": "0.6.1-2.1+deb11u2"
 		},
 		{
@@ -2390,7 +2688,9 @@
 			"key": "libtiff5_4.2.0-1-p-deb11u5_amd64",
 			"name": "libtiff5",
 			"sha256": "7a70e9513e2b3c3a3d68f1614189f0be72b57eae2229aa64a3d7c8a3fe0639c9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_amd64.deb"
+			],
 			"version": "4.2.0-1+deb11u5"
 		},
 		{
@@ -2399,7 +2699,10 @@
 			"key": "libjpeg62-turbo_1-2.0.6-4_amd64",
 			"name": "libjpeg62-turbo",
 			"sha256": "28de780a1605cf501c3a4ebf3e588f5110e814b208548748ab064100c32202ea",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_amd64.deb"
+			],
 			"version": "1:2.0.6-4"
 		},
 		{
@@ -2408,7 +2711,10 @@
 			"key": "libjbig0_2.1-3.1-p-b2_amd64",
 			"name": "libjbig0",
 			"sha256": "9646d69eefce505407bf0437ea12fb7c2d47a3fd4434720ba46b642b6dcfd80f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_amd64.deb"
+			],
 			"version": "2.1-3.1+b2"
 		},
 		{
@@ -2417,7 +2723,10 @@
 			"key": "libdeflate0_1.7-1_amd64",
 			"name": "libdeflate0",
 			"sha256": "dadaf0d28360f6eb21ad389b2e0f12f8709c9de539b28de9c11d7ec7043dec95",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_amd64.deb"
+			],
 			"version": "1.7-1"
 		},
 		{
@@ -2426,7 +2735,10 @@
 			"key": "libpng16-16_1.6.37-3_amd64",
 			"name": "libpng16-16",
 			"sha256": "7d5336af395d1f658d0e66d74d0e1f4c632028750e7e04314d1a650e0317f3d6",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_amd64.deb"
+			],
 			"version": "1.6.37-3"
 		},
 		{
@@ -2435,7 +2747,10 @@
 			"key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_amd64",
 			"name": "libfreetype6",
 			"sha256": "b21cfdd12adf6cac4af320c2485fb62a8a5edc6f9768bc2288fd686f4fa6dfdf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_amd64.deb"
+			],
 			"version": "2.10.4+dfsg-1+deb11u1"
 		},
 		{
@@ -2444,7 +2759,10 @@
 			"key": "libbrotli1_1.0.9-2-p-b2_amd64",
 			"name": "libbrotli1",
 			"sha256": "65ca7d8b03e9dac09c5d544a89dd52d1aeb74f6a19583d32e4ff5f0c77624c24",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_amd64.deb"
+			],
 			"version": "1.0.9-2+b2"
 		},
 		{
@@ -2453,7 +2771,10 @@
 			"key": "libfontconfig1_2.13.1-4.2_amd64",
 			"name": "libfontconfig1",
 			"sha256": "b92861827627a76e74d6f447a5577d039ef2f95da18af1f29aa98fb96baea4c1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_amd64.deb"
+			],
 			"version": "2.13.1-4.2"
 		},
 		{
@@ -2462,7 +2783,10 @@
 			"key": "fontconfig-config_2.13.1-4.2_amd64",
 			"name": "fontconfig-config",
 			"sha256": "48afb6ad7d15e6104a343b789f73697301ad8bff77b69927bc998f5a409d8e90",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb"
+			],
 			"version": "2.13.1-4.2"
 		},
 		{
@@ -2471,7 +2795,10 @@
 			"key": "fonts-texgyre_20180621-3.1_amd64",
 			"name": "fonts-texgyre",
 			"sha256": "cb7e9a4b2471cfdd57194c16364f9102f0639816a2662fed4b30d2a158747076",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb"
+			],
 			"version": "20180621-3.1"
 		},
 		{
@@ -2480,7 +2807,10 @@
 			"key": "ucf_3.0043_amd64",
 			"name": "ucf",
 			"sha256": "ebef6bcd777b5c0cc2699926f2159db08433aed07c50cb321fd828b28c5e8d53",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb"
+			],
 			"version": "3.0043"
 		},
 		{
@@ -2489,7 +2819,10 @@
 			"key": "sensible-utils_0.0.14_amd64",
 			"name": "sensible-utils",
 			"sha256": "b9a447dc4ec8714196b037e20a2209e62cd669f5450222952f259bda4416b71f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb"
+			],
 			"version": "0.0.14"
 		},
 		{
@@ -2498,7 +2831,9 @@
 			"key": "libuuid1_2.36.1-8-p-deb11u1_amd64",
 			"name": "libuuid1",
 			"sha256": "31250af4dd3b7d1519326a9a6764d1466a93d8f498cf6545058761ebc38b2823",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_amd64.deb"
+			],
 			"version": "2.36.1-8+deb11u1"
 		},
 		{
@@ -2507,7 +2842,9 @@
 			"key": "libexpat1_2.2.10-2-p-deb11u5_amd64",
 			"name": "libexpat1",
 			"sha256": "5744040c4735bcdd51238aebfa3e402b857244897f1007f61154982ebe5abbd7",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_amd64.deb"
+			],
 			"version": "2.2.10-2+deb11u5"
 		},
 		{
@@ -2516,7 +2853,9 @@
 			"key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-geoip",
 			"sha256": "639ceb3e17c3d5a3033757d86a57f3fa786be27ef51fd1618c8a84e9d55ef974",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2525,7 +2864,9 @@
 			"key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-stream-geoip2",
 			"sha256": "20abf8d42ceebe21dcf76c9c4952b9b9a5d8c140affade21c8aebb22d38469d9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2534,7 +2875,10 @@
 			"key": "libmaxminddb0_1.5.2-1_amd64",
 			"name": "libmaxminddb0",
 			"sha256": "9779e86a61b8315d119939f3226472f17d707dce0673eff7b961a478e519e351",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_amd64.deb"
+			],
 			"version": "1.5.2-1"
 		},
 		{
@@ -2543,7 +2887,9 @@
 			"key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-upstream-fair",
 			"sha256": "9650cbb1808fd4d63703b70d5d4599c34e4781c85f5e2b2b47f0abc934397f28",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2552,7 +2898,9 @@
 			"key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-subs-filter",
 			"sha256": "fbfc00d65a6305911a7f025eb331912dadb6de7cdc5e65e5d94f2e65d70a5596",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2561,7 +2909,9 @@
 			"key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-geoip2",
 			"sha256": "de912c363bb1864148379f0784c8031194a3749ae930a5fd0eb1bc2df63d7957",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2570,7 +2920,9 @@
 			"key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-echo",
 			"sha256": "a5be1358d4fb799fdd5941377dea2c45cd013e2c4130dfce98f4af94aead1ec3",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2579,7 +2931,9 @@
 			"key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-dav-ext",
 			"sha256": "48458923ac10ed4ad432237583b617702e8ca6b88da330989711aa734f7e06ee",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2588,17 +2942,21 @@
 			"key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-auth-pam",
 			"sha256": "08f23455c05eee95e8c0bf96d1a52e6a1ddcf509dd1b4dec97c778ff2c596c92",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
 			"arch": "amd64",
 			"dependencies": [],
-			"key": "google-cloud-cli_503.0.0-0_amd64",
+			"key": "google-cloud-cli_507.0.0-0_amd64",
 			"name": "google-cloud-cli",
-			"sha256": "bf4388490f1facb8f0e67f4969c5d65eaadaba57d9dd95a71651e6a5ceafe891",
-			"url": "https://packages.cloud.google.com/apt/pool/cloud-sdk/google-cloud-cli_503.0.0-0_amd64_b5a207cb84a9db198e6aa8d1bda24b14.deb",
-			"version": "503.0.0-0"
+			"sha256": "d84b4e1891fac2f4132efdcdb42108a851b752612e08080c82a2eaff47b02afe",
+			"urls": [
+				"https://packages.cloud.google.com/apt/pool/cloud-sdk/google-cloud-cli_507.0.0-0_amd64_563ffde9b6bc7a27c15f014c68905adf.deb"
+			],
+			"version": "507.0.0-0"
 		},
 		{
 			"arch": "arm64",
@@ -2606,7 +2964,10 @@
 			"key": "ncurses-base_6.2-p-20201114-2-p-deb11u2_arm64",
 			"name": "ncurses-base",
 			"sha256": "a55a5f94299448279da6a6c2031a9816dc768cd300668ff82ecfc6480bbfc83d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -2641,7 +3002,10 @@
 			"key": "libncurses6_6.2-p-20201114-2-p-deb11u2_arm64",
 			"name": "libncurses6",
 			"sha256": "039b71b8839538a92988003e13c29e7cf1149cdc6a77d3de882f1d386a5f3a5c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_arm64.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -2650,7 +3014,10 @@
 			"key": "libc6_2.31-13-p-deb11u8_arm64",
 			"name": "libc6",
 			"sha256": "6eb629090615ebda5dcac2365a7358c035add00b89c2724c2e9e13ccd5bd9f7c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_arm64.deb"
+			],
 			"version": "2.31-13+deb11u8"
 		},
 		{
@@ -2659,7 +3026,10 @@
 			"key": "libcrypt1_1-4.4.18-4_arm64",
 			"name": "libcrypt1",
 			"sha256": "22b586b29e840dabebf0bf227d233376628b87954915d064bc142ae85d1b7979",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_arm64.deb"
+			],
 			"version": "1:4.4.18-4"
 		},
 		{
@@ -2668,7 +3038,10 @@
 			"key": "libgcc-s1_10.2.1-6_arm64",
 			"name": "libgcc-s1",
 			"sha256": "e2fcdb378d3c1ad1bcb64d4fb6b37aab44011152beca12a4944f435a2582df1f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_arm64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -2677,7 +3050,10 @@
 			"key": "gcc-10-base_10.2.1-6_arm64",
 			"name": "gcc-10-base",
 			"sha256": "7d782bece7b4a36bed045a7e17d17244cb8f7e4732466091b01412ebf215defb",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_arm64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -2686,7 +3062,10 @@
 			"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
 			"name": "libtinfo6",
 			"sha256": "58027c991756930a2abb2f87a829393d3fdbfb76f4eca9795ef38ea2b0510e27",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -2766,7 +3145,10 @@
 			"key": "tzdata_2024a-0-p-deb11u1_arm64",
 			"name": "tzdata",
 			"sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb"
+			],
 			"version": "2024a-0+deb11u1"
 		},
 		{
@@ -2775,7 +3157,10 @@
 			"key": "debconf_1.5.77_arm64",
 			"name": "debconf",
 			"sha256": "d9ee4dff77aaad12674eed3ccefdcccd332424c9e2ac2ac00a37a1e06c84ab70",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb"
+			],
 			"version": "1.5.77"
 		},
 		{
@@ -2784,7 +3169,10 @@
 			"key": "perl-base_5.32.1-4-p-deb11u3_arm64",
 			"name": "perl-base",
 			"sha256": "53e09d9594692c462f33d4e9394bff60f95fe74b70402772dc7396a5829b76e5",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_arm64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -2849,7 +3237,10 @@
 			"key": "dpkg_1.20.13_arm64",
 			"name": "dpkg",
 			"sha256": "87b0bce7361d94cc15caf27709fa8a70de44f9dd742cf0d69d25796a03d24853",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_arm64.deb"
+			],
 			"version": "1.20.13"
 		},
 		{
@@ -2858,7 +3249,10 @@
 			"key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
 			"name": "tar",
 			"sha256": "0f94aac4e6d25e07ed23b7fc3ed06e69074c95276d82caae7fc7b207fd714e39",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_arm64.deb"
+			],
 			"version": "1.34+dfsg-1+deb11u1"
 		},
 		{
@@ -2867,7 +3261,10 @@
 			"key": "libselinux1_3.1-3_arm64",
 			"name": "libselinux1",
 			"sha256": "da98279a47dabaa46a83514142f5c691c6a71fa7e582661a3a3db6887ad3e9d1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_arm64.deb"
+			],
 			"version": "3.1-3"
 		},
 		{
@@ -2876,7 +3273,10 @@
 			"key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
 			"name": "libpcre2-8-0",
 			"sha256": "27a4362a4793cb67a8ae571bd8c3f7e8654dc2e56d99088391b87af1793cca9c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_arm64.deb"
+			],
 			"version": "10.36-2+deb11u1"
 		},
 		{
@@ -2885,7 +3285,10 @@
 			"key": "libacl1_2.2.53-10_arm64",
 			"name": "libacl1",
 			"sha256": "f164c48192cb47746101de6c59afa3f97777c8fc821e5a30bb890df1f4cb4cfd",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_arm64.deb"
+			],
 			"version": "2.2.53-10"
 		},
 		{
@@ -2894,7 +3297,9 @@
 			"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
 			"name": "zlib1g",
 			"sha256": "e3963985d1a020d67ffd4180e6f9c4b5c600b515f0c9d8fda513d7a0e48e63a1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_arm64.deb"
+			],
 			"version": "1:1.2.11.dfsg-2+deb11u2"
 		},
 		{
@@ -2903,7 +3308,9 @@
 			"key": "liblzma5_5.2.5-2.1_deb11u1_arm64",
 			"name": "liblzma5",
 			"sha256": "d865bba41952c707b3fa3ae8cab4d4bd337ee92991d2aead66c925bf7cc48846",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_arm64.deb"
+			],
 			"version": "5.2.5-2.1~deb11u1"
 		},
 		{
@@ -2912,7 +3319,10 @@
 			"key": "libbz2-1.0_1.0.8-4_arm64",
 			"name": "libbz2-1.0",
 			"sha256": "da340e8470e96445c56966f74e48a9a91dee0fa5c89876e88a4575cc17d17a97",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_arm64.deb"
+			],
 			"version": "1.0.8-4"
 		},
 		{
@@ -2967,7 +3377,10 @@
 			"key": "coreutils_8.32-4_arm64",
 			"name": "coreutils",
 			"sha256": "6210c84d6ff84b867dc430f661f22f536e1704c27bdb79de38e26f75b853d9c0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4_arm64.deb"
+			],
 			"version": "8.32-4"
 		},
 		{
@@ -2976,7 +3389,10 @@
 			"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
 			"name": "libgmp10",
 			"sha256": "d52619b6ff8829aa5424dfe3189dd05f22118211e69273e9576030584ffcce80",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_arm64.deb"
+			],
 			"version": "2:6.2.1+dfsg-1+deb11u1"
 		},
 		{
@@ -2985,7 +3401,10 @@
 			"key": "libattr1_1-2.4.48-6_arm64",
 			"name": "libattr1",
 			"sha256": "cb9b59be719a6fdbaabaa60e22aa6158b2de7a68c88ccd7c3fb7f41a25fb43d0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_arm64.deb"
+			],
 			"version": "1:2.4.48-6"
 		},
 		{
@@ -3280,7 +3699,10 @@
 			"key": "apt_2.2.4_arm64",
 			"name": "apt",
 			"sha256": "39cbe42f3e64c6359b445d6fed7385273881e507b8be1d3b653ec9fb7d4c917c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_arm64.deb"
+			],
 			"version": "2.2.4"
 		},
 		{
@@ -3289,7 +3711,9 @@
 			"key": "libsystemd0_247.3-7-p-deb11u4_arm64",
 			"name": "libsystemd0",
 			"sha256": "32e8c12301a9ada555adea9a4c2f15df788411dadd164baca5c31690fe06e381",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_arm64.deb"
+			],
 			"version": "247.3-7+deb11u4"
 		},
 		{
@@ -3298,7 +3722,10 @@
 			"key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
 			"name": "libzstd1",
 			"sha256": "dd01659c6c122f983a3369a04ede63539f666585d52a03f8aa2c27b307e547e0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_arm64.deb"
+			],
 			"version": "1.4.8+dfsg-2.1"
 		},
 		{
@@ -3307,7 +3734,10 @@
 			"key": "liblz4-1_1.9.3-2_arm64",
 			"name": "liblz4-1",
 			"sha256": "83f0ee547cd42854e1b2a2e4c1a5705e28259ee5fa6560119f918f961a5dada2",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_arm64.deb"
+			],
 			"version": "1.9.3-2"
 		},
 		{
@@ -3316,7 +3746,10 @@
 			"key": "libgcrypt20_1.8.7-6_arm64",
 			"name": "libgcrypt20",
 			"sha256": "61ec779149f20923b30adad7bdf4732957e88a5b6a26d94b2210dfe79409959b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_arm64.deb"
+			],
 			"version": "1.8.7-6"
 		},
 		{
@@ -3325,7 +3758,10 @@
 			"key": "libgpg-error0_1.38-2_arm64",
 			"name": "libgpg-error0",
 			"sha256": "d1116f4281d6db35279799a21051e0d0e2600d110d7ee2b95b3cca6bec28067c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_arm64.deb"
+			],
 			"version": "1.38-2"
 		},
 		{
@@ -3334,7 +3770,10 @@
 			"key": "libstdc-p--p-6_10.2.1-6_arm64",
 			"name": "libstdc++6",
 			"sha256": "7869aa540cc46e9f3d4267d5bde2af0e5b429a820c1d6f1a4cfccfe788c31890",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_arm64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -3343,7 +3782,10 @@
 			"key": "libseccomp2_2.5.1-1-p-deb11u1_arm64",
 			"name": "libseccomp2",
 			"sha256": "5b8983c2e330790dbe04ae990f166d7939a3e14b75556a8489309ae704fbeb50",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_arm64.deb"
+			],
 			"version": "2.5.1-1+deb11u1"
 		},
 		{
@@ -3352,7 +3794,10 @@
 			"key": "libgnutls30_3.7.1-5-p-deb11u4_arm64",
 			"name": "libgnutls30",
 			"sha256": "7153ec6ee985eebba710dcb6e425bb881c91ee5987a4517518f3f44a9bb5fc1a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_arm64.deb"
+			],
 			"version": "3.7.1-5+deb11u4"
 		},
 		{
@@ -3361,7 +3806,10 @@
 			"key": "libunistring2_0.9.10-4_arm64",
 			"name": "libunistring2",
 			"sha256": "53ff395ea4d8cf17c52155a452a0dc15af0ee2fa5cb3b0085b9c7335de8d5f7f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_arm64.deb"
+			],
 			"version": "0.9.10-4"
 		},
 		{
@@ -3370,7 +3818,10 @@
 			"key": "libtasn1-6_4.16.0-2-p-deb11u1_arm64",
 			"name": "libtasn1-6",
 			"sha256": "f469147bbd3969055c51fc661c9aa0d56d48eccd070d233f1424b0d8b3f29295",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_arm64.deb"
+			],
 			"version": "4.16.0-2+deb11u1"
 		},
 		{
@@ -3379,7 +3830,10 @@
 			"key": "libp11-kit0_0.23.22-1_arm64",
 			"name": "libp11-kit0",
 			"sha256": "ac6e8eda3277708069bc6f03aff06dc319855d64ede9fca219938e52f92ee09c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_arm64.deb"
+			],
 			"version": "0.23.22-1"
 		},
 		{
@@ -3388,7 +3842,10 @@
 			"key": "libffi7_3.3-6_arm64",
 			"name": "libffi7",
 			"sha256": "eb748e33ae4ed46f5a4c14b7a2a09792569f2029ede319d0979c373829ba1532",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb"
+			],
 			"version": "3.3-6"
 		},
 		{
@@ -3397,7 +3854,10 @@
 			"key": "libnettle8_3.7.3-1_arm64",
 			"name": "libnettle8",
 			"sha256": "5061c931f95dc7277d95fc58bce7c17b1a95c6aa9a9aac781784f3b3dc909047",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb"
+			],
 			"version": "3.7.3-1"
 		},
 		{
@@ -3406,7 +3866,10 @@
 			"key": "libidn2-0_2.3.0-5_arm64",
 			"name": "libidn2-0",
 			"sha256": "0d2e6d39bf65f16861f284be567c1a6c5d4dc6b54dcfdf9dba631546ff4e6796",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_arm64.deb"
+			],
 			"version": "2.3.0-5"
 		},
 		{
@@ -3415,7 +3878,10 @@
 			"key": "libhogweed6_3.7.3-1_arm64",
 			"name": "libhogweed6",
 			"sha256": "3e9eea5e474dd98a7de9e4c1ecfbfd6f6efb1d40bf51d6473de9713cf41d2191",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb"
+			],
 			"version": "3.7.3-1"
 		},
 		{
@@ -3424,7 +3890,10 @@
 			"key": "debian-archive-keyring_2021.1.1-p-deb11u1_arm64",
 			"name": "debian-archive-keyring",
 			"sha256": "28ca7749ab7978f3c571732c3aa1c56e3ad1d5db3c915293763d4f6cb8fcce89",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb"
+			],
 			"version": "2021.1.1+deb11u1"
 		},
 		{
@@ -3433,7 +3902,10 @@
 			"key": "libapt-pkg6.0_2.2.4_arm64",
 			"name": "libapt-pkg6.0",
 			"sha256": "7cb6015ea5c185ef93706989fb730377406878c72f6943b6ecdd956697f1abe6",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_arm64.deb"
+			],
 			"version": "2.2.4"
 		},
 		{
@@ -3442,7 +3914,10 @@
 			"key": "libxxhash0_0.8.0-2_arm64",
 			"name": "libxxhash0",
 			"sha256": "a31effcbd7a248b64dd480330557f41ea796a010b2c2e7ac91ed10f94e605065",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_arm64.deb"
+			],
 			"version": "0.8.0-2"
 		},
 		{
@@ -3451,7 +3926,9 @@
 			"key": "libudev1_247.3-7-p-deb11u4_arm64",
 			"name": "libudev1",
 			"sha256": "d53ca63927b51ad6f9a85ee1e4ce74d20ef45651179fd70f3c8d72607071e393",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_arm64.deb"
+			],
 			"version": "247.3-7+deb11u4"
 		},
 		{
@@ -3460,7 +3937,10 @@
 			"key": "gpgv1_1.4.23-1.1_arm64",
 			"name": "gpgv1",
 			"sha256": "f65792c432a2a741dfb0a56b9e5f39fe87ff477636dafcf38644c6f726b1addc",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_arm64.deb"
+			],
 			"version": "1.4.23-1.1"
 		},
 		{
@@ -3469,7 +3949,10 @@
 			"key": "adduser_3.118-p-deb11u1_arm64",
 			"name": "adduser",
 			"sha256": "1478a610fd50e190882ff41e16c57b628a508bcf5b5ac5313affb49d20818e0a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb"
+			],
 			"version": "3.118+deb11u1"
 		},
 		{
@@ -3478,7 +3961,10 @@
 			"key": "passwd_1-4.8.1-1_arm64",
 			"name": "passwd",
 			"sha256": "5a675c9d23f176ea195678a949e144b23c7a8b268b03e0df8919a2cfc198e585",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_arm64.deb"
+			],
 			"version": "1:4.8.1-1"
 		},
 		{
@@ -3487,7 +3973,10 @@
 			"key": "libpam-modules_1.4.0-9-p-deb11u1_arm64",
 			"name": "libpam-modules",
 			"sha256": "7f46ae216fdc6c69b0120d430936f40f3c5f37249296042324aeb584d5566a3c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_arm64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -3496,7 +3985,10 @@
 			"key": "libpam-modules-bin_1.4.0-9-p-deb11u1_arm64",
 			"name": "libpam-modules-bin",
 			"sha256": "bc20fa16c91a239de350ffcc019fbae5ce7c47c21235b332ff9d67638804866e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_arm64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -3505,7 +3997,10 @@
 			"key": "libpam0g_1.4.0-9-p-deb11u1_arm64",
 			"name": "libpam0g",
 			"sha256": "4905e523ce38e80b79f13f0227fca519f6833eb116dd9c58cbbecb39c0e01e3d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_arm64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -3514,7 +4009,10 @@
 			"key": "libaudit1_1-3.0-2_arm64",
 			"name": "libaudit1",
 			"sha256": "c93da146715dcd0c71759629c04afb01a41c879d91b2f5330adc74365db03763",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_arm64.deb"
+			],
 			"version": "1:3.0-2"
 		},
 		{
@@ -3523,7 +4021,10 @@
 			"key": "libcap-ng0_0.7.9-2.2-p-b1_arm64",
 			"name": "libcap-ng0",
 			"sha256": "b7b14e0b7747872f04691efe6c126de5ed0bf1dc200f51b93039cc2f4a65a96a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_arm64.deb"
+			],
 			"version": "0.7.9-2.2+b1"
 		},
 		{
@@ -3532,7 +4033,10 @@
 			"key": "libaudit-common_1-3.0-2_arm64",
 			"name": "libaudit-common",
 			"sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb"
+			],
 			"version": "1:3.0-2"
 		},
 		{
@@ -3541,7 +4045,9 @@
 			"key": "libtirpc3_1.3.1-1-p-deb11u1_arm64",
 			"name": "libtirpc3",
 			"sha256": "ccff0927f55b97fe9ea13057fab8bff9920bf4628eb2d5d48b9656f2fb74d2e1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_arm64.deb"
+			],
 			"version": "1.3.1-1+deb11u1"
 		},
 		{
@@ -3550,7 +4056,9 @@
 			"key": "libtirpc-common_1.3.1-1-p-deb11u1_arm64",
 			"name": "libtirpc-common",
 			"sha256": "b2f10cb79e7d7a2f9b30bcdf036127df55cd4a34688547bc2886fa38f4969f77",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb"
+			],
 			"version": "1.3.1-1+deb11u1"
 		},
 		{
@@ -3559,7 +4067,10 @@
 			"key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_arm64",
 			"name": "libgssapi-krb5-2",
 			"sha256": "5572a462c7f78f9610bd4f1dd9f8e4f8243fa9dc2d1deb5b1cf7cec1f1df83dc",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_arm64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -3568,7 +4079,10 @@
 			"key": "libkrb5support0_1.18.3-6-p-deb11u4_arm64",
 			"name": "libkrb5support0",
 			"sha256": "d44585771e26c9b8d115aad33736fcc3e03cf98238ea7c7985554f166441aa07",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_arm64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -3577,7 +4091,10 @@
 			"key": "libkrb5-3_1.18.3-6-p-deb11u4_arm64",
 			"name": "libkrb5-3",
 			"sha256": "3dcdadb1db461d14b6051a19c6a94ae9f61c3d2b1d35fd9d63326cd8f4ae49e5",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_arm64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -3586,7 +4103,10 @@
 			"key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
 			"name": "libssl1.1",
 			"sha256": "fe7a7d313c87e46e62e614a07137e4a476a79fc9e5aab7b23e8235211280fee3",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_arm64.deb"
+			],
 			"version": "1.1.1w-0+deb11u1"
 		},
 		{
@@ -3595,7 +4115,10 @@
 			"key": "libkeyutils1_1.6.1-2_arm64",
 			"name": "libkeyutils1",
 			"sha256": "7101c2380ab47a3627a6fa076a149ab71078263064f936fccbd43efbaed4a2da",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_arm64.deb"
+			],
 			"version": "1.6.1-2"
 		},
 		{
@@ -3604,7 +4127,10 @@
 			"key": "libk5crypto3_1.18.3-6-p-deb11u4_arm64",
 			"name": "libk5crypto3",
 			"sha256": "d8f31a8bd83fe2593e83a930fc2713e1213f25311a629836dfcde5bd23a85e83",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_arm64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -3613,7 +4139,10 @@
 			"key": "libcom-err2_1.46.2-2_arm64",
 			"name": "libcom-err2",
 			"sha256": "fc95d415c35f5b687871f660a5bf66963fd117daa490110499119411e2d6145e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_arm64.deb"
+			],
 			"version": "1.46.2-2"
 		},
 		{
@@ -3622,7 +4151,10 @@
 			"key": "libnsl2_1.3.0-2_arm64",
 			"name": "libnsl2",
 			"sha256": "8f9ba58b219779b43c4ccc78c79b0a23f721fc96323c202abb31e02f942104b3",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb"
+			],
 			"version": "1.3.0-2"
 		},
 		{
@@ -3631,7 +4163,10 @@
 			"key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
 			"name": "libdb5.3",
 			"sha256": "cf9aa3eae9cfc4c84f93e32f3d11e2707146e4d9707712909e3c61530b50353e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_arm64.deb"
+			],
 			"version": "5.3.28+dfsg1-0.8"
 		},
 		{
@@ -3640,7 +4175,10 @@
 			"key": "libsemanage1_3.1-1-p-b2_arm64",
 			"name": "libsemanage1",
 			"sha256": "342a804007338314211981fac0bc083c3c66c6040bca0e47342c6d9ff44f103e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_arm64.deb"
+			],
 			"version": "3.1-1+b2"
 		},
 		{
@@ -3649,7 +4187,10 @@
 			"key": "libsepol1_3.1-1_arm64",
 			"name": "libsepol1",
 			"sha256": "354d36c3084c14f242baba3a06372a3c034cec7a0cb38e626fc03cc4751b2cd3",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_arm64.deb"
+			],
 			"version": "3.1-1"
 		},
 		{
@@ -3658,7 +4199,10 @@
 			"key": "libsemanage-common_3.1-1_arm64",
 			"name": "libsemanage-common",
 			"sha256": "d319a026ecd02e2f605c52350949279f3c331a19380f8b6888ce5b9ef0d31349",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb"
+			],
 			"version": "3.1-1"
 		},
 		{
@@ -3758,7 +4302,10 @@
 			"key": "perl_5.32.1-4-p-deb11u3_arm64",
 			"name": "perl",
 			"sha256": "6ed36a59241bbeec132eebec770567a4d23884f71dc922ac6770862cac1f3d9a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_arm64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -3767,7 +4314,10 @@
 			"key": "libperl5.32_5.32.1-4-p-deb11u3_arm64",
 			"name": "libperl5.32",
 			"sha256": "9a5524101015f14773246336cb615c0e58fff2e7420a79f511262df9a7ff1c91",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_arm64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -3776,7 +4326,10 @@
 			"key": "perl-modules-5.32_5.32.1-4-p-deb11u3_arm64",
 			"name": "perl-modules-5.32",
 			"sha256": "9a5cb99d0f33cb11c7f535aaebfb569c6b6f97a75d748a9a52ea3afed5bd3960",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -3785,7 +4338,10 @@
 			"key": "libgdbm6_1.19-2_arm64",
 			"name": "libgdbm6",
 			"sha256": "97a88c2698bd836d04e51ad70c76826850857869b51e90b5343621ba30bbf525",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_arm64.deb"
+			],
 			"version": "1.19-2"
 		},
 		{
@@ -3794,7 +4350,10 @@
 			"key": "libgdbm-compat4_1.19-2_arm64",
 			"name": "libgdbm-compat4",
 			"sha256": "0853cc0b0f92784b7fbd193d737c63b1d95f932e2b95dc1bb10c273e01a0f754",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_arm64.deb"
+			],
 			"version": "1.19-2"
 		},
 		{
@@ -3884,7 +4443,10 @@
 			"key": "ca-certificates_20210119_arm64",
 			"name": "ca-certificates",
 			"sha256": "b2d488ad4d8d8adb3ba319fc9cb2cf9909fc42cb82ad239a26c570a2e749c389",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb"
+			],
 			"version": "20210119"
 		},
 		{
@@ -3893,7 +4455,10 @@
 			"key": "openssl_1.1.1w-0-p-deb11u1_arm64",
 			"name": "openssl",
 			"sha256": "d9159af073e95641e7eda440fa1d7623873b8c0034c9826a353f890bed107f3c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_arm64.deb"
+			],
 			"version": "1.1.1w-0+deb11u1"
 		},
 		{
@@ -3902,7 +4467,10 @@
 			"key": "nvidia-kernel-common_20151021-p-13_arm64",
 			"name": "nvidia-kernel-common",
 			"sha256": "5a1f10cffc5407a6b63dcdf3f72af842ad9e39a808bb9418a4805aa0be345c65",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_arm64.deb"
+			],
 			"version": "20151021+13"
 		},
 		{
@@ -3947,7 +4515,10 @@
 			"key": "bash_5.1-2-p-deb11u1_arm64",
 			"name": "bash",
 			"sha256": "d7c7af5d86f43a885069408a89788f67f248e8124c682bb73936f33874e0611b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb"
+			],
 			"version": "5.1-2+deb11u1"
 		},
 		{
@@ -3956,7 +4527,10 @@
 			"key": "debianutils_4.11.2_arm64",
 			"name": "debianutils",
 			"sha256": "6543b2b1a61b4b7b4b55b4bd25162309d7d23d14d3303649aee84ad314c30e02",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_arm64.deb"
+			],
 			"version": "4.11.2"
 		},
 		{
@@ -3965,7 +4539,10 @@
 			"key": "base-files_11.1-p-deb11u9_arm64",
 			"name": "base-files",
 			"sha256": "c40dc4d5c6b82f5cfe75efa1a12bd09b9d5b9b8446ea045a991896a1ead8b02c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_arm64.deb"
+			],
 			"version": "11.1+deb11u9"
 		},
 		{
@@ -4375,7 +4952,9 @@
 			"key": "nginx-full_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "nginx-full",
 			"sha256": "4049950f648478009faeaf028ab7287240ebd28c27799a5b128a1623290b3e44",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4720,7 +5299,9 @@
 			"key": "nginx-core_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "nginx-core",
 			"sha256": "932d9d78df093f037caf9a32af5f3a9f42f113ccc87ca59946f983753a9b83b8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4729,7 +5310,10 @@
 			"key": "libpcre3_2-8.39-13_arm64",
 			"name": "libpcre3",
 			"sha256": "21cac4064a41dbc354295c437f37bf623f9004513a97a6fa030248566aa986e9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_arm64.deb"
+			],
 			"version": "2:8.39-13"
 		},
 		{
@@ -4738,7 +5322,10 @@
 			"key": "iproute2_5.10.0-4_arm64",
 			"name": "iproute2",
 			"sha256": "92d6c7ca67fca91257a3734d94417a3300c4240d8f6934c6b742c001814b4e31",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_arm64.deb"
+			],
 			"version": "5.10.0-4"
 		},
 		{
@@ -4747,7 +5334,10 @@
 			"key": "libcap2-bin_1-2.44-1_arm64",
 			"name": "libcap2-bin",
 			"sha256": "37915f4cc73cfaef7862043f2bdad062d1b1639df04c511665f1f9321c84d0db",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_arm64.deb"
+			],
 			"version": "1:2.44-1"
 		},
 		{
@@ -4756,7 +5346,10 @@
 			"key": "libcap2_1-2.44-1_arm64",
 			"name": "libcap2",
 			"sha256": "7c5729a1cfd14876685217c5f0545301e7ff1b839262fb487d6a778e8cd8c05a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_arm64.deb"
+			],
 			"version": "1:2.44-1"
 		},
 		{
@@ -4765,7 +5358,10 @@
 			"key": "libxtables12_1.8.7-1_arm64",
 			"name": "libxtables12",
 			"sha256": "fa07088a313d8dae7a8cba0780117e80ead683ac549fd9986a52a3280232272a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_arm64.deb"
+			],
 			"version": "1.8.7-1"
 		},
 		{
@@ -4774,7 +5370,10 @@
 			"key": "libmnl0_1.0.4-3_arm64",
 			"name": "libmnl0",
 			"sha256": "d63aafb6f2c07db8fcb135b00ff915baf72ef8a3397e773c9c24d67950c6a46c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_arm64.deb"
+			],
 			"version": "1.0.4-3"
 		},
 		{
@@ -4783,7 +5382,10 @@
 			"key": "libelf1_0.183-1_arm64",
 			"name": "libelf1",
 			"sha256": "12e14110cd66b3bf0564e3b184985b3e91c9cd76e909531a7f7bd2cb9b35a1f3",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_arm64.deb"
+			],
 			"version": "0.183-1"
 		},
 		{
@@ -4792,7 +5394,10 @@
 			"key": "libbsd0_0.11.3-1-p-deb11u1_arm64",
 			"name": "libbsd0",
 			"sha256": "614d36d41b670955a75526865bd321703f2accb6e0c07ee4c283fbba12e494df",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_arm64.deb"
+			],
 			"version": "0.11.3-1+deb11u1"
 		},
 		{
@@ -4801,7 +5406,10 @@
 			"key": "libmd0_1.0.3-3_arm64",
 			"name": "libmd0",
 			"sha256": "3c490cdcce9d25e702e6587b6166cd8e7303fce8343642d9d5d99695282a9e5c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_arm64.deb"
+			],
 			"version": "1.0.3-3"
 		},
 		{
@@ -4810,7 +5418,10 @@
 			"key": "libbpf0_1-0.3-2_arm64",
 			"name": "libbpf0",
 			"sha256": "1ef325a3bd9e43970cd8e7f9f44b13e36bc935ac496e56d96f715aa69ae7281b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_arm64.deb"
+			],
 			"version": "1:0.3-2"
 		},
 		{
@@ -4819,7 +5430,9 @@
 			"key": "nginx-common_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "nginx-common",
 			"sha256": "bfd22beb7bd248db58eee6e6434a7c500f6e98e264219b3832f248696cd58f67",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4828,7 +5441,10 @@
 			"key": "lsb-base_11.1.0_arm64",
 			"name": "lsb-base",
 			"sha256": "89ed6332074d827a65305f9a51e591dff20641d61ff5e11f4e1822a9987e96fe",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb"
+			],
 			"version": "11.1.0"
 		},
 		{
@@ -4837,7 +5453,9 @@
 			"key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-stream-geoip",
 			"sha256": "140963ecb81a3ea933e96fd7c89d01c4ffdb12509e3869d769d7b21ca5d690bf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4846,7 +5464,9 @@
 			"key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-stream",
 			"sha256": "88d083135df9c2c1e2401f174b4e48dde2d92cca7fc8ef661f9d26f00b395a75",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4855,7 +5475,10 @@
 			"key": "libgeoip1_1.6.12-7_arm64",
 			"name": "libgeoip1",
 			"sha256": "17225fb2ed7ce9a090c39d90acc2696e5582805a2a1f391e0a8278bb6a2d0178",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_arm64.deb"
+			],
 			"version": "1.6.12-7"
 		},
 		{
@@ -4864,7 +5487,9 @@
 			"key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-mail",
 			"sha256": "f8fa0d620dcdea21669b5fd9f503528d53b94117a9c31ac36dc318db0fbac315",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4873,7 +5498,9 @@
 			"key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-xslt-filter",
 			"sha256": "5d9bb33231c8589a07063a73bb6b3061bc92fae79e5731e96b5b398f1fafee29",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4882,7 +5509,9 @@
 			"key": "libxslt1.1_1.1.34-4-p-deb11u1_arm64",
 			"name": "libxslt1.1",
 			"sha256": "2505ed3d8e6b049349ecfeff1cb6923eca43403d252e8ddd308a6a644b97eec7",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_arm64.deb"
+			],
 			"version": "1.1.34-4+deb11u1"
 		},
 		{
@@ -4891,7 +5520,9 @@
 			"key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_arm64",
 			"name": "libxml2",
 			"sha256": "ccd9f449fa88827258bd51eeb8d5f6f33719df290f157c2b0be3c527a6ee45aa",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_arm64.deb"
+			],
 			"version": "2.9.10+dfsg-6.7+deb11u4"
 		},
 		{
@@ -4900,7 +5531,10 @@
 			"key": "libicu67_67.1-7_arm64",
 			"name": "libicu67",
 			"sha256": "776303db230b275d8a17dfe8f0012bf61093dfc910f0d51f175be36707686efe",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_arm64.deb"
+			],
 			"version": "67.1-7"
 		},
 		{
@@ -4909,7 +5543,9 @@
 			"key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-image-filter",
 			"sha256": "d972b39dcca41c42f7c797fcc4472d81b64e99978845b2309e18e6d5937e384e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4918,7 +5554,10 @@
 			"key": "libgd3_2.3.0-2_arm64",
 			"name": "libgd3",
 			"sha256": "1e6d6af0c90fe62193b3e51e45f69d075b86d7bde3fb4fd30b60da763aeca43f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_arm64.deb"
+			],
 			"version": "2.3.0-2"
 		},
 		{
@@ -4927,7 +5566,9 @@
 			"key": "libxpm4_1-3.5.12-1.1-p-deb11u1_arm64",
 			"name": "libxpm4",
 			"sha256": "83ba23ecaaf3f7b700f1ec2c1e349b5a63f3c8cdceb43cc78eb353e16051427d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_arm64.deb"
+			],
 			"version": "1:3.5.12-1.1+deb11u1"
 		},
 		{
@@ -4936,7 +5577,9 @@
 			"key": "libx11-6_2-1.7.2-1-p-deb11u2_arm64",
 			"name": "libx11-6",
 			"sha256": "1ddb1a4d3dbdaeac8fd8d0009a27e6453b15d97362fdd1d3efb1d5f577364f30",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_arm64.deb"
+			],
 			"version": "2:1.7.2-1+deb11u2"
 		},
 		{
@@ -4945,7 +5588,9 @@
 			"key": "libx11-data_2-1.7.2-1-p-deb11u2_arm64",
 			"name": "libx11-data",
 			"sha256": "9db24e1e7ed3cd738b503e7df5c1b9b52b1eadcb55019cd63b1409e578565d29",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb"
+			],
 			"version": "2:1.7.2-1+deb11u2"
 		},
 		{
@@ -4954,7 +5599,10 @@
 			"key": "libxcb1_1.14-3_arm64",
 			"name": "libxcb1",
 			"sha256": "48f82b65c93adb7af7757961fdd2730928316459f008d767b7104a56bc20a8f1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_arm64.deb"
+			],
 			"version": "1.14-3"
 		},
 		{
@@ -4963,7 +5611,10 @@
 			"key": "libxdmcp6_1-1.1.2-3_arm64",
 			"name": "libxdmcp6",
 			"sha256": "e92569ac33247261aa09adfadc34ced3994ac301cf8b58de415a2d5dbf15ccfc",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb"
+			],
 			"version": "1:1.1.2-3"
 		},
 		{
@@ -4972,7 +5623,10 @@
 			"key": "libxau6_1-1.0.9-1_arm64",
 			"name": "libxau6",
 			"sha256": "36c2bf400641a80521093771dc2562c903df4065f9eb03add50d90564337ea6c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb"
+			],
 			"version": "1:1.0.9-1"
 		},
 		{
@@ -4981,7 +5635,9 @@
 			"key": "libwebp6_0.6.1-2.1-p-deb11u2_arm64",
 			"name": "libwebp6",
 			"sha256": "edeb260e528fecae77457a63a468e55837a98079fdd7f1e20e9813c358f8c755",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_arm64.deb"
+			],
 			"version": "0.6.1-2.1+deb11u2"
 		},
 		{
@@ -4990,7 +5646,9 @@
 			"key": "libtiff5_4.2.0-1-p-deb11u5_arm64",
 			"name": "libtiff5",
 			"sha256": "6896296ef6193ff77434c5d1d09dd9a333633f7a208ab1cc7de3b286d2d45824",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_arm64.deb"
+			],
 			"version": "4.2.0-1+deb11u5"
 		},
 		{
@@ -4999,7 +5657,10 @@
 			"key": "libjpeg62-turbo_1-2.0.6-4_arm64",
 			"name": "libjpeg62-turbo",
 			"sha256": "8903394de23dc6ead5abfc80972c8fd44300c9903ad4589d0df926e71977d881",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_arm64.deb"
+			],
 			"version": "1:2.0.6-4"
 		},
 		{
@@ -5008,7 +5669,10 @@
 			"key": "libjbig0_2.1-3.1-p-b2_arm64",
 			"name": "libjbig0",
 			"sha256": "b71b3e62e162f64cb24466bf7c6e40b05ce2a67ca7fed26d267d498f2896d549",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_arm64.deb"
+			],
 			"version": "2.1-3.1+b2"
 		},
 		{
@@ -5017,7 +5681,10 @@
 			"key": "libdeflate0_1.7-1_arm64",
 			"name": "libdeflate0",
 			"sha256": "a1adc22600ea5e44e8ea715972ac2af7994cc7ff4d94bba8e8b01abb9ddbdfd0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_arm64.deb"
+			],
 			"version": "1.7-1"
 		},
 		{
@@ -5026,7 +5693,10 @@
 			"key": "libpng16-16_1.6.37-3_arm64",
 			"name": "libpng16-16",
 			"sha256": "f5f61274aa5f71b9e44b077bd7b9fa9cd5ff71d8b8295f47dc1b2d45378aa73e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_arm64.deb"
+			],
 			"version": "1.6.37-3"
 		},
 		{
@@ -5035,7 +5705,10 @@
 			"key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_arm64",
 			"name": "libfreetype6",
 			"sha256": "b25f1c148498dd2b49dc30da0a2b2537a7bd0cb34afb8ea681dd145053c9a3f8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_arm64.deb"
+			],
 			"version": "2.10.4+dfsg-1+deb11u1"
 		},
 		{
@@ -5044,7 +5717,10 @@
 			"key": "libbrotli1_1.0.9-2-p-b2_arm64",
 			"name": "libbrotli1",
 			"sha256": "52ca7f90de6cb6576a0a5cf5712fc4ae7344b79c44b8a1548087fd5d92bf1f64",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_arm64.deb"
+			],
 			"version": "1.0.9-2+b2"
 		},
 		{
@@ -5053,7 +5729,10 @@
 			"key": "libfontconfig1_2.13.1-4.2_arm64",
 			"name": "libfontconfig1",
 			"sha256": "18b13ef8a46e9d79ba6a6ba2db0c86e42583277b5d47f6942f3223e349c22641",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_arm64.deb"
+			],
 			"version": "2.13.1-4.2"
 		},
 		{
@@ -5062,7 +5741,10 @@
 			"key": "fontconfig-config_2.13.1-4.2_arm64",
 			"name": "fontconfig-config",
 			"sha256": "48afb6ad7d15e6104a343b789f73697301ad8bff77b69927bc998f5a409d8e90",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb"
+			],
 			"version": "2.13.1-4.2"
 		},
 		{
@@ -5071,7 +5753,10 @@
 			"key": "fonts-texgyre_20180621-3.1_arm64",
 			"name": "fonts-texgyre",
 			"sha256": "cb7e9a4b2471cfdd57194c16364f9102f0639816a2662fed4b30d2a158747076",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb"
+			],
 			"version": "20180621-3.1"
 		},
 		{
@@ -5080,7 +5765,10 @@
 			"key": "ucf_3.0043_arm64",
 			"name": "ucf",
 			"sha256": "ebef6bcd777b5c0cc2699926f2159db08433aed07c50cb321fd828b28c5e8d53",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb"
+			],
 			"version": "3.0043"
 		},
 		{
@@ -5089,7 +5777,10 @@
 			"key": "sensible-utils_0.0.14_arm64",
 			"name": "sensible-utils",
 			"sha256": "b9a447dc4ec8714196b037e20a2209e62cd669f5450222952f259bda4416b71f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb"
+			],
 			"version": "0.0.14"
 		},
 		{
@@ -5098,7 +5789,9 @@
 			"key": "libuuid1_2.36.1-8-p-deb11u1_arm64",
 			"name": "libuuid1",
 			"sha256": "3d677da6a22e9cac519fed5a2ed5b20a4217f51ca420fce57434b5e813c26e03",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_arm64.deb"
+			],
 			"version": "2.36.1-8+deb11u1"
 		},
 		{
@@ -5107,7 +5800,9 @@
 			"key": "libexpat1_2.2.10-2-p-deb11u5_arm64",
 			"name": "libexpat1",
 			"sha256": "8d20bfd061845bda0321d01accd6f8386ead5b1d7250a585d12b8d5fb1408ffa",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_arm64.deb"
+			],
 			"version": "2.2.10-2+deb11u5"
 		},
 		{
@@ -5116,7 +5811,9 @@
 			"key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-geoip",
 			"sha256": "7b1d105339402426108d4d10fa733f24f2340c9b6482d10917c194d13f66072f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5125,7 +5822,9 @@
 			"key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-stream-geoip2",
 			"sha256": "da0e67b4cc318b7bb338bec7476c260fecd6cc06ecfad4c7f9acb22a4a74d07b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5134,7 +5833,10 @@
 			"key": "libmaxminddb0_1.5.2-1_arm64",
 			"name": "libmaxminddb0",
 			"sha256": "05504845f0fab5c54075e462b99b326a224ceaefaccda864f641f1bf6d99914d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_arm64.deb"
+			],
 			"version": "1.5.2-1"
 		},
 		{
@@ -5143,7 +5845,9 @@
 			"key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-upstream-fair",
 			"sha256": "7be1dfa763e9158ccdea168b1103f5b6b16b3a0c95c3996076c7f4a20aa35bca",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5152,7 +5856,9 @@
 			"key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-subs-filter",
 			"sha256": "22354006f199cc3e8e51aac00ca649dd169ca91c2e565a4734f18f3741b061ef",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5161,7 +5867,9 @@
 			"key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-geoip2",
 			"sha256": "1ae5c1491a8f43ff3a0269270d1f954441cf6fb160b3f83bb2f10ae7b47eb0ce",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5170,7 +5878,9 @@
 			"key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-echo",
 			"sha256": "ef014f5f294e744e465a9075722c1d7cb3423392b2bd029d60e0d952fd90fde7",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5179,7 +5889,9 @@
 			"key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-dav-ext",
 			"sha256": "8c65130c9d18a28eadfb657bbe818de567ed6625147e868c3bbd739189f8a991",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5188,7 +5900,9 @@
 			"key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-auth-pam",
 			"sha256": "4e6e906608ef1960c2514f371445bf3a32ea72b7098cae38cedac4b5c10abf05",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5455,11 +6169,13 @@
 					"version": "3.9.2-3"
 				}
 			],
-			"key": "google-cloud-cli_503.0.0-0_arm64",
+			"key": "google-cloud-cli_507.0.0-0_arm64",
 			"name": "google-cloud-cli",
-			"sha256": "17f037d69e38af51a221bee880c08c84e5e10c7ef6b62322c3861d3634fc92bf",
-			"url": "https://packages.cloud.google.com/apt/pool/cloud-sdk/google-cloud-cli_503.0.0-0_arm64_0e6cae0af91a3189215d95843a1b0ad7.deb",
-			"version": "503.0.0-0"
+			"sha256": "631a094bcbbde91ba9e6dd338490feccc3c30d2354d281108a5b34bb3f905903",
+			"urls": [
+				"https://packages.cloud.google.com/apt/pool/cloud-sdk/google-cloud-cli_507.0.0-0_arm64_f4f857cbc23508883b7a94bd63b553be.deb"
+			],
+			"version": "507.0.0-0"
 		},
 		{
 			"arch": "arm64",
@@ -5467,7 +6183,10 @@
 			"key": "python3_3.9.2-3_arm64",
 			"name": "python3",
 			"sha256": "79197285d25e73a2a07667efe80af152dd932ac5ef3e13717f1ac824d111ea81",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3_3.9.2-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3_3.9.2-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3_3.9.2-3_arm64.deb"
+			],
 			"version": "3.9.2-3"
 		},
 		{
@@ -5476,7 +6195,10 @@
 			"key": "libpython3-stdlib_3.9.2-3_arm64",
 			"name": "libpython3-stdlib",
 			"sha256": "79ec02b6afc81938fd1418170c103cc90aabbc52e0e1738e2744c5a4ec69fde8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/libpython3-stdlib_3.9.2-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/libpython3-stdlib_3.9.2-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/libpython3-stdlib_3.9.2-3_arm64.deb"
+			],
 			"version": "3.9.2-3"
 		},
 		{
@@ -5485,7 +6207,10 @@
 			"key": "libpython3.9-stdlib_3.9.2-1_arm64",
 			"name": "libpython3.9-stdlib",
 			"sha256": "3b3612dcd7550f01ec3517fbe955838223f4cf115b6983e4ed6d7320cd4b05c4",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-stdlib_3.9.2-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-stdlib_3.9.2-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-stdlib_3.9.2-1_arm64.deb"
+			],
 			"version": "3.9.2-1"
 		},
 		{
@@ -5494,7 +6219,10 @@
 			"key": "libsqlite3-0_3.34.1-3_arm64",
 			"name": "libsqlite3-0",
 			"sha256": "1e33cd39dc4fff2a7edd7bb7e90a71e20fb528f6a581fe0287652e4dae77e0d0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sqlite3/libsqlite3-0_3.34.1-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sqlite3/libsqlite3-0_3.34.1-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/s/sqlite3/libsqlite3-0_3.34.1-3_arm64.deb"
+			],
 			"version": "3.34.1-3"
 		},
 		{
@@ -5503,7 +6231,10 @@
 			"key": "libreadline8_8.1-1_arm64",
 			"name": "libreadline8",
 			"sha256": "500c3cdc00dcaea2c4ed736e00bfcb6cb43c3415e808566c5dfa266dbfc0c5e5",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/libreadline8_8.1-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/libreadline8_8.1-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/libreadline8_8.1-1_arm64.deb"
+			],
 			"version": "8.1-1"
 		},
 		{
@@ -5512,7 +6243,10 @@
 			"key": "readline-common_8.1-1_arm64",
 			"name": "readline-common",
 			"sha256": "3f947176ef949f93e4ad5d76c067d33fa97cf90b62ee0748acb4f5f64790edc8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/readline-common_8.1-1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/readline-common_8.1-1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/readline-common_8.1-1_all.deb"
+			],
 			"version": "8.1-1"
 		},
 		{
@@ -5521,7 +6255,10 @@
 			"key": "install-info_6.7.0.dfsg.2-6_arm64",
 			"name": "install-info",
 			"sha256": "f12d0f3d104419e4796d44f720a77d6e4b522d2ae800a24a784e5485a7fcc5c5",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/texinfo/install-info_6.7.0.dfsg.2-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/texinfo/install-info_6.7.0.dfsg.2-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/texinfo/install-info_6.7.0.dfsg.2-6_arm64.deb"
+			],
 			"version": "6.7.0.dfsg.2-6"
 		},
 		{
@@ -5530,7 +6267,10 @@
 			"key": "libncursesw6_6.2-p-20201114-2-p-deb11u2_arm64",
 			"name": "libncursesw6",
 			"sha256": "26bd6f488b885d02dfe933038d1e15414f5fe98704b3f49d2cecf665ebcb0f5b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncursesw6_6.2+20201114-2+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncursesw6_6.2+20201114-2+deb11u2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncursesw6_6.2+20201114-2+deb11u2_arm64.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -5539,7 +6279,10 @@
 			"key": "libmpdec3_2.5.1-1_arm64",
 			"name": "libmpdec3",
 			"sha256": "171e2581970f36a39f65d1ca3c761e76b103844daae7903fcc07f7c3822a05bb",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mpdecimal/libmpdec3_2.5.1-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mpdecimal/libmpdec3_2.5.1-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/m/mpdecimal/libmpdec3_2.5.1-1_arm64.deb"
+			],
 			"version": "2.5.1-1"
 		},
 		{
@@ -5548,7 +6291,10 @@
 			"key": "mime-support_3.66_arm64",
 			"name": "mime-support",
 			"sha256": "b964e671e6c47674879a3e54130b6737e8760fbd3da6afcc015faa174af98ba0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mime-support/mime-support_3.66_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mime-support/mime-support_3.66_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/m/mime-support/mime-support_3.66_all.deb"
+			],
 			"version": "3.66"
 		},
 		{
@@ -5557,7 +6303,10 @@
 			"key": "media-types_4.0.0_arm64",
 			"name": "media-types",
 			"sha256": "f9835dcf3cdbaf163104d4e511c9c4e0f41a56822e147e57f28f749fcbf7d44c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/media-types/media-types_4.0.0_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/media-types/media-types_4.0.0_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/m/media-types/media-types_4.0.0_all.deb"
+			],
 			"version": "4.0.0"
 		},
 		{
@@ -5566,7 +6315,10 @@
 			"key": "mailcap_3.69_arm64",
 			"name": "mailcap",
 			"sha256": "63fa5520f05d2aea5ca23eee95981a5e029608e1186ded4143470c8f84184158",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mailcap/mailcap_3.69_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mailcap/mailcap_3.69_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/m/mailcap/mailcap_3.69_all.deb"
+			],
 			"version": "3.69"
 		},
 		{
@@ -5575,7 +6327,10 @@
 			"key": "libpython3.9-minimal_3.9.2-1_arm64",
 			"name": "libpython3.9-minimal",
 			"sha256": "b49736ab0e8b8577f97a474ca67e20c1c025f9d7394ec8d7820de6314c903cf9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-minimal_3.9.2-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-minimal_3.9.2-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-minimal_3.9.2-1_arm64.deb"
+			],
 			"version": "3.9.2-1"
 		},
 		{
@@ -5584,7 +6339,10 @@
 			"key": "python3.9_3.9.2-1_arm64",
 			"name": "python3.9",
 			"sha256": "88cbc8eee37ef1f240fdd458f984bd3770cdd8cb1703e8e1666e026f6ca61327",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9_3.9.2-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9_3.9.2-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9_3.9.2-1_arm64.deb"
+			],
 			"version": "3.9.2-1"
 		},
 		{
@@ -5593,7 +6351,10 @@
 			"key": "python3.9-minimal_3.9.2-1_arm64",
 			"name": "python3.9-minimal",
 			"sha256": "bc0d0ed39ebc066020c3a16afdab4fd3e0260b41ae799273531d5b2403ae7b27",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9-minimal_3.9.2-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9-minimal_3.9.2-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9-minimal_3.9.2-1_arm64.deb"
+			],
 			"version": "3.9.2-1"
 		},
 		{
@@ -5602,7 +6363,10 @@
 			"key": "python3-minimal_3.9.2-3_arm64",
 			"name": "python3-minimal",
 			"sha256": "7c0e0e24c995d3419e3c80fa47407b8fef0b631c70dbadee75d1783e509c4783",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3-minimal_3.9.2-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3-minimal_3.9.2-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3-minimal_3.9.2-3_arm64.deb"
+			],
 			"version": "3.9.2-3"
 		}
 	],

--- a/e2e/smoke/bullseye.yaml
+++ b/e2e/smoke/bullseye.yaml
@@ -11,12 +11,13 @@ version: 1
 
 sources:
   - channel: bullseye main contrib
-    url: https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z
+    urls:
+      - https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z
+      - https://snapshot.debian.org/archive/debian/20240210T223313Z
   - channel: bullseye-security main
     url: https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z
   - channel: bullseye-updates main
     url: https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/
-  # This channel contains an uncompressed Packages file
   - channel: cloud-sdk main
     url: https://packages.cloud.google.com/apt
 

--- a/examples/debian_snapshot/bullseye.lock.json
+++ b/examples/debian_snapshot/bullseye.lock.json
@@ -6,7 +6,10 @@
 			"key": "ncurses-base_6.2-p-20201114-2-p-deb11u2_amd64",
 			"name": "ncurses-base",
 			"sha256": "a55a5f94299448279da6a6c2031a9816dc768cd300668ff82ecfc6480bbfc83d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -41,7 +44,10 @@
 			"key": "libncurses6_6.2-p-20201114-2-p-deb11u2_amd64",
 			"name": "libncurses6",
 			"sha256": "5b75c540d26d0525f231d39e5cf27ea7919d57305ba7101ea430c975369095eb",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_amd64.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -50,7 +56,10 @@
 			"key": "libc6_2.31-13-p-deb11u8_amd64",
 			"name": "libc6",
 			"sha256": "d55d9c9769336f9b8516c20bd8364ce90746fb860ae3dda242f421e711af3d1a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_amd64.deb"
+			],
 			"version": "2.31-13+deb11u8"
 		},
 		{
@@ -59,7 +68,10 @@
 			"key": "libcrypt1_1-4.4.18-4_amd64",
 			"name": "libcrypt1",
 			"sha256": "f617952df0c57b4ee039448e3941bccd3f97bfff71e9b0f87ca6dae15cb3f5ef",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_amd64.deb"
+			],
 			"version": "1:4.4.18-4"
 		},
 		{
@@ -68,7 +80,10 @@
 			"key": "libgcc-s1_10.2.1-6_amd64",
 			"name": "libgcc-s1",
 			"sha256": "e478f2709d8474165bb664de42e16950c391f30eaa55bc9b3573281d83a29daf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -77,7 +92,10 @@
 			"key": "gcc-10-base_10.2.1-6_amd64",
 			"name": "gcc-10-base",
 			"sha256": "be65535e94f95fbf04b104e8ab36790476f063374430f7dfc6c516cbe2d2cd1e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_amd64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -86,7 +104,10 @@
 			"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_amd64",
 			"name": "libtinfo6",
 			"sha256": "96ed58b8fd656521e08549c763cd18da6cff1b7801a3a22f29678701a95d7e7b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_amd64.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -166,7 +187,10 @@
 			"key": "tzdata_2024a-0-p-deb11u1_amd64",
 			"name": "tzdata",
 			"sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb"
+			],
 			"version": "2024a-0+deb11u1"
 		},
 		{
@@ -175,7 +199,10 @@
 			"key": "debconf_1.5.77_amd64",
 			"name": "debconf",
 			"sha256": "d9ee4dff77aaad12674eed3ccefdcccd332424c9e2ac2ac00a37a1e06c84ab70",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb"
+			],
 			"version": "1.5.77"
 		},
 		{
@@ -184,7 +211,10 @@
 			"key": "perl-base_5.32.1-4-p-deb11u3_amd64",
 			"name": "perl-base",
 			"sha256": "94c6299552866aadc58acb8ec5111a74b17bcb453f6e2f45ea5f7c4f42580d13",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_amd64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -249,7 +279,10 @@
 			"key": "dpkg_1.20.13_amd64",
 			"name": "dpkg",
 			"sha256": "eb2b7ba3a3c4e905a380045a2d1cd219d2d45755aba5966d6c804b79400beb05",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_amd64.deb"
+			],
 			"version": "1.20.13"
 		},
 		{
@@ -258,7 +291,10 @@
 			"key": "tar_1.34-p-dfsg-1-p-deb11u1_amd64",
 			"name": "tar",
 			"sha256": "41c9c31f67a76b3532036f09ceac1f40a9224f1680395d120a8b24eae60dd54a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_amd64.deb"
+			],
 			"version": "1.34+dfsg-1+deb11u1"
 		},
 		{
@@ -267,7 +303,10 @@
 			"key": "libselinux1_3.1-3_amd64",
 			"name": "libselinux1",
 			"sha256": "339f5ede10500c16dd7192d73169c31c4b27ab12130347275f23044ec8c7d897",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_amd64.deb"
+			],
 			"version": "3.1-3"
 		},
 		{
@@ -276,7 +315,10 @@
 			"key": "libpcre2-8-0_10.36-2-p-deb11u1_amd64",
 			"name": "libpcre2-8-0",
 			"sha256": "ee192c8d22624eb9d0a2ae95056bad7fb371e5abc17e23e16b1de3ddb17a1064",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_amd64.deb"
+			],
 			"version": "10.36-2+deb11u1"
 		},
 		{
@@ -285,7 +327,10 @@
 			"key": "libacl1_2.2.53-10_amd64",
 			"name": "libacl1",
 			"sha256": "aa18d721be8aea50fbdb32cd9a319cb18a3f111ea6ad17399aa4ba9324c8e26a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_amd64.deb"
+			],
 			"version": "2.2.53-10"
 		},
 		{
@@ -294,7 +339,9 @@
 			"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_amd64",
 			"name": "zlib1g",
 			"sha256": "03d2ab2174af76df6f517b854b77460fbdafc3dac0dca979317da67538159a3e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_amd64.deb"
+			],
 			"version": "1:1.2.11.dfsg-2+deb11u2"
 		},
 		{
@@ -303,7 +350,9 @@
 			"key": "liblzma5_5.2.5-2.1_deb11u1_amd64",
 			"name": "liblzma5",
 			"sha256": "1c79a02415ca5ee7234ac60502fb33ee94fa70b02d1c329a6a14178f8329c435",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_amd64.deb"
+			],
 			"version": "5.2.5-2.1~deb11u1"
 		},
 		{
@@ -312,7 +361,10 @@
 			"key": "libbz2-1.0_1.0.8-4_amd64",
 			"name": "libbz2-1.0",
 			"sha256": "16e27c3ebd97981e70db3733f899963362748f178a62644df69d1f247e741379",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_amd64.deb"
+			],
 			"version": "1.0.8-4"
 		},
 		{
@@ -367,7 +419,10 @@
 			"key": "coreutils_8.32-4-p-b1_amd64",
 			"name": "coreutils",
 			"sha256": "3558a412ab51eee4b60641327cb145bb91415f127769823b68f9335585b308d4",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4+b1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4+b1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4+b1_amd64.deb"
+			],
 			"version": "8.32-4+b1"
 		},
 		{
@@ -376,7 +431,10 @@
 			"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_amd64",
 			"name": "libgmp10",
 			"sha256": "fc117ccb084a98d25021f7e01e4dfedd414fa2118fdd1e27d2d801d7248aebbc",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_amd64.deb"
+			],
 			"version": "2:6.2.1+dfsg-1+deb11u1"
 		},
 		{
@@ -385,7 +443,10 @@
 			"key": "libattr1_1-2.4.48-6_amd64",
 			"name": "libattr1",
 			"sha256": "af3c3562eb2802481a2b9558df1b389f3c6d9b1bf3b4219e000e05131372ebaf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_amd64.deb"
+			],
 			"version": "1:2.4.48-6"
 		},
 		{
@@ -680,7 +741,10 @@
 			"key": "apt_2.2.4_amd64",
 			"name": "apt",
 			"sha256": "75f07c4965ff0813f26623a1164e162538f5e94defba6961347527ed71bc4f3d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_amd64.deb"
+			],
 			"version": "2.2.4"
 		},
 		{
@@ -689,7 +753,9 @@
 			"key": "libsystemd0_247.3-7-p-deb11u4_amd64",
 			"name": "libsystemd0",
 			"sha256": "e6f3e65e388196a399c1a36564c38ad987337350358732056227db1b6e708878",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_amd64.deb"
+			],
 			"version": "247.3-7+deb11u4"
 		},
 		{
@@ -698,7 +764,10 @@
 			"key": "libzstd1_1.4.8-p-dfsg-2.1_amd64",
 			"name": "libzstd1",
 			"sha256": "5dcadfbb743bfa1c1c773bff91c018f835e8e8c821d423d3836f3ab84773507b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_amd64.deb"
+			],
 			"version": "1.4.8+dfsg-2.1"
 		},
 		{
@@ -707,7 +776,10 @@
 			"key": "liblz4-1_1.9.3-2_amd64",
 			"name": "liblz4-1",
 			"sha256": "79ac6e9ca19c483f2e8effcc3401d723dd9dbb3a4ae324714de802adb21a8117",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_amd64.deb"
+			],
 			"version": "1.9.3-2"
 		},
 		{
@@ -716,7 +788,10 @@
 			"key": "libgcrypt20_1.8.7-6_amd64",
 			"name": "libgcrypt20",
 			"sha256": "7a2e0eef8e0c37f03f3a5fcf7102a2e3dc70ba987f696ab71949f9abf36f35ef",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_amd64.deb"
+			],
 			"version": "1.8.7-6"
 		},
 		{
@@ -725,7 +800,10 @@
 			"key": "libgpg-error0_1.38-2_amd64",
 			"name": "libgpg-error0",
 			"sha256": "16a507fb20cc58b5a524a0dc254a9cb1df02e1ce758a2d8abde0bc4a3c9b7c26",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_amd64.deb"
+			],
 			"version": "1.38-2"
 		},
 		{
@@ -734,7 +812,10 @@
 			"key": "libstdc-p--p-6_10.2.1-6_amd64",
 			"name": "libstdc++6",
 			"sha256": "5c155c58935870bf3b4bfe769116841c0d286a74f59eccfd5645693ac23f06b1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -743,7 +824,10 @@
 			"key": "libseccomp2_2.5.1-1-p-deb11u1_amd64",
 			"name": "libseccomp2",
 			"sha256": "2617fc8b99dca0fa8ed466ee0f5fe087aa4e8413b88ca45d717290f4a0551e36",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_amd64.deb"
+			],
 			"version": "2.5.1-1+deb11u1"
 		},
 		{
@@ -752,7 +836,10 @@
 			"key": "libgnutls30_3.7.1-5-p-deb11u4_amd64",
 			"name": "libgnutls30",
 			"sha256": "b2fa128881a16c2196caddb551d3577baa296a7bc5d38109a978e8e69fdb5c94",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_amd64.deb"
+			],
 			"version": "3.7.1-5+deb11u4"
 		},
 		{
@@ -761,7 +848,10 @@
 			"key": "libunistring2_0.9.10-4_amd64",
 			"name": "libunistring2",
 			"sha256": "654433ad02d3a8b05c1683c6c29a224500bf343039c34dcec4e5e9515345e3d4",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_amd64.deb"
+			],
 			"version": "0.9.10-4"
 		},
 		{
@@ -770,7 +860,10 @@
 			"key": "libtasn1-6_4.16.0-2-p-deb11u1_amd64",
 			"name": "libtasn1-6",
 			"sha256": "6ebb579337cdc9d6201237a66578425a7a221db622524354e27c0c1bcb6dd7ca",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_amd64.deb"
+			],
 			"version": "4.16.0-2+deb11u1"
 		},
 		{
@@ -779,7 +872,10 @@
 			"key": "libp11-kit0_0.23.22-1_amd64",
 			"name": "libp11-kit0",
 			"sha256": "bfef5f31ee1c730e56e16bb62cc5ff8372185106c75bf1ed1756c96703019457",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_amd64.deb"
+			],
 			"version": "0.23.22-1"
 		},
 		{
@@ -788,7 +884,10 @@
 			"key": "libffi7_3.3-6_amd64",
 			"name": "libffi7",
 			"sha256": "30ca89bfddae5fa6e0a2a044f22b6e50cd17c4bc6bc850c579819aeab7101f0f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb"
+			],
 			"version": "3.3-6"
 		},
 		{
@@ -797,7 +896,10 @@
 			"key": "libnettle8_3.7.3-1_amd64",
 			"name": "libnettle8",
 			"sha256": "e4f8ec31ed14518b241eb7b423ad5ed3f4a4e8ac50aae72c9fd475c569582764",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_amd64.deb"
+			],
 			"version": "3.7.3-1"
 		},
 		{
@@ -806,7 +908,10 @@
 			"key": "libidn2-0_2.3.0-5_amd64",
 			"name": "libidn2-0",
 			"sha256": "cb80cd769171537bafbb4a16c12ec427065795946b3415781bc9792e92d60b59",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_amd64.deb"
+			],
 			"version": "2.3.0-5"
 		},
 		{
@@ -815,7 +920,10 @@
 			"key": "libhogweed6_3.7.3-1_amd64",
 			"name": "libhogweed6",
 			"sha256": "6aab2e892cdb2dfba45707601bc6c3b19aa228f70ae5841017f14c3b0ca3d22f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb"
+			],
 			"version": "3.7.3-1"
 		},
 		{
@@ -824,7 +932,10 @@
 			"key": "debian-archive-keyring_2021.1.1-p-deb11u1_amd64",
 			"name": "debian-archive-keyring",
 			"sha256": "28ca7749ab7978f3c571732c3aa1c56e3ad1d5db3c915293763d4f6cb8fcce89",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb"
+			],
 			"version": "2021.1.1+deb11u1"
 		},
 		{
@@ -833,7 +944,10 @@
 			"key": "libapt-pkg6.0_2.2.4_amd64",
 			"name": "libapt-pkg6.0",
 			"sha256": "4ae47bedf773ad1342e5aae8fa6275f864cfc87a45f4472775f5a9cdd60abbbf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_amd64.deb"
+			],
 			"version": "2.2.4"
 		},
 		{
@@ -842,7 +956,10 @@
 			"key": "libxxhash0_0.8.0-2_amd64",
 			"name": "libxxhash0",
 			"sha256": "3fb82550a71d27d05672472508548576dfb34486847bc860d3066cda5aaf186f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_amd64.deb"
+			],
 			"version": "0.8.0-2"
 		},
 		{
@@ -851,7 +968,9 @@
 			"key": "libudev1_247.3-7-p-deb11u4_amd64",
 			"name": "libudev1",
 			"sha256": "9274ca1aa37fcdf5895dad1de0895162351099ef8dff8a62f2f4c9eb181a8fce",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_amd64.deb"
+			],
 			"version": "247.3-7+deb11u4"
 		},
 		{
@@ -860,7 +979,10 @@
 			"key": "gpgv1_1.4.23-1.1_amd64",
 			"name": "gpgv1",
 			"sha256": "90b29048ca3a5dce708b1c0ed27522fcda9e946c0a2ff8117724f440f853adcf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_amd64.deb"
+			],
 			"version": "1.4.23-1.1"
 		},
 		{
@@ -869,7 +991,10 @@
 			"key": "adduser_3.118-p-deb11u1_amd64",
 			"name": "adduser",
 			"sha256": "1478a610fd50e190882ff41e16c57b628a508bcf5b5ac5313affb49d20818e0a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb"
+			],
 			"version": "3.118+deb11u1"
 		},
 		{
@@ -878,7 +1003,10 @@
 			"key": "passwd_1-4.8.1-1_amd64",
 			"name": "passwd",
 			"sha256": "542593f26502e87b4276fa778e6e3ae52e66b973979986fff77803d9fcb2c2e8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_amd64.deb"
+			],
 			"version": "1:4.8.1-1"
 		},
 		{
@@ -887,7 +1015,10 @@
 			"key": "libpam-modules_1.4.0-9-p-deb11u1_amd64",
 			"name": "libpam-modules",
 			"sha256": "ca1e121700bf4b3eb33e30e0774d3e63e1adae9d4b6a940ea3501225db3cc287",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_amd64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -896,7 +1027,10 @@
 			"key": "libpam-modules-bin_1.4.0-9-p-deb11u1_amd64",
 			"name": "libpam-modules-bin",
 			"sha256": "abbbd181329c236676222d3e912df13f8d1d90a117559edd997d90006369e5c8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_amd64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -905,7 +1039,10 @@
 			"key": "libpam0g_1.4.0-9-p-deb11u1_amd64",
 			"name": "libpam0g",
 			"sha256": "496771218fb585bb716fdae6ef8824dbfb5d544b4fa2f3cd4d0e4d7158ae2220",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_amd64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -914,7 +1051,10 @@
 			"key": "libaudit1_1-3.0-2_amd64",
 			"name": "libaudit1",
 			"sha256": "e3aa1383e387dc077a1176f7f3cbfdbc084bcc270a8938f598d5cb119773b268",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_amd64.deb"
+			],
 			"version": "1:3.0-2"
 		},
 		{
@@ -923,7 +1063,10 @@
 			"key": "libcap-ng0_0.7.9-2.2-p-b1_amd64",
 			"name": "libcap-ng0",
 			"sha256": "d34e29769b8ef23e9b9920814afb7905b8ee749db0814e6a8d937ccc4f309830",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_amd64.deb"
+			],
 			"version": "0.7.9-2.2+b1"
 		},
 		{
@@ -932,7 +1075,10 @@
 			"key": "libaudit-common_1-3.0-2_amd64",
 			"name": "libaudit-common",
 			"sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb"
+			],
 			"version": "1:3.0-2"
 		},
 		{
@@ -941,7 +1087,9 @@
 			"key": "libtirpc3_1.3.1-1-p-deb11u1_amd64",
 			"name": "libtirpc3",
 			"sha256": "86b216d59b6efcd07d56d14b8f4281d5c47f24e9c962f46bbaf02fce762c5e6a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_amd64.deb"
+			],
 			"version": "1.3.1-1+deb11u1"
 		},
 		{
@@ -950,7 +1098,9 @@
 			"key": "libtirpc-common_1.3.1-1-p-deb11u1_amd64",
 			"name": "libtirpc-common",
 			"sha256": "b2f10cb79e7d7a2f9b30bcdf036127df55cd4a34688547bc2886fa38f4969f77",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb"
+			],
 			"version": "1.3.1-1+deb11u1"
 		},
 		{
@@ -959,7 +1109,10 @@
 			"key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_amd64",
 			"name": "libgssapi-krb5-2",
 			"sha256": "037cc4bb34a6cd0d7a6e83bdcae6d68e0d0f9218eb7dedafc8099c8c0be491a2",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_amd64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -968,7 +1121,10 @@
 			"key": "libkrb5support0_1.18.3-6-p-deb11u4_amd64",
 			"name": "libkrb5support0",
 			"sha256": "da8d022e3dd7f4a72ea32e328b3ac382dbe6bdb91606c5738fe17a29f8ea8080",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_amd64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -977,7 +1133,10 @@
 			"key": "libkrb5-3_1.18.3-6-p-deb11u4_amd64",
 			"name": "libkrb5-3",
 			"sha256": "b785fa324cf27e6bf7f97fc0279470e6ce8a8cc54f8ccc6c9b24c8111ba5c952",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_amd64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -986,7 +1145,10 @@
 			"key": "libssl1.1_1.1.1w-0-p-deb11u1_amd64",
 			"name": "libssl1.1",
 			"sha256": "aadf8b4b197335645b230c2839b4517aa444fd2e8f434e5438c48a18857988f7",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb"
+			],
 			"version": "1.1.1w-0+deb11u1"
 		},
 		{
@@ -995,7 +1157,10 @@
 			"key": "libkeyutils1_1.6.1-2_amd64",
 			"name": "libkeyutils1",
 			"sha256": "f01060b434d8cad3c58d5811d2082389f11b3db8152657d6c22c1d298953f2a5",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_amd64.deb"
+			],
 			"version": "1.6.1-2"
 		},
 		{
@@ -1004,7 +1169,10 @@
 			"key": "libk5crypto3_1.18.3-6-p-deb11u4_amd64",
 			"name": "libk5crypto3",
 			"sha256": "f635062bcbfe2eef5a83fcba7d1a8ae343fc7c779cae88b11cae90fd6845a744",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_amd64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -1013,7 +1181,10 @@
 			"key": "libcom-err2_1.46.2-2_amd64",
 			"name": "libcom-err2",
 			"sha256": "d478f132871f4ab8352d39becf936d0ad74db905398bf98465d8fe3da6fb1126",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_amd64.deb"
+			],
 			"version": "1.46.2-2"
 		},
 		{
@@ -1022,7 +1193,10 @@
 			"key": "libnsl2_1.3.0-2_amd64",
 			"name": "libnsl2",
 			"sha256": "c0d83437fdb016cb289436f49f28a36be44b3e8f1f2498c7e3a095f709c0d6f8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_amd64.deb"
+			],
 			"version": "1.3.0-2"
 		},
 		{
@@ -1031,7 +1205,10 @@
 			"key": "libdb5.3_5.3.28-p-dfsg1-0.8_amd64",
 			"name": "libdb5.3",
 			"sha256": "00b9e63e287f45300d4a4f59b6b88e25918443c932ae3e5845d5761ae193c530",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_amd64.deb"
+			],
 			"version": "5.3.28+dfsg1-0.8"
 		},
 		{
@@ -1040,7 +1217,10 @@
 			"key": "libsemanage1_3.1-1-p-b2_amd64",
 			"name": "libsemanage1",
 			"sha256": "d8f2835b22df58ba45d52eb3aab224190f193576caf05e3f80deb2e4f927fad6",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_amd64.deb"
+			],
 			"version": "3.1-1+b2"
 		},
 		{
@@ -1049,7 +1229,10 @@
 			"key": "libsepol1_3.1-1_amd64",
 			"name": "libsepol1",
 			"sha256": "b6057dc6806a6dfaef74b09d84d1f18716d7a6d2f1da30520cef555210c6af62",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_amd64.deb"
+			],
 			"version": "3.1-1"
 		},
 		{
@@ -1058,7 +1241,10 @@
 			"key": "libsemanage-common_3.1-1_amd64",
 			"name": "libsemanage-common",
 			"sha256": "d319a026ecd02e2f605c52350949279f3c331a19380f8b6888ce5b9ef0d31349",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb"
+			],
 			"version": "3.1-1"
 		},
 		{
@@ -1158,7 +1344,10 @@
 			"key": "perl_5.32.1-4-p-deb11u3_amd64",
 			"name": "perl",
 			"sha256": "d5f710c7db9fcd6d9d6f119cd0dea64a4f765867447dd97b24ab44be1de7c60f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_amd64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -1167,7 +1356,10 @@
 			"key": "libperl5.32_5.32.1-4-p-deb11u3_amd64",
 			"name": "libperl5.32",
 			"sha256": "078487a45916167e3e4ee2e584c50306c84368dd06dae276604861ca0426c34e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_amd64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -1176,7 +1368,10 @@
 			"key": "perl-modules-5.32_5.32.1-4-p-deb11u3_amd64",
 			"name": "perl-modules-5.32",
 			"sha256": "9a5cb99d0f33cb11c7f535aaebfb569c6b6f97a75d748a9a52ea3afed5bd3960",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -1185,7 +1380,10 @@
 			"key": "libgdbm6_1.19-2_amd64",
 			"name": "libgdbm6",
 			"sha256": "e54cfe4d8b8f209bb7df31a404ce040f7c2f9b1045114a927a7e1061cdf90727",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_amd64.deb"
+			],
 			"version": "1.19-2"
 		},
 		{
@@ -1194,7 +1392,10 @@
 			"key": "libgdbm-compat4_1.19-2_amd64",
 			"name": "libgdbm-compat4",
 			"sha256": "e62caed68b0ffaa03b5fa539d6fdc08c4151f66236d5878949bead0b71b7bb09",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_amd64.deb"
+			],
 			"version": "1.19-2"
 		},
 		{
@@ -1284,7 +1485,10 @@
 			"key": "ca-certificates_20210119_amd64",
 			"name": "ca-certificates",
 			"sha256": "b2d488ad4d8d8adb3ba319fc9cb2cf9909fc42cb82ad239a26c570a2e749c389",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb"
+			],
 			"version": "20210119"
 		},
 		{
@@ -1293,7 +1497,10 @@
 			"key": "openssl_1.1.1w-0-p-deb11u1_amd64",
 			"name": "openssl",
 			"sha256": "04873d74cbe86bad3a9901f6e57f1150040eba9891b443c5c975a72a97238e35",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_amd64.deb"
+			],
 			"version": "1.1.1w-0+deb11u1"
 		},
 		{
@@ -1302,7 +1509,10 @@
 			"key": "nvidia-kernel-common_20151021-p-13_amd64",
 			"name": "nvidia-kernel-common",
 			"sha256": "fa4b007bf64cf8cf0e9b3aaae5dd388fcec3a589ce2475f16d64347945691533",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_amd64.deb"
+			],
 			"version": "20151021+13"
 		},
 		{
@@ -1347,7 +1557,10 @@
 			"key": "bash_5.1-2-p-deb11u1_amd64",
 			"name": "bash",
 			"sha256": "f702ef058e762d7208a9c83f6f6bbf02645533bfd615c54e8cdcce842cd57377",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_amd64.deb"
+			],
 			"version": "5.1-2+deb11u1"
 		},
 		{
@@ -1356,7 +1569,10 @@
 			"key": "debianutils_4.11.2_amd64",
 			"name": "debianutils",
 			"sha256": "83d21669c5957e3eaee20096a7d8c596bd07f57f1e95dc74f192b3fb7bb2e6a9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_amd64.deb"
+			],
 			"version": "4.11.2"
 		},
 		{
@@ -1365,7 +1581,10 @@
 			"key": "base-files_11.1-p-deb11u9_amd64",
 			"name": "base-files",
 			"sha256": "1ff08cf6e1b97af1e37cda830f3658f9af43a906abb80a21951c81aea02ce230",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_amd64.deb"
+			],
 			"version": "11.1+deb11u9"
 		},
 		{
@@ -1775,7 +1994,9 @@
 			"key": "nginx-full_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "nginx-full",
 			"sha256": "4049950f648478009faeaf028ab7287240ebd28c27799a5b128a1623290b3e44",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2120,7 +2341,9 @@
 			"key": "nginx-core_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "nginx-core",
 			"sha256": "3d36d36ee74a62037159aeae87c51d2535bf7195a0fb325bde90a325034fc152",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2129,7 +2352,10 @@
 			"key": "libpcre3_2-8.39-13_amd64",
 			"name": "libpcre3",
 			"sha256": "48efcf2348967c211cd9408539edf7ec3fa9d800b33041f6511ccaecc1ffa9d0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_amd64.deb"
+			],
 			"version": "2:8.39-13"
 		},
 		{
@@ -2138,7 +2364,10 @@
 			"key": "iproute2_5.10.0-4_amd64",
 			"name": "iproute2",
 			"sha256": "bad652452612c81b8cfdca1411a036a768f5fa3461a04d6662f1ee0807ea3791",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_amd64.deb"
+			],
 			"version": "5.10.0-4"
 		},
 		{
@@ -2147,7 +2376,10 @@
 			"key": "libcap2-bin_1-2.44-1_amd64",
 			"name": "libcap2-bin",
 			"sha256": "a5b9717d8455cf8517c4c5f29aa04a4dec973430f0d3c1232f652abb9a4d93cc",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_amd64.deb"
+			],
 			"version": "1:2.44-1"
 		},
 		{
@@ -2156,7 +2388,10 @@
 			"key": "libcap2_1-2.44-1_amd64",
 			"name": "libcap2",
 			"sha256": "7a3ae3e97d0d403a4c54663c0bb48e9341d98822420a4ab808c6dc8e8474558f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_amd64.deb"
+			],
 			"version": "1:2.44-1"
 		},
 		{
@@ -2165,7 +2400,10 @@
 			"key": "libxtables12_1.8.7-1_amd64",
 			"name": "libxtables12",
 			"sha256": "9702a4be6f267b58c8fc1cfa0747bbefccb8b9a9af2a3547535533fbf2a7c14d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_amd64.deb"
+			],
 			"version": "1.8.7-1"
 		},
 		{
@@ -2174,7 +2412,10 @@
 			"key": "libmnl0_1.0.4-3_amd64",
 			"name": "libmnl0",
 			"sha256": "4581f42e3373cb72f9ea4e88163b17873afca614a6c6f54637e95aa75983ea7c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_amd64.deb"
+			],
 			"version": "1.0.4-3"
 		},
 		{
@@ -2183,7 +2424,10 @@
 			"key": "libelf1_0.183-1_amd64",
 			"name": "libelf1",
 			"sha256": "e1ad132d502b255023c222d0cae1d02ca941f6b68fd0e9b908c6004cc326592c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_amd64.deb"
+			],
 			"version": "0.183-1"
 		},
 		{
@@ -2192,7 +2436,10 @@
 			"key": "libbsd0_0.11.3-1-p-deb11u1_amd64",
 			"name": "libbsd0",
 			"sha256": "6ec5a08a4bb32c0dc316617f4bbefa8654c472d1cd4412ab8995f3955491f4a8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_amd64.deb"
+			],
 			"version": "0.11.3-1+deb11u1"
 		},
 		{
@@ -2201,7 +2448,10 @@
 			"key": "libmd0_1.0.3-3_amd64",
 			"name": "libmd0",
 			"sha256": "9e425b3c128b69126d95e61998e1b5ef74e862dd1fc953d91eebcc315aea62ea",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_amd64.deb"
+			],
 			"version": "1.0.3-3"
 		},
 		{
@@ -2210,7 +2460,10 @@
 			"key": "libbpf0_1-0.3-2_amd64",
 			"name": "libbpf0",
 			"sha256": "21775f2ae3e1221dab6b9cbb7743df54f751b831e89e005a6f3ce951ba3a30b9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_amd64.deb"
+			],
 			"version": "1:0.3-2"
 		},
 		{
@@ -2219,7 +2472,9 @@
 			"key": "nginx-common_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "nginx-common",
 			"sha256": "bfd22beb7bd248db58eee6e6434a7c500f6e98e264219b3832f248696cd58f67",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2228,7 +2483,10 @@
 			"key": "lsb-base_11.1.0_amd64",
 			"name": "lsb-base",
 			"sha256": "89ed6332074d827a65305f9a51e591dff20641d61ff5e11f4e1822a9987e96fe",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb"
+			],
 			"version": "11.1.0"
 		},
 		{
@@ -2237,7 +2495,9 @@
 			"key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-stream-geoip",
 			"sha256": "b1b22074e8586b9c2fa48fdd460fb43f719e4305a89209cd151102a012af4772",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2246,7 +2506,9 @@
 			"key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-stream",
 			"sha256": "1fbc038483013a78f884314a274bafa221000c8d6cddfd76fd217d23bf26b8d0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2255,7 +2517,10 @@
 			"key": "libgeoip1_1.6.12-7_amd64",
 			"name": "libgeoip1",
 			"sha256": "d4d6076106a6f522144e8071baf6d5fdbd415035f51e081075053ca8223cad51",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_amd64.deb"
+			],
 			"version": "1.6.12-7"
 		},
 		{
@@ -2264,7 +2529,9 @@
 			"key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-mail",
 			"sha256": "3d401417fc74090544c8cd8586add33cbd2f8d88437072233bca9547922f3384",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2273,7 +2540,9 @@
 			"key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-xslt-filter",
 			"sha256": "e51af1373b99ce692dfcb11f185ceb4664b6009a50b4d92773af2c74601d2d4a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2282,7 +2551,9 @@
 			"key": "libxslt1.1_1.1.34-4-p-deb11u1_amd64",
 			"name": "libxslt1.1",
 			"sha256": "e6109d282ad9a330856b88944a953e86329b2c07d8b0f378a2fd0493f27352c8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_amd64.deb"
+			],
 			"version": "1.1.34-4+deb11u1"
 		},
 		{
@@ -2291,7 +2562,9 @@
 			"key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_amd64",
 			"name": "libxml2",
 			"sha256": "b29ea9026561ef0019a57b8b192bf08f725976cd1dddd3fc6bcf876840350989",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_amd64.deb"
+			],
 			"version": "2.9.10+dfsg-6.7+deb11u4"
 		},
 		{
@@ -2300,7 +2573,10 @@
 			"key": "libicu67_67.1-7_amd64",
 			"name": "libicu67",
 			"sha256": "2bf5c46254f527865bfd6368e1120908755fa57d83634bd7d316c9b3cfd57303",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_amd64.deb"
+			],
 			"version": "67.1-7"
 		},
 		{
@@ -2309,7 +2585,9 @@
 			"key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-image-filter",
 			"sha256": "811bae64a056aeb4d68329296b0d5f96749a688285977fd2b192f8c81f623304",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2318,7 +2596,10 @@
 			"key": "libgd3_2.3.0-2_amd64",
 			"name": "libgd3",
 			"sha256": "fadaa01272200dcaa476c6b8908e1faa93d6840610beca909099647829f3fdc1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_amd64.deb"
+			],
 			"version": "2.3.0-2"
 		},
 		{
@@ -2327,7 +2608,9 @@
 			"key": "libxpm4_1-3.5.12-1.1-p-deb11u1_amd64",
 			"name": "libxpm4",
 			"sha256": "349a5a8cf0de6cb33c199027abfbd6b7a13f5160948e6db066a96080c61e4819",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_amd64.deb"
+			],
 			"version": "1:3.5.12-1.1+deb11u1"
 		},
 		{
@@ -2336,7 +2619,9 @@
 			"key": "libx11-6_2-1.7.2-1-p-deb11u2_amd64",
 			"name": "libx11-6",
 			"sha256": "2b3b959cb10c07be065eb638a8577fe20f282045aaef76425dbd7310d1244b8c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_amd64.deb"
+			],
 			"version": "2:1.7.2-1+deb11u2"
 		},
 		{
@@ -2345,7 +2630,9 @@
 			"key": "libx11-data_2-1.7.2-1-p-deb11u2_amd64",
 			"name": "libx11-data",
 			"sha256": "9db24e1e7ed3cd738b503e7df5c1b9b52b1eadcb55019cd63b1409e578565d29",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb"
+			],
 			"version": "2:1.7.2-1+deb11u2"
 		},
 		{
@@ -2354,7 +2641,10 @@
 			"key": "libxcb1_1.14-3_amd64",
 			"name": "libxcb1",
 			"sha256": "d5e0f047ed766f45eb7473947b70f9e8fddbe45ef22ecfd92ab712c0671a93ac",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_amd64.deb"
+			],
 			"version": "1.14-3"
 		},
 		{
@@ -2363,7 +2653,10 @@
 			"key": "libxdmcp6_1-1.1.2-3_amd64",
 			"name": "libxdmcp6",
 			"sha256": "ecb8536f5fb34543b55bb9dc5f5b14c9dbb4150a7bddb3f2287b7cab6e9d25ef",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_amd64.deb"
+			],
 			"version": "1:1.1.2-3"
 		},
 		{
@@ -2372,7 +2665,10 @@
 			"key": "libxau6_1-1.0.9-1_amd64",
 			"name": "libxau6",
 			"sha256": "679db1c4579ec7c61079adeaae8528adeb2e4bf5465baa6c56233b995d714750",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb"
+			],
 			"version": "1:1.0.9-1"
 		},
 		{
@@ -2381,7 +2677,9 @@
 			"key": "libwebp6_0.6.1-2.1-p-deb11u2_amd64",
 			"name": "libwebp6",
 			"sha256": "8abc2b1ca77a458bbbcdeb6af5d85316260977370fa2518d017222b3584d9653",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_amd64.deb"
+			],
 			"version": "0.6.1-2.1+deb11u2"
 		},
 		{
@@ -2390,7 +2688,9 @@
 			"key": "libtiff5_4.2.0-1-p-deb11u5_amd64",
 			"name": "libtiff5",
 			"sha256": "7a70e9513e2b3c3a3d68f1614189f0be72b57eae2229aa64a3d7c8a3fe0639c9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_amd64.deb"
+			],
 			"version": "4.2.0-1+deb11u5"
 		},
 		{
@@ -2399,7 +2699,10 @@
 			"key": "libjpeg62-turbo_1-2.0.6-4_amd64",
 			"name": "libjpeg62-turbo",
 			"sha256": "28de780a1605cf501c3a4ebf3e588f5110e814b208548748ab064100c32202ea",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_amd64.deb"
+			],
 			"version": "1:2.0.6-4"
 		},
 		{
@@ -2408,7 +2711,10 @@
 			"key": "libjbig0_2.1-3.1-p-b2_amd64",
 			"name": "libjbig0",
 			"sha256": "9646d69eefce505407bf0437ea12fb7c2d47a3fd4434720ba46b642b6dcfd80f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_amd64.deb"
+			],
 			"version": "2.1-3.1+b2"
 		},
 		{
@@ -2417,7 +2723,10 @@
 			"key": "libdeflate0_1.7-1_amd64",
 			"name": "libdeflate0",
 			"sha256": "dadaf0d28360f6eb21ad389b2e0f12f8709c9de539b28de9c11d7ec7043dec95",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_amd64.deb"
+			],
 			"version": "1.7-1"
 		},
 		{
@@ -2426,7 +2735,10 @@
 			"key": "libpng16-16_1.6.37-3_amd64",
 			"name": "libpng16-16",
 			"sha256": "7d5336af395d1f658d0e66d74d0e1f4c632028750e7e04314d1a650e0317f3d6",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_amd64.deb"
+			],
 			"version": "1.6.37-3"
 		},
 		{
@@ -2435,7 +2747,10 @@
 			"key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_amd64",
 			"name": "libfreetype6",
 			"sha256": "b21cfdd12adf6cac4af320c2485fb62a8a5edc6f9768bc2288fd686f4fa6dfdf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_amd64.deb"
+			],
 			"version": "2.10.4+dfsg-1+deb11u1"
 		},
 		{
@@ -2444,7 +2759,10 @@
 			"key": "libbrotli1_1.0.9-2-p-b2_amd64",
 			"name": "libbrotli1",
 			"sha256": "65ca7d8b03e9dac09c5d544a89dd52d1aeb74f6a19583d32e4ff5f0c77624c24",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_amd64.deb"
+			],
 			"version": "1.0.9-2+b2"
 		},
 		{
@@ -2453,7 +2771,10 @@
 			"key": "libfontconfig1_2.13.1-4.2_amd64",
 			"name": "libfontconfig1",
 			"sha256": "b92861827627a76e74d6f447a5577d039ef2f95da18af1f29aa98fb96baea4c1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_amd64.deb"
+			],
 			"version": "2.13.1-4.2"
 		},
 		{
@@ -2462,7 +2783,10 @@
 			"key": "fontconfig-config_2.13.1-4.2_amd64",
 			"name": "fontconfig-config",
 			"sha256": "48afb6ad7d15e6104a343b789f73697301ad8bff77b69927bc998f5a409d8e90",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb"
+			],
 			"version": "2.13.1-4.2"
 		},
 		{
@@ -2471,7 +2795,10 @@
 			"key": "fonts-texgyre_20180621-3.1_amd64",
 			"name": "fonts-texgyre",
 			"sha256": "cb7e9a4b2471cfdd57194c16364f9102f0639816a2662fed4b30d2a158747076",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb"
+			],
 			"version": "20180621-3.1"
 		},
 		{
@@ -2480,7 +2807,10 @@
 			"key": "ucf_3.0043_amd64",
 			"name": "ucf",
 			"sha256": "ebef6bcd777b5c0cc2699926f2159db08433aed07c50cb321fd828b28c5e8d53",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb"
+			],
 			"version": "3.0043"
 		},
 		{
@@ -2489,7 +2819,10 @@
 			"key": "sensible-utils_0.0.14_amd64",
 			"name": "sensible-utils",
 			"sha256": "b9a447dc4ec8714196b037e20a2209e62cd669f5450222952f259bda4416b71f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb"
+			],
 			"version": "0.0.14"
 		},
 		{
@@ -2498,7 +2831,9 @@
 			"key": "libuuid1_2.36.1-8-p-deb11u1_amd64",
 			"name": "libuuid1",
 			"sha256": "31250af4dd3b7d1519326a9a6764d1466a93d8f498cf6545058761ebc38b2823",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_amd64.deb"
+			],
 			"version": "2.36.1-8+deb11u1"
 		},
 		{
@@ -2507,7 +2842,9 @@
 			"key": "libexpat1_2.2.10-2-p-deb11u5_amd64",
 			"name": "libexpat1",
 			"sha256": "5744040c4735bcdd51238aebfa3e402b857244897f1007f61154982ebe5abbd7",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_amd64.deb"
+			],
 			"version": "2.2.10-2+deb11u5"
 		},
 		{
@@ -2516,7 +2853,9 @@
 			"key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-geoip",
 			"sha256": "639ceb3e17c3d5a3033757d86a57f3fa786be27ef51fd1618c8a84e9d55ef974",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2525,7 +2864,9 @@
 			"key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-stream-geoip2",
 			"sha256": "20abf8d42ceebe21dcf76c9c4952b9b9a5d8c140affade21c8aebb22d38469d9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2534,7 +2875,10 @@
 			"key": "libmaxminddb0_1.5.2-1_amd64",
 			"name": "libmaxminddb0",
 			"sha256": "9779e86a61b8315d119939f3226472f17d707dce0673eff7b961a478e519e351",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_amd64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_amd64.deb"
+			],
 			"version": "1.5.2-1"
 		},
 		{
@@ -2543,7 +2887,9 @@
 			"key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-upstream-fair",
 			"sha256": "9650cbb1808fd4d63703b70d5d4599c34e4781c85f5e2b2b47f0abc934397f28",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2552,7 +2898,9 @@
 			"key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-subs-filter",
 			"sha256": "fbfc00d65a6305911a7f025eb331912dadb6de7cdc5e65e5d94f2e65d70a5596",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2561,7 +2909,9 @@
 			"key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-geoip2",
 			"sha256": "de912c363bb1864148379f0784c8031194a3749ae930a5fd0eb1bc2df63d7957",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2570,7 +2920,9 @@
 			"key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-echo",
 			"sha256": "a5be1358d4fb799fdd5941377dea2c45cd013e2c4130dfce98f4af94aead1ec3",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2579,7 +2931,9 @@
 			"key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-dav-ext",
 			"sha256": "48458923ac10ed4ad432237583b617702e8ca6b88da330989711aa734f7e06ee",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -2588,17 +2942,21 @@
 			"key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_amd64",
 			"name": "libnginx-mod-http-auth-pam",
 			"sha256": "08f23455c05eee95e8c0bf96d1a52e6a1ddcf509dd1b4dec97c778ff2c596c92",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_amd64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_amd64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
 			"arch": "amd64",
 			"dependencies": [],
-			"key": "google-cloud-cli_503.0.0-0_amd64",
+			"key": "google-cloud-cli_507.0.0-0_amd64",
 			"name": "google-cloud-cli",
-			"sha256": "bf4388490f1facb8f0e67f4969c5d65eaadaba57d9dd95a71651e6a5ceafe891",
-			"url": "https://packages.cloud.google.com/apt/pool/cloud-sdk/google-cloud-cli_503.0.0-0_amd64_b5a207cb84a9db198e6aa8d1bda24b14.deb",
-			"version": "503.0.0-0"
+			"sha256": "d84b4e1891fac2f4132efdcdb42108a851b752612e08080c82a2eaff47b02afe",
+			"urls": [
+				"https://packages.cloud.google.com/apt/pool/cloud-sdk/google-cloud-cli_507.0.0-0_amd64_563ffde9b6bc7a27c15f014c68905adf.deb"
+			],
+			"version": "507.0.0-0"
 		},
 		{
 			"arch": "arm64",
@@ -2606,7 +2964,10 @@
 			"key": "ncurses-base_6.2-p-20201114-2-p-deb11u2_arm64",
 			"name": "ncurses-base",
 			"sha256": "a55a5f94299448279da6a6c2031a9816dc768cd300668ff82ecfc6480bbfc83d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/ncurses-base_6.2+20201114-2+deb11u2_all.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -2641,7 +3002,10 @@
 			"key": "libncurses6_6.2-p-20201114-2-p-deb11u2_arm64",
 			"name": "libncurses6",
 			"sha256": "039b71b8839538a92988003e13c29e7cf1149cdc6a77d3de882f1d386a5f3a5c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncurses6_6.2+20201114-2+deb11u2_arm64.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -2650,7 +3014,10 @@
 			"key": "libc6_2.31-13-p-deb11u8_arm64",
 			"name": "libc6",
 			"sha256": "6eb629090615ebda5dcac2365a7358c035add00b89c2724c2e9e13ccd5bd9f7c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/glibc/libc6_2.31-13+deb11u8_arm64.deb"
+			],
 			"version": "2.31-13+deb11u8"
 		},
 		{
@@ -2659,7 +3026,10 @@
 			"key": "libcrypt1_1-4.4.18-4_arm64",
 			"name": "libcrypt1",
 			"sha256": "22b586b29e840dabebf0bf227d233376628b87954915d064bc142ae85d1b7979",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcrypt/libcrypt1_4.4.18-4_arm64.deb"
+			],
 			"version": "1:4.4.18-4"
 		},
 		{
@@ -2668,7 +3038,10 @@
 			"key": "libgcc-s1_10.2.1-6_arm64",
 			"name": "libgcc-s1",
 			"sha256": "e2fcdb378d3c1ad1bcb64d4fb6b37aab44011152beca12a4944f435a2582df1f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_arm64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -2677,7 +3050,10 @@
 			"key": "gcc-10-base_10.2.1-6_arm64",
 			"name": "gcc-10-base",
 			"sha256": "7d782bece7b4a36bed045a7e17d17244cb8f7e4732466091b01412ebf215defb",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/gcc-10-base_10.2.1-6_arm64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -2686,7 +3062,10 @@
 			"key": "libtinfo6_6.2-p-20201114-2-p-deb11u2_arm64",
 			"name": "libtinfo6",
 			"sha256": "58027c991756930a2abb2f87a829393d3fdbfb76f4eca9795ef38ea2b0510e27",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -2766,7 +3145,10 @@
 			"key": "tzdata_2024a-0-p-deb11u1_arm64",
 			"name": "tzdata",
 			"sha256": "13befffb7ee127f569af92d736e30c86c199bbd58f9c3cca0d071ed63e04d003",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tzdata/tzdata_2024a-0+deb11u1_all.deb"
+			],
 			"version": "2024a-0+deb11u1"
 		},
 		{
@@ -2775,7 +3157,10 @@
 			"key": "debconf_1.5.77_arm64",
 			"name": "debconf",
 			"sha256": "d9ee4dff77aaad12674eed3ccefdcccd332424c9e2ac2ac00a37a1e06c84ab70",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debconf/debconf_1.5.77_all.deb"
+			],
 			"version": "1.5.77"
 		},
 		{
@@ -2784,7 +3169,10 @@
 			"key": "perl-base_5.32.1-4-p-deb11u3_arm64",
 			"name": "perl-base",
 			"sha256": "53e09d9594692c462f33d4e9394bff60f95fe74b70402772dc7396a5829b76e5",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-base_5.32.1-4+deb11u3_arm64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -2849,7 +3237,10 @@
 			"key": "dpkg_1.20.13_arm64",
 			"name": "dpkg",
 			"sha256": "87b0bce7361d94cc15caf27709fa8a70de44f9dd742cf0d69d25796a03d24853",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/dpkg/dpkg_1.20.13_arm64.deb"
+			],
 			"version": "1.20.13"
 		},
 		{
@@ -2858,7 +3249,10 @@
 			"key": "tar_1.34-p-dfsg-1-p-deb11u1_arm64",
 			"name": "tar",
 			"sha256": "0f94aac4e6d25e07ed23b7fc3ed06e69074c95276d82caae7fc7b207fd714e39",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tar/tar_1.34+dfsg-1+deb11u1_arm64.deb"
+			],
 			"version": "1.34+dfsg-1+deb11u1"
 		},
 		{
@@ -2867,7 +3261,10 @@
 			"key": "libselinux1_3.1-3_arm64",
 			"name": "libselinux1",
 			"sha256": "da98279a47dabaa46a83514142f5c691c6a71fa7e582661a3a3db6887ad3e9d1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libselinux/libselinux1_3.1-3_arm64.deb"
+			],
 			"version": "3.1-3"
 		},
 		{
@@ -2876,7 +3273,10 @@
 			"key": "libpcre2-8-0_10.36-2-p-deb11u1_arm64",
 			"name": "libpcre2-8-0",
 			"sha256": "27a4362a4793cb67a8ae571bd8c3f7e8654dc2e56d99088391b87af1793cca9c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre2/libpcre2-8-0_10.36-2+deb11u1_arm64.deb"
+			],
 			"version": "10.36-2+deb11u1"
 		},
 		{
@@ -2885,7 +3285,10 @@
 			"key": "libacl1_2.2.53-10_arm64",
 			"name": "libacl1",
 			"sha256": "f164c48192cb47746101de6c59afa3f97777c8fc821e5a30bb890df1f4cb4cfd",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/acl/libacl1_2.2.53-10_arm64.deb"
+			],
 			"version": "2.2.53-10"
 		},
 		{
@@ -2894,7 +3297,9 @@
 			"key": "zlib1g_1-1.2.11.dfsg-2-p-deb11u2_arm64",
 			"name": "zlib1g",
 			"sha256": "e3963985d1a020d67ffd4180e6f9c4b5c600b515f0c9d8fda513d7a0e48e63a1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/z/zlib/zlib1g_1.2.11.dfsg-2+deb11u2_arm64.deb"
+			],
 			"version": "1:1.2.11.dfsg-2+deb11u2"
 		},
 		{
@@ -2903,7 +3308,9 @@
 			"key": "liblzma5_5.2.5-2.1_deb11u1_arm64",
 			"name": "liblzma5",
 			"sha256": "d865bba41952c707b3fa3ae8cab4d4bd337ee92991d2aead66c925bf7cc48846",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/x/xz-utils/liblzma5_5.2.5-2.1~deb11u1_arm64.deb"
+			],
 			"version": "5.2.5-2.1~deb11u1"
 		},
 		{
@@ -2912,7 +3319,10 @@
 			"key": "libbz2-1.0_1.0.8-4_arm64",
 			"name": "libbz2-1.0",
 			"sha256": "da340e8470e96445c56966f74e48a9a91dee0fa5c89876e88a4575cc17d17a97",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/bzip2/libbz2-1.0_1.0.8-4_arm64.deb"
+			],
 			"version": "1.0.8-4"
 		},
 		{
@@ -2967,7 +3377,10 @@
 			"key": "coreutils_8.32-4_arm64",
 			"name": "coreutils",
 			"sha256": "6210c84d6ff84b867dc430f661f22f536e1704c27bdb79de38e26f75b853d9c0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/c/coreutils/coreutils_8.32-4_arm64.deb"
+			],
 			"version": "8.32-4"
 		},
 		{
@@ -2976,7 +3389,10 @@
 			"key": "libgmp10_2-6.2.1-p-dfsg-1-p-deb11u1_arm64",
 			"name": "libgmp10",
 			"sha256": "d52619b6ff8829aa5424dfe3189dd05f22118211e69273e9576030584ffcce80",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gmp/libgmp10_6.2.1+dfsg-1+deb11u1_arm64.deb"
+			],
 			"version": "2:6.2.1+dfsg-1+deb11u1"
 		},
 		{
@@ -2985,7 +3401,10 @@
 			"key": "libattr1_1-2.4.48-6_arm64",
 			"name": "libattr1",
 			"sha256": "cb9b59be719a6fdbaabaa60e22aa6158b2de7a68c88ccd7c3fb7f41a25fb43d0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/attr/libattr1_2.4.48-6_arm64.deb"
+			],
 			"version": "1:2.4.48-6"
 		},
 		{
@@ -3280,7 +3699,10 @@
 			"key": "apt_2.2.4_arm64",
 			"name": "apt",
 			"sha256": "39cbe42f3e64c6359b445d6fed7385273881e507b8be1d3b653ec9fb7d4c917c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/apt_2.2.4_arm64.deb"
+			],
 			"version": "2.2.4"
 		},
 		{
@@ -3289,7 +3711,9 @@
 			"key": "libsystemd0_247.3-7-p-deb11u4_arm64",
 			"name": "libsystemd0",
 			"sha256": "32e8c12301a9ada555adea9a4c2f15df788411dadd164baca5c31690fe06e381",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libsystemd0_247.3-7+deb11u4_arm64.deb"
+			],
 			"version": "247.3-7+deb11u4"
 		},
 		{
@@ -3298,7 +3722,10 @@
 			"key": "libzstd1_1.4.8-p-dfsg-2.1_arm64",
 			"name": "libzstd1",
 			"sha256": "dd01659c6c122f983a3369a04ede63539f666585d52a03f8aa2c27b307e547e0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libz/libzstd/libzstd1_1.4.8+dfsg-2.1_arm64.deb"
+			],
 			"version": "1.4.8+dfsg-2.1"
 		},
 		{
@@ -3307,7 +3734,10 @@
 			"key": "liblz4-1_1.9.3-2_arm64",
 			"name": "liblz4-1",
 			"sha256": "83f0ee547cd42854e1b2a2e4c1a5705e28259ee5fa6560119f918f961a5dada2",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/l/lz4/liblz4-1_1.9.3-2_arm64.deb"
+			],
 			"version": "1.9.3-2"
 		},
 		{
@@ -3316,7 +3746,10 @@
 			"key": "libgcrypt20_1.8.7-6_arm64",
 			"name": "libgcrypt20",
 			"sha256": "61ec779149f20923b30adad7bdf4732957e88a5b6a26d94b2210dfe79409959b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgcrypt20/libgcrypt20_1.8.7-6_arm64.deb"
+			],
 			"version": "1.8.7-6"
 		},
 		{
@@ -3325,7 +3758,10 @@
 			"key": "libgpg-error0_1.38-2_arm64",
 			"name": "libgpg-error0",
 			"sha256": "d1116f4281d6db35279799a21051e0d0e2600d110d7ee2b95b3cca6bec28067c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgpg-error/libgpg-error0_1.38-2_arm64.deb"
+			],
 			"version": "1.38-2"
 		},
 		{
@@ -3334,7 +3770,10 @@
 			"key": "libstdc-p--p-6_10.2.1-6_arm64",
 			"name": "libstdc++6",
 			"sha256": "7869aa540cc46e9f3d4267d5bde2af0e5b429a820c1d6f1a4cfccfe788c31890",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_arm64.deb"
+			],
 			"version": "10.2.1-6"
 		},
 		{
@@ -3343,7 +3782,10 @@
 			"key": "libseccomp2_2.5.1-1-p-deb11u1_arm64",
 			"name": "libseccomp2",
 			"sha256": "5b8983c2e330790dbe04ae990f166d7939a3e14b75556a8489309ae704fbeb50",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libseccomp/libseccomp2_2.5.1-1+deb11u1_arm64.deb"
+			],
 			"version": "2.5.1-1+deb11u1"
 		},
 		{
@@ -3352,7 +3794,10 @@
 			"key": "libgnutls30_3.7.1-5-p-deb11u4_arm64",
 			"name": "libgnutls30",
 			"sha256": "7153ec6ee985eebba710dcb6e425bb881c91ee5987a4517518f3f44a9bb5fc1a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnutls28/libgnutls30_3.7.1-5+deb11u4_arm64.deb"
+			],
 			"version": "3.7.1-5+deb11u4"
 		},
 		{
@@ -3361,7 +3806,10 @@
 			"key": "libunistring2_0.9.10-4_arm64",
 			"name": "libunistring2",
 			"sha256": "53ff395ea4d8cf17c52155a452a0dc15af0ee2fa5cb3b0085b9c7335de8d5f7f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libu/libunistring/libunistring2_0.9.10-4_arm64.deb"
+			],
 			"version": "0.9.10-4"
 		},
 		{
@@ -3370,7 +3818,10 @@
 			"key": "libtasn1-6_4.16.0-2-p-deb11u1_arm64",
 			"name": "libtasn1-6",
 			"sha256": "f469147bbd3969055c51fc661c9aa0d56d48eccd070d233f1424b0d8b3f29295",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libt/libtasn1-6/libtasn1-6_4.16.0-2+deb11u1_arm64.deb"
+			],
 			"version": "4.16.0-2+deb11u1"
 		},
 		{
@@ -3379,7 +3830,10 @@
 			"key": "libp11-kit0_0.23.22-1_arm64",
 			"name": "libp11-kit0",
 			"sha256": "ac6e8eda3277708069bc6f03aff06dc319855d64ede9fca219938e52f92ee09c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/p11-kit/libp11-kit0_0.23.22-1_arm64.deb"
+			],
 			"version": "0.23.22-1"
 		},
 		{
@@ -3388,7 +3842,10 @@
 			"key": "libffi7_3.3-6_arm64",
 			"name": "libffi7",
 			"sha256": "eb748e33ae4ed46f5a4c14b7a2a09792569f2029ede319d0979c373829ba1532",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libf/libffi/libffi7_3.3-6_arm64.deb"
+			],
 			"version": "3.3-6"
 		},
 		{
@@ -3397,7 +3854,10 @@
 			"key": "libnettle8_3.7.3-1_arm64",
 			"name": "libnettle8",
 			"sha256": "5061c931f95dc7277d95fc58bce7c17b1a95c6aa9a9aac781784f3b3dc909047",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libnettle8_3.7.3-1_arm64.deb"
+			],
 			"version": "3.7.3-1"
 		},
 		{
@@ -3406,7 +3866,10 @@
 			"key": "libidn2-0_2.3.0-5_arm64",
 			"name": "libidn2-0",
 			"sha256": "0d2e6d39bf65f16861f284be567c1a6c5d4dc6b54dcfdf9dba631546ff4e6796",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libi/libidn2/libidn2-0_2.3.0-5_arm64.deb"
+			],
 			"version": "2.3.0-5"
 		},
 		{
@@ -3415,7 +3878,10 @@
 			"key": "libhogweed6_3.7.3-1_arm64",
 			"name": "libhogweed6",
 			"sha256": "3e9eea5e474dd98a7de9e4c1ecfbfd6f6efb1d40bf51d6473de9713cf41d2191",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb"
+			],
 			"version": "3.7.3-1"
 		},
 		{
@@ -3424,7 +3890,10 @@
 			"key": "debian-archive-keyring_2021.1.1-p-deb11u1_arm64",
 			"name": "debian-archive-keyring",
 			"sha256": "28ca7749ab7978f3c571732c3aa1c56e3ad1d5db3c915293763d4f6cb8fcce89",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debian-archive-keyring/debian-archive-keyring_2021.1.1+deb11u1_all.deb"
+			],
 			"version": "2021.1.1+deb11u1"
 		},
 		{
@@ -3433,7 +3902,10 @@
 			"key": "libapt-pkg6.0_2.2.4_arm64",
 			"name": "libapt-pkg6.0",
 			"sha256": "7cb6015ea5c185ef93706989fb730377406878c72f6943b6ecdd956697f1abe6",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/apt/libapt-pkg6.0_2.2.4_arm64.deb"
+			],
 			"version": "2.2.4"
 		},
 		{
@@ -3442,7 +3914,10 @@
 			"key": "libxxhash0_0.8.0-2_arm64",
 			"name": "libxxhash0",
 			"sha256": "a31effcbd7a248b64dd480330557f41ea796a010b2c2e7ac91ed10f94e605065",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/x/xxhash/libxxhash0_0.8.0-2_arm64.deb"
+			],
 			"version": "0.8.0-2"
 		},
 		{
@@ -3451,7 +3926,9 @@
 			"key": "libudev1_247.3-7-p-deb11u4_arm64",
 			"name": "libudev1",
 			"sha256": "d53ca63927b51ad6f9a85ee1e4ce74d20ef45651179fd70f3c8d72607071e393",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/systemd/libudev1_247.3-7+deb11u4_arm64.deb"
+			],
 			"version": "247.3-7+deb11u4"
 		},
 		{
@@ -3460,7 +3937,10 @@
 			"key": "gpgv1_1.4.23-1.1_arm64",
 			"name": "gpgv1",
 			"sha256": "f65792c432a2a741dfb0a56b9e5f39fe87ff477636dafcf38644c6f726b1addc",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gnupg1/gpgv1_1.4.23-1.1_arm64.deb"
+			],
 			"version": "1.4.23-1.1"
 		},
 		{
@@ -3469,7 +3949,10 @@
 			"key": "adduser_3.118-p-deb11u1_arm64",
 			"name": "adduser",
 			"sha256": "1478a610fd50e190882ff41e16c57b628a508bcf5b5ac5313affb49d20818e0a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/adduser/adduser_3.118+deb11u1_all.deb"
+			],
 			"version": "3.118+deb11u1"
 		},
 		{
@@ -3478,7 +3961,10 @@
 			"key": "passwd_1-4.8.1-1_arm64",
 			"name": "passwd",
 			"sha256": "5a675c9d23f176ea195678a949e144b23c7a8b268b03e0df8919a2cfc198e585",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/s/shadow/passwd_4.8.1-1_arm64.deb"
+			],
 			"version": "1:4.8.1-1"
 		},
 		{
@@ -3487,7 +3973,10 @@
 			"key": "libpam-modules_1.4.0-9-p-deb11u1_arm64",
 			"name": "libpam-modules",
 			"sha256": "7f46ae216fdc6c69b0120d430936f40f3c5f37249296042324aeb584d5566a3c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules_1.4.0-9+deb11u1_arm64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -3496,7 +3985,10 @@
 			"key": "libpam-modules-bin_1.4.0-9-p-deb11u1_arm64",
 			"name": "libpam-modules-bin",
 			"sha256": "bc20fa16c91a239de350ffcc019fbae5ce7c47c21235b332ff9d67638804866e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam-modules-bin_1.4.0-9+deb11u1_arm64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -3505,7 +3997,10 @@
 			"key": "libpam0g_1.4.0-9-p-deb11u1_arm64",
 			"name": "libpam0g",
 			"sha256": "4905e523ce38e80b79f13f0227fca519f6833eb116dd9c58cbbecb39c0e01e3d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pam/libpam0g_1.4.0-9+deb11u1_arm64.deb"
+			],
 			"version": "1.4.0-9+deb11u1"
 		},
 		{
@@ -3514,7 +4009,10 @@
 			"key": "libaudit1_1-3.0-2_arm64",
 			"name": "libaudit1",
 			"sha256": "c93da146715dcd0c71759629c04afb01a41c879d91b2f5330adc74365db03763",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit1_3.0-2_arm64.deb"
+			],
 			"version": "1:3.0-2"
 		},
 		{
@@ -3523,7 +4021,10 @@
 			"key": "libcap-ng0_0.7.9-2.2-p-b1_arm64",
 			"name": "libcap-ng0",
 			"sha256": "b7b14e0b7747872f04691efe6c126de5ed0bf1dc200f51b93039cc2f4a65a96a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap-ng/libcap-ng0_0.7.9-2.2+b1_arm64.deb"
+			],
 			"version": "0.7.9-2.2+b1"
 		},
 		{
@@ -3532,7 +4033,10 @@
 			"key": "libaudit-common_1-3.0-2_arm64",
 			"name": "libaudit-common",
 			"sha256": "0d52f4826a57aea13cea1a85bfae354024c7b2f7b95e39cd1ce225e4db27d0f6",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/a/audit/libaudit-common_3.0-2_all.deb"
+			],
 			"version": "1:3.0-2"
 		},
 		{
@@ -3541,7 +4045,9 @@
 			"key": "libtirpc3_1.3.1-1-p-deb11u1_arm64",
 			"name": "libtirpc3",
 			"sha256": "ccff0927f55b97fe9ea13057fab8bff9920bf4628eb2d5d48b9656f2fb74d2e1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc3_1.3.1-1+deb11u1_arm64.deb"
+			],
 			"version": "1.3.1-1+deb11u1"
 		},
 		{
@@ -3550,7 +4056,9 @@
 			"key": "libtirpc-common_1.3.1-1-p-deb11u1_arm64",
 			"name": "libtirpc-common",
 			"sha256": "b2f10cb79e7d7a2f9b30bcdf036127df55cd4a34688547bc2886fa38f4969f77",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libt/libtirpc/libtirpc-common_1.3.1-1+deb11u1_all.deb"
+			],
 			"version": "1.3.1-1+deb11u1"
 		},
 		{
@@ -3559,7 +4067,10 @@
 			"key": "libgssapi-krb5-2_1.18.3-6-p-deb11u4_arm64",
 			"name": "libgssapi-krb5-2",
 			"sha256": "5572a462c7f78f9610bd4f1dd9f8e4f8243fa9dc2d1deb5b1cf7cec1f1df83dc",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libgssapi-krb5-2_1.18.3-6+deb11u4_arm64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -3568,7 +4079,10 @@
 			"key": "libkrb5support0_1.18.3-6-p-deb11u4_arm64",
 			"name": "libkrb5support0",
 			"sha256": "d44585771e26c9b8d115aad33736fcc3e03cf98238ea7c7985554f166441aa07",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5support0_1.18.3-6+deb11u4_arm64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -3577,7 +4091,10 @@
 			"key": "libkrb5-3_1.18.3-6-p-deb11u4_arm64",
 			"name": "libkrb5-3",
 			"sha256": "3dcdadb1db461d14b6051a19c6a94ae9f61c3d2b1d35fd9d63326cd8f4ae49e5",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libkrb5-3_1.18.3-6+deb11u4_arm64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -3586,7 +4103,10 @@
 			"key": "libssl1.1_1.1.1w-0-p-deb11u1_arm64",
 			"name": "libssl1.1",
 			"sha256": "fe7a7d313c87e46e62e614a07137e4a476a79fc9e5aab7b23e8235211280fee3",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_arm64.deb"
+			],
 			"version": "1.1.1w-0+deb11u1"
 		},
 		{
@@ -3595,7 +4115,10 @@
 			"key": "libkeyutils1_1.6.1-2_arm64",
 			"name": "libkeyutils1",
 			"sha256": "7101c2380ab47a3627a6fa076a149ab71078263064f936fccbd43efbaed4a2da",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/keyutils/libkeyutils1_1.6.1-2_arm64.deb"
+			],
 			"version": "1.6.1-2"
 		},
 		{
@@ -3604,7 +4127,10 @@
 			"key": "libk5crypto3_1.18.3-6-p-deb11u4_arm64",
 			"name": "libk5crypto3",
 			"sha256": "d8f31a8bd83fe2593e83a930fc2713e1213f25311a629836dfcde5bd23a85e83",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/k/krb5/libk5crypto3_1.18.3-6+deb11u4_arm64.deb"
+			],
 			"version": "1.18.3-6+deb11u4"
 		},
 		{
@@ -3613,7 +4139,10 @@
 			"key": "libcom-err2_1.46.2-2_arm64",
 			"name": "libcom-err2",
 			"sha256": "fc95d415c35f5b687871f660a5bf66963fd117daa490110499119411e2d6145e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/e/e2fsprogs/libcom-err2_1.46.2-2_arm64.deb"
+			],
 			"version": "1.46.2-2"
 		},
 		{
@@ -3622,7 +4151,10 @@
 			"key": "libnsl2_1.3.0-2_arm64",
 			"name": "libnsl2",
 			"sha256": "8f9ba58b219779b43c4ccc78c79b0a23f721fc96323c202abb31e02f942104b3",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libn/libnsl/libnsl2_1.3.0-2_arm64.deb"
+			],
 			"version": "1.3.0-2"
 		},
 		{
@@ -3631,7 +4163,10 @@
 			"key": "libdb5.3_5.3.28-p-dfsg1-0.8_arm64",
 			"name": "libdb5.3",
 			"sha256": "cf9aa3eae9cfc4c84f93e32f3d11e2707146e4d9707712909e3c61530b50353e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8_arm64.deb"
+			],
 			"version": "5.3.28+dfsg1-0.8"
 		},
 		{
@@ -3640,7 +4175,10 @@
 			"key": "libsemanage1_3.1-1-p-b2_arm64",
 			"name": "libsemanage1",
 			"sha256": "342a804007338314211981fac0bc083c3c66c6040bca0e47342c6d9ff44f103e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage1_3.1-1+b2_arm64.deb"
+			],
 			"version": "3.1-1+b2"
 		},
 		{
@@ -3649,7 +4187,10 @@
 			"key": "libsepol1_3.1-1_arm64",
 			"name": "libsepol1",
 			"sha256": "354d36c3084c14f242baba3a06372a3c034cec7a0cb38e626fc03cc4751b2cd3",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsepol/libsepol1_3.1-1_arm64.deb"
+			],
 			"version": "3.1-1"
 		},
 		{
@@ -3658,7 +4199,10 @@
 			"key": "libsemanage-common_3.1-1_arm64",
 			"name": "libsemanage-common",
 			"sha256": "d319a026ecd02e2f605c52350949279f3c331a19380f8b6888ce5b9ef0d31349",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libs/libsemanage/libsemanage-common_3.1-1_all.deb"
+			],
 			"version": "3.1-1"
 		},
 		{
@@ -3758,7 +4302,10 @@
 			"key": "perl_5.32.1-4-p-deb11u3_arm64",
 			"name": "perl",
 			"sha256": "6ed36a59241bbeec132eebec770567a4d23884f71dc922ac6770862cac1f3d9a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl_5.32.1-4+deb11u3_arm64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -3767,7 +4314,10 @@
 			"key": "libperl5.32_5.32.1-4-p-deb11u3_arm64",
 			"name": "libperl5.32",
 			"sha256": "9a5524101015f14773246336cb615c0e58fff2e7420a79f511262df9a7ff1c91",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/libperl5.32_5.32.1-4+deb11u3_arm64.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -3776,7 +4326,10 @@
 			"key": "perl-modules-5.32_5.32.1-4-p-deb11u3_arm64",
 			"name": "perl-modules-5.32",
 			"sha256": "9a5cb99d0f33cb11c7f535aaebfb569c6b6f97a75d748a9a52ea3afed5bd3960",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/perl/perl-modules-5.32_5.32.1-4+deb11u3_all.deb"
+			],
 			"version": "5.32.1-4+deb11u3"
 		},
 		{
@@ -3785,7 +4338,10 @@
 			"key": "libgdbm6_1.19-2_arm64",
 			"name": "libgdbm6",
 			"sha256": "97a88c2698bd836d04e51ad70c76826850857869b51e90b5343621ba30bbf525",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm6_1.19-2_arm64.deb"
+			],
 			"version": "1.19-2"
 		},
 		{
@@ -3794,7 +4350,10 @@
 			"key": "libgdbm-compat4_1.19-2_arm64",
 			"name": "libgdbm-compat4",
 			"sha256": "0853cc0b0f92784b7fbd193d737c63b1d95f932e2b95dc1bb10c273e01a0f754",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/gdbm/libgdbm-compat4_1.19-2_arm64.deb"
+			],
 			"version": "1.19-2"
 		},
 		{
@@ -3884,7 +4443,10 @@
 			"key": "ca-certificates_20210119_arm64",
 			"name": "ca-certificates",
 			"sha256": "b2d488ad4d8d8adb3ba319fc9cb2cf9909fc42cb82ad239a26c570a2e749c389",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/c/ca-certificates/ca-certificates_20210119_all.deb"
+			],
 			"version": "20210119"
 		},
 		{
@@ -3893,7 +4455,10 @@
 			"key": "openssl_1.1.1w-0-p-deb11u1_arm64",
 			"name": "openssl",
 			"sha256": "d9159af073e95641e7eda440fa1d7623873b8c0034c9826a353f890bed107f3c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/o/openssl/openssl_1.1.1w-0+deb11u1_arm64.deb"
+			],
 			"version": "1.1.1w-0+deb11u1"
 		},
 		{
@@ -3902,7 +4467,10 @@
 			"key": "nvidia-kernel-common_20151021-p-13_arm64",
 			"name": "nvidia-kernel-common",
 			"sha256": "5a1f10cffc5407a6b63dcdf3f72af842ad9e39a808bb9418a4805aa0be345c65",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/contrib/n/nvidia-support/nvidia-kernel-common_20151021+13_arm64.deb"
+			],
 			"version": "20151021+13"
 		},
 		{
@@ -3947,7 +4515,10 @@
 			"key": "bash_5.1-2-p-deb11u1_arm64",
 			"name": "bash",
 			"sha256": "d7c7af5d86f43a885069408a89788f67f248e8124c682bb73936f33874e0611b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb"
+			],
 			"version": "5.1-2+deb11u1"
 		},
 		{
@@ -3956,7 +4527,10 @@
 			"key": "debianutils_4.11.2_arm64",
 			"name": "debianutils",
 			"sha256": "6543b2b1a61b4b7b4b55b4bd25162309d7d23d14d3303649aee84ad314c30e02",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/d/debianutils/debianutils_4.11.2_arm64.deb"
+			],
 			"version": "4.11.2"
 		},
 		{
@@ -3965,7 +4539,10 @@
 			"key": "base-files_11.1-p-deb11u9_arm64",
 			"name": "base-files",
 			"sha256": "c40dc4d5c6b82f5cfe75efa1a12bd09b9d5b9b8446ea045a991896a1ead8b02c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/base-files/base-files_11.1+deb11u9_arm64.deb"
+			],
 			"version": "11.1+deb11u9"
 		},
 		{
@@ -4375,7 +4952,9 @@
 			"key": "nginx-full_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "nginx-full",
 			"sha256": "4049950f648478009faeaf028ab7287240ebd28c27799a5b128a1623290b3e44",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-full_1.18.0-6.1+deb11u3_all.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4720,7 +5299,9 @@
 			"key": "nginx-core_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "nginx-core",
 			"sha256": "932d9d78df093f037caf9a32af5f3a9f42f113ccc87ca59946f983753a9b83b8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-core_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4729,7 +5310,10 @@
 			"key": "libpcre3_2-8.39-13_arm64",
 			"name": "libpcre3",
 			"sha256": "21cac4064a41dbc354295c437f37bf623f9004513a97a6fa030248566aa986e9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/pcre3/libpcre3_8.39-13_arm64.deb"
+			],
 			"version": "2:8.39-13"
 		},
 		{
@@ -4738,7 +5322,10 @@
 			"key": "iproute2_5.10.0-4_arm64",
 			"name": "iproute2",
 			"sha256": "92d6c7ca67fca91257a3734d94417a3300c4240d8f6934c6b742c001814b4e31",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/iproute2/iproute2_5.10.0-4_arm64.deb"
+			],
 			"version": "5.10.0-4"
 		},
 		{
@@ -4747,7 +5334,10 @@
 			"key": "libcap2-bin_1-2.44-1_arm64",
 			"name": "libcap2-bin",
 			"sha256": "37915f4cc73cfaef7862043f2bdad062d1b1639df04c511665f1f9321c84d0db",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2-bin_2.44-1_arm64.deb"
+			],
 			"version": "1:2.44-1"
 		},
 		{
@@ -4756,7 +5346,10 @@
 			"key": "libcap2_1-2.44-1_arm64",
 			"name": "libcap2",
 			"sha256": "7c5729a1cfd14876685217c5f0545301e7ff1b839262fb487d6a778e8cd8c05a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libc/libcap2/libcap2_2.44-1_arm64.deb"
+			],
 			"version": "1:2.44-1"
 		},
 		{
@@ -4765,7 +5358,10 @@
 			"key": "libxtables12_1.8.7-1_arm64",
 			"name": "libxtables12",
 			"sha256": "fa07088a313d8dae7a8cba0780117e80ead683ac549fd9986a52a3280232272a",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/iptables/libxtables12_1.8.7-1_arm64.deb"
+			],
 			"version": "1.8.7-1"
 		},
 		{
@@ -4774,7 +5370,10 @@
 			"key": "libmnl0_1.0.4-3_arm64",
 			"name": "libmnl0",
 			"sha256": "d63aafb6f2c07db8fcb135b00ff915baf72ef8a3397e773c9c24d67950c6a46c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmnl/libmnl0_1.0.4-3_arm64.deb"
+			],
 			"version": "1.0.4-3"
 		},
 		{
@@ -4783,7 +5382,10 @@
 			"key": "libelf1_0.183-1_arm64",
 			"name": "libelf1",
 			"sha256": "12e14110cd66b3bf0564e3b184985b3e91c9cd76e909531a7f7bd2cb9b35a1f3",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/e/elfutils/libelf1_0.183-1_arm64.deb"
+			],
 			"version": "0.183-1"
 		},
 		{
@@ -4792,7 +5394,10 @@
 			"key": "libbsd0_0.11.3-1-p-deb11u1_arm64",
 			"name": "libbsd0",
 			"sha256": "614d36d41b670955a75526865bd321703f2accb6e0c07ee4c283fbba12e494df",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbsd/libbsd0_0.11.3-1+deb11u1_arm64.deb"
+			],
 			"version": "0.11.3-1+deb11u1"
 		},
 		{
@@ -4801,7 +5406,10 @@
 			"key": "libmd0_1.0.3-3_arm64",
 			"name": "libmd0",
 			"sha256": "3c490cdcce9d25e702e6587b6166cd8e7303fce8343642d9d5d99695282a9e5c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmd/libmd0_1.0.3-3_arm64.deb"
+			],
 			"version": "1.0.3-3"
 		},
 		{
@@ -4810,7 +5418,10 @@
 			"key": "libbpf0_1-0.3-2_arm64",
 			"name": "libbpf0",
 			"sha256": "1ef325a3bd9e43970cd8e7f9f44b13e36bc935ac496e56d96f715aa69ae7281b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libb/libbpf/libbpf0_0.3-2_arm64.deb"
+			],
 			"version": "1:0.3-2"
 		},
 		{
@@ -4819,7 +5430,9 @@
 			"key": "nginx-common_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "nginx-common",
 			"sha256": "bfd22beb7bd248db58eee6e6434a7c500f6e98e264219b3832f248696cd58f67",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/nginx-common_1.18.0-6.1+deb11u3_all.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4828,7 +5441,10 @@
 			"key": "lsb-base_11.1.0_arm64",
 			"name": "lsb-base",
 			"sha256": "89ed6332074d827a65305f9a51e591dff20641d61ff5e11f4e1822a9987e96fe",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/l/lsb/lsb-base_11.1.0_all.deb"
+			],
 			"version": "11.1.0"
 		},
 		{
@@ -4837,7 +5453,9 @@
 			"key": "libnginx-mod-stream-geoip_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-stream-geoip",
 			"sha256": "140963ecb81a3ea933e96fd7c89d01c4ffdb12509e3869d769d7b21ca5d690bf",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4846,7 +5464,9 @@
 			"key": "libnginx-mod-stream_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-stream",
 			"sha256": "88d083135df9c2c1e2401f174b4e48dde2d92cca7fc8ef661f9d26f00b395a75",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4855,7 +5475,10 @@
 			"key": "libgeoip1_1.6.12-7_arm64",
 			"name": "libgeoip1",
 			"sha256": "17225fb2ed7ce9a090c39d90acc2696e5582805a2a1f391e0a8278bb6a2d0178",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/g/geoip/libgeoip1_1.6.12-7_arm64.deb"
+			],
 			"version": "1.6.12-7"
 		},
 		{
@@ -4864,7 +5487,9 @@
 			"key": "libnginx-mod-mail_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-mail",
 			"sha256": "f8fa0d620dcdea21669b5fd9f503528d53b94117a9c31ac36dc318db0fbac315",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-mail_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4873,7 +5498,9 @@
 			"key": "libnginx-mod-http-xslt-filter_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-xslt-filter",
 			"sha256": "5d9bb33231c8589a07063a73bb6b3061bc92fae79e5731e96b5b398f1fafee29",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-xslt-filter_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4882,7 +5509,9 @@
 			"key": "libxslt1.1_1.1.34-4-p-deb11u1_arm64",
 			"name": "libxslt1.1",
 			"sha256": "2505ed3d8e6b049349ecfeff1cb6923eca43403d252e8ddd308a6a644b97eec7",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxslt/libxslt1.1_1.1.34-4+deb11u1_arm64.deb"
+			],
 			"version": "1.1.34-4+deb11u1"
 		},
 		{
@@ -4891,7 +5520,9 @@
 			"key": "libxml2_2.9.10-p-dfsg-6.7-p-deb11u4_arm64",
 			"name": "libxml2",
 			"sha256": "ccd9f449fa88827258bd51eeb8d5f6f33719df290f157c2b0be3c527a6ee45aa",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxml2/libxml2_2.9.10+dfsg-6.7+deb11u4_arm64.deb"
+			],
 			"version": "2.9.10+dfsg-6.7+deb11u4"
 		},
 		{
@@ -4900,7 +5531,10 @@
 			"key": "libicu67_67.1-7_arm64",
 			"name": "libicu67",
 			"sha256": "776303db230b275d8a17dfe8f0012bf61093dfc910f0d51f175be36707686efe",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/i/icu/libicu67_67.1-7_arm64.deb"
+			],
 			"version": "67.1-7"
 		},
 		{
@@ -4909,7 +5543,9 @@
 			"key": "libnginx-mod-http-image-filter_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-image-filter",
 			"sha256": "d972b39dcca41c42f7c797fcc4472d81b64e99978845b2309e18e6d5937e384e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-image-filter_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -4918,7 +5554,10 @@
 			"key": "libgd3_2.3.0-2_arm64",
 			"name": "libgd3",
 			"sha256": "1e6d6af0c90fe62193b3e51e45f69d075b86d7bde3fb4fd30b60da763aeca43f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libg/libgd2/libgd3_2.3.0-2_arm64.deb"
+			],
 			"version": "2.3.0-2"
 		},
 		{
@@ -4927,7 +5566,9 @@
 			"key": "libxpm4_1-3.5.12-1.1-p-deb11u1_arm64",
 			"name": "libxpm4",
 			"sha256": "83ba23ecaaf3f7b700f1ec2c1e349b5a63f3c8cdceb43cc78eb353e16051427d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libxpm/libxpm4_3.5.12-1.1+deb11u1_arm64.deb"
+			],
 			"version": "1:3.5.12-1.1+deb11u1"
 		},
 		{
@@ -4936,7 +5577,9 @@
 			"key": "libx11-6_2-1.7.2-1-p-deb11u2_arm64",
 			"name": "libx11-6",
 			"sha256": "1ddb1a4d3dbdaeac8fd8d0009a27e6453b15d97362fdd1d3efb1d5f577364f30",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-6_1.7.2-1+deb11u2_arm64.deb"
+			],
 			"version": "2:1.7.2-1+deb11u2"
 		},
 		{
@@ -4945,7 +5588,9 @@
 			"key": "libx11-data_2-1.7.2-1-p-deb11u2_arm64",
 			"name": "libx11-data",
 			"sha256": "9db24e1e7ed3cd738b503e7df5c1b9b52b1eadcb55019cd63b1409e578565d29",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libx/libx11/libx11-data_1.7.2-1+deb11u2_all.deb"
+			],
 			"version": "2:1.7.2-1+deb11u2"
 		},
 		{
@@ -4954,7 +5599,10 @@
 			"key": "libxcb1_1.14-3_arm64",
 			"name": "libxcb1",
 			"sha256": "48f82b65c93adb7af7757961fdd2730928316459f008d767b7104a56bc20a8f1",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxcb/libxcb1_1.14-3_arm64.deb"
+			],
 			"version": "1.14-3"
 		},
 		{
@@ -4963,7 +5611,10 @@
 			"key": "libxdmcp6_1-1.1.2-3_arm64",
 			"name": "libxdmcp6",
 			"sha256": "e92569ac33247261aa09adfadc34ced3994ac301cf8b58de415a2d5dbf15ccfc",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxdmcp/libxdmcp6_1.1.2-3_arm64.deb"
+			],
 			"version": "1:1.1.2-3"
 		},
 		{
@@ -4972,7 +5623,10 @@
 			"key": "libxau6_1-1.0.9-1_arm64",
 			"name": "libxau6",
 			"sha256": "36c2bf400641a80521093771dc2562c903df4065f9eb03add50d90564337ea6c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb"
+			],
 			"version": "1:1.0.9-1"
 		},
 		{
@@ -4981,7 +5635,9 @@
 			"key": "libwebp6_0.6.1-2.1-p-deb11u2_arm64",
 			"name": "libwebp6",
 			"sha256": "edeb260e528fecae77457a63a468e55837a98079fdd7f1e20e9813c358f8c755",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/libw/libwebp/libwebp6_0.6.1-2.1+deb11u2_arm64.deb"
+			],
 			"version": "0.6.1-2.1+deb11u2"
 		},
 		{
@@ -4990,7 +5646,9 @@
 			"key": "libtiff5_4.2.0-1-p-deb11u5_arm64",
 			"name": "libtiff5",
 			"sha256": "6896296ef6193ff77434c5d1d09dd9a333633f7a208ab1cc7de3b286d2d45824",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/t/tiff/libtiff5_4.2.0-1+deb11u5_arm64.deb"
+			],
 			"version": "4.2.0-1+deb11u5"
 		},
 		{
@@ -4999,7 +5657,10 @@
 			"key": "libjpeg62-turbo_1-2.0.6-4_arm64",
 			"name": "libjpeg62-turbo",
 			"sha256": "8903394de23dc6ead5abfc80972c8fd44300c9903ad4589d0df926e71977d881",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.0.6-4_arm64.deb"
+			],
 			"version": "1:2.0.6-4"
 		},
 		{
@@ -5008,7 +5669,10 @@
 			"key": "libjbig0_2.1-3.1-p-b2_arm64",
 			"name": "libjbig0",
 			"sha256": "b71b3e62e162f64cb24466bf7c6e40b05ce2a67ca7fed26d267d498f2896d549",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/j/jbigkit/libjbig0_2.1-3.1+b2_arm64.deb"
+			],
 			"version": "2.1-3.1+b2"
 		},
 		{
@@ -5017,7 +5681,10 @@
 			"key": "libdeflate0_1.7-1_arm64",
 			"name": "libdeflate0",
 			"sha256": "a1adc22600ea5e44e8ea715972ac2af7994cc7ff4d94bba8e8b01abb9ddbdfd0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libd/libdeflate/libdeflate0_1.7-1_arm64.deb"
+			],
 			"version": "1.7-1"
 		},
 		{
@@ -5026,7 +5693,10 @@
 			"key": "libpng16-16_1.6.37-3_arm64",
 			"name": "libpng16-16",
 			"sha256": "f5f61274aa5f71b9e44b077bd7b9fa9cd5ff71d8b8295f47dc1b2d45378aa73e",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libp/libpng1.6/libpng16-16_1.6.37-3_arm64.deb"
+			],
 			"version": "1.6.37-3"
 		},
 		{
@@ -5035,7 +5705,10 @@
 			"key": "libfreetype6_2.10.4-p-dfsg-1-p-deb11u1_arm64",
 			"name": "libfreetype6",
 			"sha256": "b25f1c148498dd2b49dc30da0a2b2537a7bd0cb34afb8ea681dd145053c9a3f8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/freetype/libfreetype6_2.10.4+dfsg-1+deb11u1_arm64.deb"
+			],
 			"version": "2.10.4+dfsg-1+deb11u1"
 		},
 		{
@@ -5044,7 +5717,10 @@
 			"key": "libbrotli1_1.0.9-2-p-b2_arm64",
 			"name": "libbrotli1",
 			"sha256": "52ca7f90de6cb6576a0a5cf5712fc4ae7344b79c44b8a1548087fd5d92bf1f64",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/b/brotli/libbrotli1_1.0.9-2+b2_arm64.deb"
+			],
 			"version": "1.0.9-2+b2"
 		},
 		{
@@ -5053,7 +5729,10 @@
 			"key": "libfontconfig1_2.13.1-4.2_arm64",
 			"name": "libfontconfig1",
 			"sha256": "18b13ef8a46e9d79ba6a6ba2db0c86e42583277b5d47f6942f3223e349c22641",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/libfontconfig1_2.13.1-4.2_arm64.deb"
+			],
 			"version": "2.13.1-4.2"
 		},
 		{
@@ -5062,7 +5741,10 @@
 			"key": "fontconfig-config_2.13.1-4.2_arm64",
 			"name": "fontconfig-config",
 			"sha256": "48afb6ad7d15e6104a343b789f73697301ad8bff77b69927bc998f5a409d8e90",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/f/fontconfig/fontconfig-config_2.13.1-4.2_all.deb"
+			],
 			"version": "2.13.1-4.2"
 		},
 		{
@@ -5071,7 +5753,10 @@
 			"key": "fonts-texgyre_20180621-3.1_arm64",
 			"name": "fonts-texgyre",
 			"sha256": "cb7e9a4b2471cfdd57194c16364f9102f0639816a2662fed4b30d2a158747076",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/tex-gyre/fonts-texgyre_20180621-3.1_all.deb"
+			],
 			"version": "20180621-3.1"
 		},
 		{
@@ -5080,7 +5765,10 @@
 			"key": "ucf_3.0043_arm64",
 			"name": "ucf",
 			"sha256": "ebef6bcd777b5c0cc2699926f2159db08433aed07c50cb321fd828b28c5e8d53",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/u/ucf/ucf_3.0043_all.deb"
+			],
 			"version": "3.0043"
 		},
 		{
@@ -5089,7 +5777,10 @@
 			"key": "sensible-utils_0.0.14_arm64",
 			"name": "sensible-utils",
 			"sha256": "b9a447dc4ec8714196b037e20a2209e62cd669f5450222952f259bda4416b71f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/s/sensible-utils/sensible-utils_0.0.14_all.deb"
+			],
 			"version": "0.0.14"
 		},
 		{
@@ -5098,7 +5789,9 @@
 			"key": "libuuid1_2.36.1-8-p-deb11u1_arm64",
 			"name": "libuuid1",
 			"sha256": "3d677da6a22e9cac519fed5a2ed5b20a4217f51ca420fce57434b5e813c26e03",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/u/util-linux/libuuid1_2.36.1-8+deb11u1_arm64.deb"
+			],
 			"version": "2.36.1-8+deb11u1"
 		},
 		{
@@ -5107,7 +5800,9 @@
 			"key": "libexpat1_2.2.10-2-p-deb11u5_arm64",
 			"name": "libexpat1",
 			"sha256": "8d20bfd061845bda0321d01accd6f8386ead5b1d7250a585d12b8d5fb1408ffa",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/e/expat/libexpat1_2.2.10-2+deb11u5_arm64.deb"
+			],
 			"version": "2.2.10-2+deb11u5"
 		},
 		{
@@ -5116,7 +5811,9 @@
 			"key": "libnginx-mod-http-geoip_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-geoip",
 			"sha256": "7b1d105339402426108d4d10fa733f24f2340c9b6482d10917c194d13f66072f",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5125,7 +5822,9 @@
 			"key": "libnginx-mod-stream-geoip2_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-stream-geoip2",
 			"sha256": "da0e67b4cc318b7bb338bec7476c260fecd6cc06ecfad4c7f9acb22a4a74d07b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-stream-geoip2_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5134,7 +5833,10 @@
 			"key": "libmaxminddb0_1.5.2-1_arm64",
 			"name": "libmaxminddb0",
 			"sha256": "05504845f0fab5c54075e462b99b326a224ceaefaccda864f641f1bf6d99914d",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/libm/libmaxminddb/libmaxminddb0_1.5.2-1_arm64.deb"
+			],
 			"version": "1.5.2-1"
 		},
 		{
@@ -5143,7 +5845,9 @@
 			"key": "libnginx-mod-http-upstream-fair_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-upstream-fair",
 			"sha256": "7be1dfa763e9158ccdea168b1103f5b6b16b3a0c95c3996076c7f4a20aa35bca",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-upstream-fair_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5152,7 +5856,9 @@
 			"key": "libnginx-mod-http-subs-filter_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-subs-filter",
 			"sha256": "22354006f199cc3e8e51aac00ca649dd169ca91c2e565a4734f18f3741b061ef",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-subs-filter_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5161,7 +5867,9 @@
 			"key": "libnginx-mod-http-geoip2_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-geoip2",
 			"sha256": "1ae5c1491a8f43ff3a0269270d1f954441cf6fb160b3f83bb2f10ae7b47eb0ce",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-geoip2_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5170,7 +5878,9 @@
 			"key": "libnginx-mod-http-echo_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-echo",
 			"sha256": "ef014f5f294e744e465a9075722c1d7cb3423392b2bd029d60e0d952fd90fde7",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-echo_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5179,7 +5889,9 @@
 			"key": "libnginx-mod-http-dav-ext_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-dav-ext",
 			"sha256": "8c65130c9d18a28eadfb657bbe818de567ed6625147e868c3bbd739189f8a991",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-dav-ext_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5188,7 +5900,9 @@
 			"key": "libnginx-mod-http-auth-pam_1.18.0-6.1-p-deb11u3_arm64",
 			"name": "libnginx-mod-http-auth-pam",
 			"sha256": "4e6e906608ef1960c2514f371445bf3a32ea72b7098cae38cedac4b5c10abf05",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z/pool/updates/main/n/nginx/libnginx-mod-http-auth-pam_1.18.0-6.1+deb11u3_arm64.deb"
+			],
 			"version": "1.18.0-6.1+deb11u3"
 		},
 		{
@@ -5455,11 +6169,13 @@
 					"version": "3.9.2-3"
 				}
 			],
-			"key": "google-cloud-cli_503.0.0-0_arm64",
+			"key": "google-cloud-cli_507.0.0-0_arm64",
 			"name": "google-cloud-cli",
-			"sha256": "17f037d69e38af51a221bee880c08c84e5e10c7ef6b62322c3861d3634fc92bf",
-			"url": "https://packages.cloud.google.com/apt/pool/cloud-sdk/google-cloud-cli_503.0.0-0_arm64_0e6cae0af91a3189215d95843a1b0ad7.deb",
-			"version": "503.0.0-0"
+			"sha256": "631a094bcbbde91ba9e6dd338490feccc3c30d2354d281108a5b34bb3f905903",
+			"urls": [
+				"https://packages.cloud.google.com/apt/pool/cloud-sdk/google-cloud-cli_507.0.0-0_arm64_f4f857cbc23508883b7a94bd63b553be.deb"
+			],
+			"version": "507.0.0-0"
 		},
 		{
 			"arch": "arm64",
@@ -5467,7 +6183,10 @@
 			"key": "python3_3.9.2-3_arm64",
 			"name": "python3",
 			"sha256": "79197285d25e73a2a07667efe80af152dd932ac5ef3e13717f1ac824d111ea81",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3_3.9.2-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3_3.9.2-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3_3.9.2-3_arm64.deb"
+			],
 			"version": "3.9.2-3"
 		},
 		{
@@ -5476,7 +6195,10 @@
 			"key": "libpython3-stdlib_3.9.2-3_arm64",
 			"name": "libpython3-stdlib",
 			"sha256": "79ec02b6afc81938fd1418170c103cc90aabbc52e0e1738e2744c5a4ec69fde8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/libpython3-stdlib_3.9.2-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/libpython3-stdlib_3.9.2-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/libpython3-stdlib_3.9.2-3_arm64.deb"
+			],
 			"version": "3.9.2-3"
 		},
 		{
@@ -5485,7 +6207,10 @@
 			"key": "libpython3.9-stdlib_3.9.2-1_arm64",
 			"name": "libpython3.9-stdlib",
 			"sha256": "3b3612dcd7550f01ec3517fbe955838223f4cf115b6983e4ed6d7320cd4b05c4",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-stdlib_3.9.2-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-stdlib_3.9.2-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-stdlib_3.9.2-1_arm64.deb"
+			],
 			"version": "3.9.2-1"
 		},
 		{
@@ -5494,7 +6219,10 @@
 			"key": "libsqlite3-0_3.34.1-3_arm64",
 			"name": "libsqlite3-0",
 			"sha256": "1e33cd39dc4fff2a7edd7bb7e90a71e20fb528f6a581fe0287652e4dae77e0d0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sqlite3/libsqlite3-0_3.34.1-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/s/sqlite3/libsqlite3-0_3.34.1-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/s/sqlite3/libsqlite3-0_3.34.1-3_arm64.deb"
+			],
 			"version": "3.34.1-3"
 		},
 		{
@@ -5503,7 +6231,10 @@
 			"key": "libreadline8_8.1-1_arm64",
 			"name": "libreadline8",
 			"sha256": "500c3cdc00dcaea2c4ed736e00bfcb6cb43c3415e808566c5dfa266dbfc0c5e5",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/libreadline8_8.1-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/libreadline8_8.1-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/libreadline8_8.1-1_arm64.deb"
+			],
 			"version": "8.1-1"
 		},
 		{
@@ -5512,7 +6243,10 @@
 			"key": "readline-common_8.1-1_arm64",
 			"name": "readline-common",
 			"sha256": "3f947176ef949f93e4ad5d76c067d33fa97cf90b62ee0748acb4f5f64790edc8",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/readline-common_8.1-1_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/readline-common_8.1-1_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/r/readline/readline-common_8.1-1_all.deb"
+			],
 			"version": "8.1-1"
 		},
 		{
@@ -5521,7 +6255,10 @@
 			"key": "install-info_6.7.0.dfsg.2-6_arm64",
 			"name": "install-info",
 			"sha256": "f12d0f3d104419e4796d44f720a77d6e4b522d2ae800a24a784e5485a7fcc5c5",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/texinfo/install-info_6.7.0.dfsg.2-6_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/t/texinfo/install-info_6.7.0.dfsg.2-6_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/t/texinfo/install-info_6.7.0.dfsg.2-6_arm64.deb"
+			],
 			"version": "6.7.0.dfsg.2-6"
 		},
 		{
@@ -5530,7 +6267,10 @@
 			"key": "libncursesw6_6.2-p-20201114-2-p-deb11u2_arm64",
 			"name": "libncursesw6",
 			"sha256": "26bd6f488b885d02dfe933038d1e15414f5fe98704b3f49d2cecf665ebcb0f5b",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncursesw6_6.2+20201114-2+deb11u2_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncursesw6_6.2+20201114-2+deb11u2_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/n/ncurses/libncursesw6_6.2+20201114-2+deb11u2_arm64.deb"
+			],
 			"version": "6.2+20201114-2+deb11u2"
 		},
 		{
@@ -5539,7 +6279,10 @@
 			"key": "libmpdec3_2.5.1-1_arm64",
 			"name": "libmpdec3",
 			"sha256": "171e2581970f36a39f65d1ca3c761e76b103844daae7903fcc07f7c3822a05bb",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mpdecimal/libmpdec3_2.5.1-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mpdecimal/libmpdec3_2.5.1-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/m/mpdecimal/libmpdec3_2.5.1-1_arm64.deb"
+			],
 			"version": "2.5.1-1"
 		},
 		{
@@ -5548,7 +6291,10 @@
 			"key": "mime-support_3.66_arm64",
 			"name": "mime-support",
 			"sha256": "b964e671e6c47674879a3e54130b6737e8760fbd3da6afcc015faa174af98ba0",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mime-support/mime-support_3.66_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mime-support/mime-support_3.66_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/m/mime-support/mime-support_3.66_all.deb"
+			],
 			"version": "3.66"
 		},
 		{
@@ -5557,7 +6303,10 @@
 			"key": "media-types_4.0.0_arm64",
 			"name": "media-types",
 			"sha256": "f9835dcf3cdbaf163104d4e511c9c4e0f41a56822e147e57f28f749fcbf7d44c",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/media-types/media-types_4.0.0_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/media-types/media-types_4.0.0_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/m/media-types/media-types_4.0.0_all.deb"
+			],
 			"version": "4.0.0"
 		},
 		{
@@ -5566,7 +6315,10 @@
 			"key": "mailcap_3.69_arm64",
 			"name": "mailcap",
 			"sha256": "63fa5520f05d2aea5ca23eee95981a5e029608e1186ded4143470c8f84184158",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mailcap/mailcap_3.69_all.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/m/mailcap/mailcap_3.69_all.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/m/mailcap/mailcap_3.69_all.deb"
+			],
 			"version": "3.69"
 		},
 		{
@@ -5575,7 +6327,10 @@
 			"key": "libpython3.9-minimal_3.9.2-1_arm64",
 			"name": "libpython3.9-minimal",
 			"sha256": "b49736ab0e8b8577f97a474ca67e20c1c025f9d7394ec8d7820de6314c903cf9",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-minimal_3.9.2-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-minimal_3.9.2-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/libpython3.9-minimal_3.9.2-1_arm64.deb"
+			],
 			"version": "3.9.2-1"
 		},
 		{
@@ -5584,7 +6339,10 @@
 			"key": "python3.9_3.9.2-1_arm64",
 			"name": "python3.9",
 			"sha256": "88cbc8eee37ef1f240fdd458f984bd3770cdd8cb1703e8e1666e026f6ca61327",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9_3.9.2-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9_3.9.2-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9_3.9.2-1_arm64.deb"
+			],
 			"version": "3.9.2-1"
 		},
 		{
@@ -5593,7 +6351,10 @@
 			"key": "python3.9-minimal_3.9.2-1_arm64",
 			"name": "python3.9-minimal",
 			"sha256": "bc0d0ed39ebc066020c3a16afdab4fd3e0260b41ae799273531d5b2403ae7b27",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9-minimal_3.9.2-1_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9-minimal_3.9.2-1_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3.9/python3.9-minimal_3.9.2-1_arm64.deb"
+			],
 			"version": "3.9.2-1"
 		},
 		{
@@ -5602,7 +6363,10 @@
 			"key": "python3-minimal_3.9.2-3_arm64",
 			"name": "python3-minimal",
 			"sha256": "7c0e0e24c995d3419e3c80fa47407b8fef0b631c70dbadee75d1783e509c4783",
-			"url": "https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3-minimal_3.9.2-3_arm64.deb",
+			"urls": [
+				"https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3-minimal_3.9.2-3_arm64.deb",
+				"https://snapshot.debian.org/archive/debian/20240210T223313Z/pool/main/p/python3-defaults/python3-minimal_3.9.2-3_arm64.deb"
+			],
 			"version": "3.9.2-3"
 		}
 	],

--- a/examples/debian_snapshot/bullseye.yaml
+++ b/examples/debian_snapshot/bullseye.yaml
@@ -11,7 +11,9 @@ version: 1
 
 sources:
   - channel: bullseye main contrib
-    url: https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z
+    urls:
+      - https://snapshot-cloudflare.debian.org/archive/debian/20240210T223313Z
+      - https://snapshot.debian.org/archive/debian/20240210T223313Z
   - channel: bullseye-security main
     url: https://snapshot-cloudflare.debian.org/archive/debian-security/20240210T223313Z
   - channel: bullseye-updates main


### PR DESCRIPTION
Fixes #113

The Debian snapshot mirror fails quite often and, while the Cloudflare mirror has had some issues in the past (e.g. it was lagging replication for months) it's much more reliable.

This commit adds support for multiple URLs in the manifest. See examples/debian_snapshot/bullseye.yaml for a sample usage.