### PR TITLE
Fix virtual package resolution

### DIFF
--- a/apt/private/apt_dep_resolver.bzl
+++ b/apt/private/apt_dep_resolver.bzl
@@ -36,7 +36,8 @@ def _resolve_package(state, name, version, arch):
 
         # Otherwise, we can't disambiguate the virtual package providers so
         # choose none and warn.
-        print("Multiple candidates for virtual package '{}': {}".format(
+        # buildifier: disable=print
+        print("\nMultiple candidates for virtual package '{}': {}".format(
             name,
             [package["Package"] for package in candidates],
         ))


### PR DESCRIPTION
Currently, a simple install of `bash` produces the following error:

```
WARNING: Following dependencies could not be resolved for bash: awk
```

In identifying the root cause of this issue, found a few behaviors for the `Provides` key are not correct (as described [by the spec here](https://www.debian.org/doc/debian-policy/ch-relationships.html#virtual-packages-provides)).

Fixed the following in `Provides`:
* Handle multiple packages, i.e. `Provides: bar, baz`.
* Handle unversioned packages, i.e. `Provides: bar` and `Provides: bar (= 1.0)` are both valid.
* Ensure alternatives (referred in code as dependency groups) are evaluated left-to-right and added to unmet_deps if none resolve.
* Handle multiple candidates for virtual packages if can fallback to a single `Priority: required` package.
* Resolve multiple virtual package candidates from the same package to the highest available version.

The usage of `Priority: required` is necessary to account for Distroless base images not containing the "true" minimal package set as described here: https://wiki.debian.org/Proposals/EssentialOnDiet. This creates a problem for package dependencies like `awk` which expect to find `mawk` by default. A potential future improvement could resolve ambiguous virtual packages by picking an explicit package in the manifest.

Fixes to the `Provides` handling leads to significantly more virtual packages being identified and resolved correctly.