### PR TITLE
Fix package index ordering

### DIFF
--- a/apt/private/apt_deb_repository.bzl
+++ b/apt/private/apt_deb_repository.bzl
@@ -11,16 +11,16 @@ def _fetch_package_index(rctx, url, dist, comp, arch, integrity):
     #  --force      -> overwrite the output if it exists
     #  --decompress -> decompress
     # Order of these matter, we want to try the one that is most likely first.
-    supported_extensions = {
-        ".xz": ["xz", "--decompress", "--keep", "--force"],
-        ".gz": ["gzip", "--decompress", "--keep", "--force"],
-        ".bz2": ["bzip2", "--decompress", "--keep", "--force"],
-        "": ["true"],
-    }
+    supported_extensions = [
+        (".xz", ["xz", "--decompress", "--keep", "--force"]),
+        (".gz", ["gzip", "--decompress", "--keep", "--force"]),
+        (".bz2", ["bzip2", "--decompress", "--keep", "--force"]),
+        ("", ["true"]),
+    ]
 
     failed_attempts = []
 
-    for (ext, cmd) in supported_extensions.items():
+    for (ext, cmd) in supported_extensions:
         output = "{}/Packages{}".format(target_triple, ext)
         dist_url = "{}/dists/{}/{}/binary-{}/Packages{}".format(url, dist, comp, arch, ext)
         download = rctx.download(


### PR DESCRIPTION
Whilst `dict` ordering should preserve import order when iterated over keys, it looks like potentially `.items()` does not preserve insertion order. I can't reliably reproduce (assuming some non determinism is involved) but have examples such as the following:

```
bazel run @bookworm//:lock

WARNING: Download from https://snapshot-cloudflare.debian.org/archive/debian/20241221T204840Z/dists/bookworm/main/binary-amd64/Packages failed: class java.io.FileNotFoundException GET returned 404 Not Found
WARNING: Download from https://snapshot-cloudflare.debian.org/archive/debian-security/20241221T204840Z/dists/bookworm-security/main/binary-amd64/Packages failed: class java.io.FileNotFoundException GET returned 404 Not Found
WARNING: Download from https://snapshot-cloudflare.debian.org/archive/debian/20241221T204840Z/dists/bookworm-updates/main/binary-amd64/Packages failed: class java.io.FileNotFoundException GET returned 404 Not Found
WARNING: Download from https://snapshot-cloudflare.debian.org/archive/debian/20241221T204840Z/dists/bookworm/main/binary-arm64/Packages failed: class java.io.FileNotFoundException GET returned 404 Not Found
WARNING: Download from https://snapshot-cloudflare.debian.org/archive/debian-security/20241221T204840Z/dists/bookworm-security/main/binary-arm64/Packages failed: class java.io.FileNotFoundException GET returned 404 Not Found
WARNING: Download from https://snapshot-cloudflare.debian.org/archive/debian/20241221T204840Z/dists/bookworm-updates/main/binary-arm64/Packages failed: class java.io.FileNotFoundException GET returned 404 Not Found
```

It should not be possible to see a 404 for the bare `../Packages` URI without additional 404 errors for the compressed indexes such as `Packages.xz`.

Using a list of tuples will guarantee iteration order.