### PR TITLE
make some shell scripts use hermetic aspect toolchains

### DIFF
--- a/apt/private/dpkg_status.sh
+++ b/apt/private/dpkg_status.sh
@@ -2,23 +2,27 @@
 set -o pipefail -o errexit -o nounset
 
 readonly bsdtar="$1"
-readonly out="$2"
-shift 2
+readonly coreutils="$2"
+readonly out="$3"
+shift 3
 
-tmp_out=$(mktemp)
+tmp_out=$($coreutils mktemp)
 
 while  (( $# > 0 )); do
-    $bsdtar -xf "$1" --to-stdout ./control |
-    awk '{
-        print $0; 
-        if (NR == 1) { print "Status: install ok installed"};
-    } END { print "" }
-    ' >> $tmp_out
+    $bsdtar -xf "$1" --to-stdout ./control | (
+        # Print first line
+        read -r line && echo "$line" && echo "Status: install ok installed"
+        # Print remaining lines, including the last one
+        while read -r line || [ -n "$line" ]; do
+            echo "$line"
+        done
+        echo ""
+    ) >> "$tmp_out"
     shift
 done
 
 echo "#mtree
 ./var/lib/dpkg/status type=file uid=0 gid=0 mode=0644 time=1672560000 contents=$tmp_out
-" | "$bsdtar" $@ -cf "$out" "@-"
+" | "$bsdtar" "$@" -cf "$out" "@-"
 
-rm $tmp_out
+$coreutils rm "$tmp_out"

--- a/apt/private/dpkg_statusd.sh
+++ b/apt/private/dpkg_statusd.sh
@@ -2,28 +2,40 @@
 set -o pipefail -o errexit -o nounset
 
 readonly bsdtar="$1"
-readonly out="$2"
-readonly control_path="$3"
-readonly package_name="$4"
-shift 4
+readonly coreutils="$2"
+readonly out="$3"
+readonly control_path="$4"
+readonly package_name="$5"
+shift 5
 
 include=(--include "^./control$" --include "^./md5sums$")
 
-tmp=$(mktemp -d)
+tmp=$($coreutils mktemp -d)
 "$bsdtar" -xf "$control_path" "${include[@]}" -C "$tmp"
 
-"$bsdtar" -cf - $@ --format=mtree "${include[@]}" --options '!gname,!uname,!sha1,!nlink,!time' "@$control_path" | \
-awk -v pkg="$package_name" '{ 
-    if ($1=="#mtree") {
-        print $1; next
-    };
-    # strip leading ./ prefix
-    sub(/^\.?\//, "", $1);
+"$bsdtar" -cf - "$@" --format=mtree "${include[@]}" --options '!gname,!uname,!sha1,!nlink,!time' "@$control_path" | \
+while IFS= read -r line; do
+   first_field=$(echo "$line" | cut -d' ' -f1) 
+   rest_of_line=$(echo "$line" | cut -d' ' -f2-)
 
-    if ($1 ~ /^control/) {
-        $1 = "./var/lib/dpkg/status.d/" pkg " contents=./" $1; 
-    } else if ($1 ~ /^md5sums/) {
-        $1 = "./var/lib/dpkg/status.d/" pkg ".md5sums contents=./" $1; 
-    }
-    print $0
-}' | "$bsdtar" $@ -cf "$out" -C "$tmp/" @-
+   if [ "$first_field" = "#mtree" ]; then
+       echo "$line"
+       continue
+   fi
+
+   # Strip leading ./ prefix using parameter expansion
+   first_field="${first_field/#.\//}"
+   first_field="${first_field/#\//}"
+
+   if [[ "$first_field" =~ ^control ]]; then
+       first_field="./var/lib/dpkg/status.d/${package_name} contents=./${first_field}"
+   elif [[ "$first_field" =~ ^md5sums ]]; then
+       first_field="./var/lib/dpkg/status.d/${package_name}.md5sums contents=./${first_field}"
+   fi
+
+   if [ -n "$rest_of_line" ]; then
+       echo "$first_field $rest_of_line"
+   else
+       echo "$first_field"
+   fi
+done | "$bsdtar" "$@" -cf "$out" -C "$tmp/" @-


### PR DESCRIPTION
This changes some of the shellscripts to use the aspect tools for coreutils to be more hermetic.

This also has a probably buggy rewrite of the embedded awk scripts to avoid needing an awk toolchain.