### PR TITLE
fix: #137 breaks tests in arm64

### DIFF
--- a/apt/tests/resolution/clang.yaml
+++ b/apt/tests/resolution/clang.yaml
@@ -11,6 +11,7 @@ sources:
     url: https://snapshot.ubuntu.com/ubuntu/20240301T030400Z
 archs:
   - "amd64"
+  - "arm64"
 
 packages:
   - "clang"


### PR DESCRIPTION
9a7d2e8 added a manifest for clang with only amd64 and the @clang//clang target fails to build in arm64.