### PR TITLE
fix: pre-commit run config and broken README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 # Commitizen runs in commit-msg stage
 # but we don't want to run the other hooks on commit messages
-default_stages: [commit]
+default_stages: [pre-commit]
 
 # Use a slightly older version of node by default
 # as the default uses a very new version of GLIBC
@@ -14,18 +14,18 @@ default_language_version:
 repos:
   # Check formatting and lint for starlark code
   - repo: https://github.com/keith/pre-commit-buildifier
-    rev: 6.1.0.1
+    rev: 7.3.1.1
     hooks:
       - id: buildifier
       - id: buildifier-lint
   # Enforce that commit messages allow for later changelog generation
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.18.0
+    rev: v4.1.0
     hooks:
       # Requires that commitizen is already installed
       - id: commitizen
         stages: [commit-msg]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.4.0"
+    rev: v3.1.0
     hooks:
       - id: prettier

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Bazel helper rules to aid with some of the steps needed to create a Linux /
 Debian installation. These rules are designed to replace commands such as
 `apt-get install`, `passwd`, `groupadd`, `useradd`, `update-ca-certificates`.
 
+> [!CAUTION]
+>
 > `rules_distroless` is currently in beta and does not yet offer a stable
 > Public API. However, many users are already successfully using it in
 > production environments. Check [Adopters](#adopters) to see who's already
@@ -19,16 +21,18 @@ align with the project goals (e.g. add support for a different compression
 format) and may reject requests that do not (e.g. supporting other packaging
 formats other than `.deb`).
 
-> There's limited maintainer time for this project, so we strongly encourage focused, small, and readable Pull Requests.
-
+> [!TIP]
+> There's limited maintainer time for this project, so we strongly encourage
+> focused, small, and readable Pull Requests.
 
 # Usage
 
 ## Bzlmod (Bazel 6+)
 
 > [!NOTE]
-> If you are using Bazel 6 you need to enable Bzlmod by adding `common --enable_bzlmod` to `.bazelrc`
-> If you are using Bazel 7+ [it's enabled by default].
+> If you are using Bazel 6 you need to enable Bzlmod by adding
+> `common --enable_bzlmod` to `.bazelrc` If you are using Bazel 7+
+> [it's enabled by default].
 
 Add the following to your `MODULE.bazel` file:
 
@@ -108,12 +112,12 @@ check the following docs:
 > project or company name here!
 
 [it's enabled by default]: https://blog.bazel.build/2023/12/11/bazel-7-release.html#bzlmod
-[bazel central registry]: https://registry.bazel.build/modules/rules_distroless
+[Bazel Central Registry]: https://registry.bazel.build/modules/rules_distroless
 [`git_override`]: https://bazel.build/versions/6.0.0/rules/lib/globals#git_override
 [`archive_override`]: https://bazel.build/versions/6.0.0/rules/lib/globals#archive_override
 [`local_path_override`]: https://bazel.build/versions/6.0.0/rules/lib/globals#local_path_override
-[bzlmod migration guide]: https://bazel.build/external/migration
-[`rules_distroless` github releases page]: https://github.com/GoogleContainerTools/rules_distroless/releases
-[update on the future stability of source code archives and hashes]: https://github.blog/2023-02-21-update-on-the-future-stability-of-source-code-archives-and-hashes
-[google's `distroless` container images]: https://github.com/GoogleContainerTools/distroless
-[arize ai]: https://www.arize.com
+[Bzlmod migration guide]: https://bazel.build/external/migration
+[`rules_distroless` Github releases page]: https://github.com/GoogleContainerTools/rules_distroless/releases
+[Update on the future stability of source code archives and hashes]: https://github.blog/2023-02-21-update-on-the-future-stability-of-source-code-archives-and-hashes
+[Google's `distroless` container images]: https://github.com/GoogleContainerTools/distroless
+[Arize AI]: https://www.arize.com


### PR DESCRIPTION
### chore: update .pre-commit-config.yaml
    
Steps:
* `pre-commit migrate-config`
* `pre-commit autoupdate`
    
Then moving prettier from `v4.0.0-alpha.8` to the latest stable version in the mirror, `v3.1.0`, because the alpha versions seem to produce a node_modules directory somehow.

Note that the prettier mirror repo is archived, it seems unsupported / unmaintained since Dec 2023 :-/

### fix: README.md

The pre-commit run --all-files that I did and rebased into #120 broke the README :(

dadc64c added some of the fixes and this commit adds the CAUTION warning plus a TIP warning to highlight the need of small and readable PRs.

Now, prettier runs without breaking this Markdown.