### PR TITLE
Upgrade `aspect_bazel_lib` to 2.14.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ module(
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "bazel_features", version = "1.20.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.9.4")
+bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
 bazel_dep(name = "rules_java", version = "8.8.0")
 
 bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")

--- a/distroless/private/flatten.bzl
+++ b/distroless/private/flatten.bzl
@@ -16,7 +16,6 @@ def _flatten_impl(ctx):
     args.add_all(tar_lib.DEFAULT_ARGS)
     args.add("--create")
     tar_lib.common.add_compression_args(ctx.attr.compress, args)
-    tar_lib.add_default_compression_args(ctx.attr.compress, args)
     args.add("--file", output)
     args.add_all(ctx.files.tars, format_each = "@%s")
 

--- a/distroless/private/group.bzl
+++ b/distroless/private/group.bzl
@@ -53,7 +53,7 @@ def group(name, entries, time = "0.0", mode = "0644", **kwargs):
         name = name,
         srcs = [":%s_content" % name],
         mtree = mtree.content(),
-        args = tar_lib.DEFAULT_ARGS + tar_lib.DEFAULT_COMPRESSION_ARGS["gzip"],
+        args = tar_lib.DEFAULT_ARGS,
         compress = "gzip",
         **common_kwargs
     )

--- a/distroless/private/home.bzl
+++ b/distroless/private/home.bzl
@@ -28,7 +28,7 @@ def home(name, dirs, **kwargs):
     tar(
         name = name,
         mtree = mtree.content(),
-        args = tar_lib.DEFAULT_ARGS + tar_lib.DEFAULT_COMPRESSION_ARGS["gzip"],
+        args = tar_lib.DEFAULT_ARGS,
         compress = "gzip",
         **kwargs
     )

--- a/distroless/private/os_release.bzl
+++ b/distroless/private/os_release.bzl
@@ -54,7 +54,7 @@ def os_release(
         name = name,
         srcs = [":%s_content" % name],
         mtree = mtree.content(),
-        args = tar_lib.DEFAULT_ARGS + tar_lib.DEFAULT_COMPRESSION_ARGS["gzip"],
+        args = tar_lib.DEFAULT_ARGS,
         compress = "gzip",
         **common_kwargs
     )

--- a/distroless/private/passwd.bzl
+++ b/distroless/private/passwd.bzl
@@ -63,7 +63,7 @@ def passwd(name, entries, mode = "0644", time = "0.0", **kwargs):
         name = name,
         srcs = [":%s_content" % name],
         mtree = mtree.content(),
-        args = tar_lib.DEFAULT_ARGS + tar_lib.DEFAULT_COMPRESSION_ARGS["gzip"],
+        args = tar_lib.DEFAULT_ARGS,
         compress = "gzip",
         **common_kwargs
     )

--- a/distroless/private/tar.bzl
+++ b/distroless/private/tar.bzl
@@ -13,13 +13,6 @@ DEFAULT_ARGS = [
     "gnutar",
 ]
 
-DEFAULT_COMPRESSION_ARGS = {
-    "gzip": [
-        # Gzip timestamps are source of non-hermeticity. disable them
-        "--options=gzip:!timestamp",
-    ],
-}
-
 def _mtree_line(dest, type, content = None, uid = DEFAULT_UID, gid = DEFAULT_GID, time = DEFAULT_TIME, mode = DEFAULT_MODE):
     # mtree expects paths to start with ./ so normalize paths that starts with
     # `/` or relative path (without / and ./)
@@ -62,7 +55,6 @@ def _build_tar(ctx, mtree, output, inputs = [], compression = "gzip", mnemonic =
     args.add_all(DEFAULT_ARGS)
     args.add("--create")
     tar.common.add_compression_args(compression, args)
-    _add_default_compression_args(compression, args)
     args.add("--file", output)
     args.add(mtree, format = "@%s")
 
@@ -106,14 +98,9 @@ def _create_mtree(ctx = None):
         content = lambda: content.to_list() + ["#end"],
     )
 
-def _add_default_compression_args(compression, args):
-    args.add_all(DEFAULT_COMPRESSION_ARGS.get(compression, []))
-
 tar_lib = struct(
     TOOLCHAIN_TYPE = tar.toolchain_type,
     DEFAULT_ARGS = DEFAULT_ARGS,
-    DEFAULT_COMPRESSION_ARGS = DEFAULT_COMPRESSION_ARGS,
-    add_default_compression_args = _add_default_compression_args,
     create_mtree = _create_mtree,
     common = tar.common,
 )


### PR DESCRIPTION
Upgrade `aspect_bazel_lib` from 2.9.4 to 2.14.0, and stop setting `--options=gzip:!timestamp` as an argument when running `tar`.

The tar lib in `aspect_bazel_lib` >2.10.0 already sets this argument, so setting it again causes warnings like these:

```
INFO: From Tar examples/passwd/passwd.tar.gz:
tar: Ignoring previous option 'gzip:!timestamp,', separate multiple options with commas
INFO: From Tar examples/ubuntu_snapshot/group.tar.gz:
tar: Ignoring previous option 'gzip:!timestamp,', separate multiple options with commas
```