### PR TITLE
fix: #120 (and #115?) in MacOS

### DIFF
--- a/examples/debian_snapshot/BUILD.bazel
+++ b/examples/debian_snapshot/BUILD.bazel
@@ -12,7 +12,14 @@ load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_distroless//distroless:defs.bzl", "cacerts", "group", "passwd")
-load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+
+COMPATIBLE_WITH = select({
+    "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],
+    "@platforms//cpu:arm64": ["@platforms//cpu:arm64"],
+}) + [
+    "@platforms//os:linux",
+]
 
 passwd(
     name = "passwd",
@@ -75,7 +82,10 @@ oci_image(
         "SSL_CERT_FILE": "/etc/ssl/certs/ca-certificates.crt",
     },
     os = "linux",
-    tags = ["manual"],
+    # NOTE: this is needed because, otherwise, bazel test //... fails, even
+    # when container_structure_test already has target_compatible_with.
+    # See 136
+    target_compatible_with = COMPATIBLE_WITH,
     tars = [
         # This target contains all the installed packages.
         "@bullseye//:flat",
@@ -111,13 +121,17 @@ platform_transition_filegroup(
     }),
 )
 
-# oci_load(
-#     name = "tarball",
-#     image = ":image_platform",
-#     repo_tags = [
-#         "distroless/test:latest",
-#     ],
-# )
+oci_load(
+    name = "tarball",
+    image = ":image_platform",
+    repo_tags = [
+        "distroless/test:latest",
+    ],
+    # NOTE: this is needed because, otherwise, bazel test //... fails, even
+    # when container_structure_test already has target_compatible_with.
+    # See 136
+    target_compatible_with = COMPATIBLE_WITH,
+)
 
 container_structure_test(
     name = "test",
@@ -126,10 +140,5 @@ container_structure_test(
         "@platforms//cpu:x86_64": ["test_linux_amd64.yaml"],
     }),
     image = ":image_platform",
-    target_compatible_with = select({
-        "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],
-        "@platforms//cpu:arm64": ["@platforms//cpu:arm64"],
-    }) + [
-        "@platforms//os:linux",
-    ],
+    target_compatible_with = COMPATIBLE_WITH,
 )

--- a/examples/ubuntu_snapshot/BUILD.bazel
+++ b/examples/ubuntu_snapshot/BUILD.bazel
@@ -3,6 +3,13 @@ load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_distroless//distroless:defs.bzl", "group", "passwd")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 
+COMPATIBLE_WITH = select({
+    "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],
+    "@platforms//cpu:arm64": ["@platforms//cpu:arm64"],
+}) + [
+    "@platforms//os:linux",
+]
+
 passwd(
     name = "passwd",
     entries = [
@@ -52,6 +59,10 @@ oci_image(
         "@platforms//cpu:x86_64": "amd64",
     }),
     os = "linux",
+    # NOTE: this is needed because, otherwise, bazel test //... fails, even
+    # when container_structure_test already has target_compatible_with.
+    # See 136
+    target_compatible_with = COMPATIBLE_WITH,
     tars = [
         ":sh",
         ":passwd",
@@ -66,6 +77,10 @@ oci_load(
     repo_tags = [
         "distroless/noble:latest",
     ],
+    # NOTE: this is needed because, otherwise, bazel test //... fails, even
+    # when container_structure_test already has target_compatible_with.
+    # See 136
+    target_compatible_with = COMPATIBLE_WITH,
 )
 
 container_structure_test(
@@ -75,10 +90,5 @@ container_structure_test(
         "@platforms//cpu:x86_64": ["test_linux_amd64.yaml"],
     }),
     image = ":noble",
-    target_compatible_with = select({
-        "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],
-        "@platforms//cpu:arm64": ["@platforms//cpu:arm64"],
-    }) + [
-        "@platforms//os:linux",
-    ],
+    target_compatible_with = COMPATIBLE_WITH,
 )


### PR DESCRIPTION
### fix: #120 (and #115?) in MacOS

Bazel was throwing an error when running the tests in MacOS even when the Linux tests were guarded with a target_compatible_with that was restricted to Linux.

As far as I could tell, this was because running `bazel test` with `//...` was recursively evaluating other targets like `//examples/ubuntu_snapshot:_noble_index_json` from `oci_image` and `oci_load`. When I guard those rules with a target_compatible_with everything works.

Also, seeing that e5f7dc0 also manually commented a test to fix CI for macos so I guess #120 didn't break this, it was probably happening since #115 added the new convenience targets.

Finally, maybe this is something that should be fixed in `rules_oci`, the "inner targets" that it creates should probably be restricted to only run in the `os` and `architecture` given for the image :-?