### PR TITLE
fix: mark apt extension as reproducible when using a lockfile

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,7 @@ bazel_dep(name = "platforms", version = "0.0.10")
 
 # Bazel 8 fails without a working version of protobuf
 bazel_dep(name = "protobuf", version = "29.0-rc2.bcr.1")
+bazel_dep(name = "bazel_features", version = "1.20.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.9.4")
 bazel_dep(name = "rules_java", version = "8.3.2")
@@ -31,7 +32,6 @@ bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependenc
 bazel_dep(name = "buildifier_prebuilt", version = "6.1.2", dev_dependency = True)
 bazel_dep(name = "rules_oci", version = "2.0.0", dev_dependency = True)
 bazel_dep(name = "container_structure_test", version = "1.16.0", dev_dependency = True)
-bazel_dep(name = "bazel_features", version = "1.20.0", dev_dependency = True)
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/apt/BUILD.bazel
+++ b/apt/BUILD.bazel
@@ -30,10 +30,10 @@ bzl_library(
     srcs = ["extensions.bzl"],
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_features//:features",
         "//apt/private:deb_import",
         "//apt/private:deb_resolve",
         "//apt/private:deb_translate_lock",
         "//apt/private:lockfile",
+        "@bazel_features//:features",
     ],
 )

--- a/apt/BUILD.bazel
+++ b/apt/BUILD.bazel
@@ -30,6 +30,7 @@ bzl_library(
     srcs = ["extensions.bzl"],
     visibility = ["//visibility:public"],
     deps = [
+        "@bazel_features//:features",
         "//apt/private:deb_import",
         "//apt/private:deb_resolve",
         "//apt/private:deb_translate_lock",

--- a/apt/extensions.bzl
+++ b/apt/extensions.bzl
@@ -1,5 +1,6 @@
 "apt extensions"
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//apt/private:deb_import.bzl", "deb_import")
 load("//apt/private:deb_resolve.bzl", "deb_resolve", "internal_resolve")
 load("//apt/private:deb_translate_lock.bzl", "deb_translate_lock")
@@ -8,6 +9,7 @@ load("//apt/private:lockfile.bzl", "lockfile")
 def _distroless_extension(module_ctx):
     root_direct_deps = []
     root_direct_dev_deps = []
+    reproducible = False
 
     for mod in module_ctx.modules:
         for install in mod.tags.install:
@@ -25,6 +27,7 @@ def _distroless_extension(module_ctx):
                     print("\nNo lockfile was given, please run `bazel run @%s//:lock` to create the lockfile." % install.name)
             else:
                 lockf = lockfile.from_json(module_ctx, module_ctx.read(install.lock))
+                reproducible = True
 
             for (package) in lockf.packages():
                 package_key = lockfile.make_package_key(
@@ -58,9 +61,14 @@ def _distroless_extension(module_ctx):
                 else:
                     root_direct_deps.append(install.name)
 
+    metadata_kwargs = {}
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        metadata_kwargs["reproducible"] = reproducible
+
     return module_ctx.extension_metadata(
         root_module_direct_deps = root_direct_deps,
         root_module_direct_dev_deps = root_direct_dev_deps,
+        **metadata_kwargs,
     )
 
 _install_doc = """

--- a/apt/extensions.bzl
+++ b/apt/extensions.bzl
@@ -68,7 +68,7 @@ def _distroless_extension(module_ctx):
     return module_ctx.extension_metadata(
         root_module_direct_deps = root_direct_deps,
         root_module_direct_dev_deps = root_direct_dev_deps,
-        **metadata_kwargs,
+        **metadata_kwargs
     )
 
 _install_doc = """


### PR DESCRIPTION
When using a lockfile, an entry in the MODULE.bazel.lock is redundant.

Marking the extension as reproducible only when a lockfile is provided saves an entry in the lockfile.

Note, I had to move `bazel_features` out of `dev_dependency` because the `reproducible` field on `extension_metadata` only appeared in `7.1.0`.