### PR TITLE
Use the correct rules_java_dependencies() for rules_java 8.8.0.

### DIFF
--- a/distroless/toolchains.bzl
+++ b/distroless/toolchains.bzl
@@ -1,7 +1,8 @@
 "macro for registering toolchains required"
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "register_expand_template_toolchains", "register_tar_toolchains", "register_yq_toolchains", "register_zstd_toolchains")
-load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
+load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
 
 def distroless_register_toolchains():
     """Register all toolchains required by distroless."""


### PR DESCRIPTION
Per `MODULE.bazel`, this repo assumes `rules_java` 8.8.0 or better. However, under `rules_java` 8.8.0, the `rules_java_dependencies()` in `@rules_java//java:repositories.bzl` is a stub that prints a message telling people to load the routine from its new location in `@rules_java//java:rules_java_deps.bzl`.