### PR TITLE
feat: Support initial empty lockfile

### DIFF
--- a/apt/private/deb_translate_lock.bzl
+++ b/apt/private/deb_translate_lock.bzl
@@ -102,7 +102,7 @@ dpkg_status(
     controls = select({{
         "//:linux_%s" % arch: ["//%s:control" % package for package in packages]
         for arch, packages in _PACKAGES.items()
-    }}),
+    }}) if _PACKAGES else {{}},
     visibility = ["//visibility:public"],
 )
 
@@ -111,7 +111,7 @@ filegroup(
     srcs = select({{
         "//:linux_%s" % arch: ["//%s" % package for package in packages]
         for arch, packages in _PACKAGES.items()
-    }}),
+    }}) if _PACKAGES else {{}},
     visibility = ["//visibility:public"],
 )
 

--- a/apt/private/lockfile.bzl
+++ b/apt/private/lockfile.bzl
@@ -55,16 +55,19 @@ def _create(rctx, lock):
         as_json = lambda: json.encode_indent(struct(version = lock.version, packages = lock.packages)),
     )
 
+_EMPTY_LOCK_DICT = dict(
+    version = 1,
+    packages = list(),
+    fast_package_lookup = dict(),
+)
+
 def _empty(rctx):
-    lock = struct(
-        version = 1,
-        packages = list(),
-        fast_package_lookup = dict(),
-    )
+    lock = struct(**_EMPTY_LOCK_DICT)
     return _create(rctx, lock)
 
 def _from_json(rctx, content):
-    lock = json.decode(content)
+    lock = json.decode(content) if content else _EMPTY_LOCK_DICT
+
     if lock["version"] != 1:
         fail("invalid lockfile version")
 


### PR DESCRIPTION
When setting up a new project, an initial template is required for lockfile generation to work without errors.
This patch allows users to create an empty file and run, for example: `bazel run @bullseye//:lock`.

Related to https://github.com/GoogleContainerTools/distroless/issues/1697.