### PR TITLE
fix: filegroup circular deps

### DIFF
--- a/apt/private/deb_translate_lock.bzl
+++ b/apt/private/deb_translate_lock.bzl
@@ -39,7 +39,7 @@ alias(
 
 filegroup(
     name = "{target_name}",
-    srcs = select({deps}) + [":data"],
+    srcs = select({deps}),
     visibility = ["//visibility:public"],
 )
 '''

--- a/apt/private/deb_translate_lock.bzl
+++ b/apt/private/deb_translate_lock.bzl
@@ -192,7 +192,7 @@ def _deb_translate_lock_impl(rctx):
                 control_targets = '"@%s//:control"' % repo_name,
                 src = '"@%s//:data"' % repo_name,
                 deps = starlark_codegen_utils.to_list_attr([
-                    "//%s/%s" % (dep["name"], package["arch"])
+                    "//%s/%s:data" % (dep["name"], package["arch"])
                     for dep in package["dependencies"]
                 ]),
                 urls = package["urls"],


### PR DESCRIPTION
Previously generated `filegroup` targets can contain dependency cycle.

The case here is that defined filegroup of a package should not have deps of other packages but rather to its `:data` package.

This change removes potential dependency cycles and makes references to package's `:data`.

Resolves #163 & Closes #163.