### PR TITLE
fix: allow only one version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -86,4 +86,9 @@ apt.install(
     manifest = "apt/tests/resolution/arch_all.yaml",
     nolock = True,
 )
-use_repo(apt, "arch_all_test", "arch_all_test_resolve", "bullseye", "bullseye_nolock", "noble", "resolution_test", "resolution_test_resolve")
+apt.install(
+    name = "clang",
+    manifest = "apt/tests/resolution/clang.yaml",
+    nolock = True,
+)
+use_repo(apt, "arch_all_test", "arch_all_test_resolve", "bullseye", "bullseye_nolock", "clang", "noble", "resolution_test", "resolution_test_resolve")

--- a/apt/private/apt_dep_resolver.bzl
+++ b/apt/private/apt_dep_resolver.bzl
@@ -77,7 +77,6 @@ def _resolve_all(state, name, version, arch, include_transitive = True):
 
         # If this package is not found but is not part of a dependency group, then add it to unmet dependencies.
         if not package:
-            key = "%s~~%s" % (name, version[1] if version else "")
             unmet_dependencies.append((name, version))
             continue
 
@@ -89,7 +88,7 @@ def _resolve_all(state, name, version, arch, include_transitive = True):
         if i == 0:
             root_package = package
 
-        key = "%s~~%s" % (package["Package"], package["Version"])
+        key = package["Package"]
 
         # If we encountered package before in the transitive closure, skip it
         if key in already_recursed:

--- a/apt/private/deb_translate_lock.bzl
+++ b/apt/private/deb_translate_lock.bzl
@@ -154,11 +154,14 @@ def _deb_translate_lock_impl(rctx):
 
         if package["arch"] not in architectures:
             architectures[package["arch"]] = []
-        architectures[package["arch"]].append(package["name"])
+
+        if package["name"] not in architectures[package["arch"]]:
+            architectures[package["arch"]].append(package["name"])
 
         if package["name"] not in packages:
             packages[package["name"]] = []
-        packages[package["name"]].append(package["arch"])
+        if package["arch"] not in packages[package["name"]]:
+            packages[package["name"]].append(package["arch"])
 
         if not lock_content:
             package_defs.append(

--- a/apt/tests/resolution/BUILD.bazel
+++ b/apt/tests/resolution/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 jq(
     name = "pick_libuuid_version",
@@ -44,4 +45,14 @@ assert_contains(
     name = "test_quake_version",
     actual = ":pick_quake_version",
     expected = "73",
+)
+
+build_test(
+    name = "build_clang",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    targets = [
+        "@clang//clang",
+    ],
 )

--- a/apt/tests/resolution/clang.yaml
+++ b/apt/tests/resolution/clang.yaml
@@ -1,0 +1,16 @@
+# bazel run @jammy_cuda//:lock
+version: 1
+sources:
+  - channel: jammy main
+    url: https://snapshot.ubuntu.com/ubuntu/20240301T030400Z
+  - channel: jammy universe
+    url: https://snapshot.ubuntu.com/ubuntu/20240301T030400Z
+  - channel: jammy-updates main
+    url: https://snapshot.ubuntu.com/ubuntu/20240301T030400Z
+  - channel: jammy-security main
+    url: https://snapshot.ubuntu.com/ubuntu/20240301T030400Z
+archs:
+  - "amd64"
+
+packages:
+  - "clang"

--- a/distroless/private/flatten.bzl
+++ b/distroless/private/flatten.bzl
@@ -27,7 +27,7 @@ def _flatten_impl(ctx):
         tools = bsdtar.default.files,
         arguments = [args],
         mnemonic = "Flatten",
-        progress_message = "Flattening %{label}}",
+        progress_message = "Flattening %{label}",
     )
 
     return [


### PR DESCRIPTION
Currently, in some repos there are more than one version of the same package leading to multiple packages being put into lockfiles, ideally we only want the one that matches the most version constraints. 