### PR TITLE
fix: relocate tar toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,7 +37,7 @@ use_repo(yq_toolchains, "yq_windows_amd64")
 bazel_dep(name = "gazelle", version = "0.34.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "8.0.1", dev_dependency = True)
-bazel_dep(name = "jq.bzl", version = "0.3.0", dev_dependency = True)
+bazel_dep(name = "jq.bzl", version = "0.4.0", dev_dependency = True)
 bazel_dep(name = "rules_oci", version = "2.0.0", dev_dependency = True)
 bazel_dep(name = "container_structure_test", version = "1.16.0", dev_dependency = True)
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,22 +12,32 @@ bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")  # TODO(alexeagle): remove
 bazel_dep(name = "rules_java", version = "8.8.0")
 bazel_dep(name = "rules_shell", version = "0.4.1")
+bazel_dep(name = "tar.bzl", version = "0.6.0")
+bazel_dep(name = "yq.bzl", version = "0.3.1")
 
 bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
+
+tar_toolchains = use_extension("@tar.bzl//tar:extensions.bzl", "toolchains")
+
+yq_toolchains = use_extension("@yq.bzl//yq:extensions.bzl", "yq")
+
 use_repo(bazel_lib_toolchains, "zstd_toolchains")
-use_repo(bazel_lib_toolchains, "bsd_tar_toolchains")
-use_repo(bazel_lib_toolchains, "yq_darwin_amd64")
-use_repo(bazel_lib_toolchains, "yq_darwin_arm64")
-use_repo(bazel_lib_toolchains, "yq_linux_amd64")
-use_repo(bazel_lib_toolchains, "yq_linux_arm64")
-use_repo(bazel_lib_toolchains, "yq_linux_ppc64le")
-use_repo(bazel_lib_toolchains, "yq_linux_s390x")
-use_repo(bazel_lib_toolchains, "yq_windows_amd64")
+
+use_repo(tar_toolchains, "bsd_tar_toolchains")
+
+use_repo(yq_toolchains, "yq_darwin_amd64")
+use_repo(yq_toolchains, "yq_darwin_arm64")
+use_repo(yq_toolchains, "yq_linux_amd64")
+use_repo(yq_toolchains, "yq_linux_arm64")
+use_repo(yq_toolchains, "yq_linux_ppc64le")
+use_repo(yq_toolchains, "yq_linux_s390x")
+use_repo(yq_toolchains, "yq_windows_amd64")
 
 # Dev dependencies
 bazel_dep(name = "gazelle", version = "0.34.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "8.0.1", dev_dependency = True)
+bazel_dep(name = "jq.bzl", version = "0.3.0", dev_dependency = True)
 bazel_dep(name = "rules_oci", version = "2.0.0", dev_dependency = True)
 bazel_dep(name = "container_structure_test", version = "1.16.0", dev_dependency = True)
 

--- a/apt/tests/resolution/BUILD.bazel
+++ b/apt/tests/resolution/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@jq.bzl", "jq")
 
 jq(
     name = "pick_libuuid_version",

--- a/distroless/private/BUILD.bazel
+++ b/distroless/private/BUILD.bazel
@@ -37,9 +37,9 @@ bzl_library(
     visibility = ["//distroless:__subpackages__"],
     deps = [
         "@aspect_bazel_lib//lib:expand_template",
-        "@aspect_bazel_lib//lib:tar",
         "@aspect_bazel_lib//lib:utils",
         "@bazel_skylib//rules:write_file",
+        "@tar.bzl//tar:tar",
     ],
 )
 
@@ -49,9 +49,9 @@ bzl_library(
     visibility = ["//distroless:__subpackages__"],
     deps = [
         "@aspect_bazel_lib//lib:expand_template",
-        "@aspect_bazel_lib//lib:tar",
         "@aspect_bazel_lib//lib:utils",
         "@bazel_skylib//rules:write_file",
+        "@tar.bzl//tar:tar",
     ],
 )
 
@@ -62,9 +62,9 @@ bzl_library(
     deps = [
         ":util",
         "@aspect_bazel_lib//lib:expand_template",
-        "@aspect_bazel_lib//lib:tar",
         "@aspect_bazel_lib//lib:utils",
         "@bazel_skylib//rules:write_file",
+        "@tar.bzl//tar:tar",
     ],
 )
 
@@ -82,7 +82,7 @@ bzl_library(
     deps = [
         ":tar",
         ":util",
-        "@aspect_bazel_lib//lib:tar",
+        "@tar.bzl//tar:tar",
     ],
 )
 
@@ -101,8 +101,8 @@ bzl_library(
         "//distroless:__subpackages__",
     ],
     deps = [
-        "@aspect_bazel_lib//lib:tar",
         "@bazel_skylib//lib:sets",
+        "@tar.bzl//tar:tar",
     ],
 )
 

--- a/distroless/private/group.bzl
+++ b/distroless/private/group.bzl
@@ -1,8 +1,8 @@
 "group"
 
-load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_bazel_lib//lib:utils.bzl", "propagate_common_rule_attributes")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@tar.bzl//tar:tar.bzl", "tar")
 load(":tar.bzl", "tar_lib")
 load(":util.bzl", "util")
 

--- a/distroless/private/home.bzl
+++ b/distroless/private/home.bzl
@@ -1,6 +1,6 @@
 "home"
 
-load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("@tar.bzl//tar:tar.bzl", "tar")
 load(":tar.bzl", "tar_lib")
 load(":util.bzl", "util")
 

--- a/distroless/private/os_release.bzl
+++ b/distroless/private/os_release.bzl
@@ -1,8 +1,8 @@
 "os release"
 
-load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_bazel_lib//lib:utils.bzl", "propagate_common_rule_attributes")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@tar.bzl//tar:tar.bzl", "tar")
 load(":tar.bzl", "tar_lib")
 
 def os_release(

--- a/distroless/private/passwd.bzl
+++ b/distroless/private/passwd.bzl
@@ -1,8 +1,8 @@
 "osrelease"
 
-load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_bazel_lib//lib:utils.bzl", "propagate_common_rule_attributes")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@tar.bzl//tar:tar.bzl", "tar")
 load(":tar.bzl", "tar_lib")
 
 # WARNING: the mode `0o644` is important

--- a/distroless/private/tar.bzl
+++ b/distroless/private/tar.bzl
@@ -1,7 +1,7 @@
 "mtree helpers"
 
-load("@aspect_bazel_lib//lib:tar.bzl", tar = "tar_lib")
 load("@bazel_skylib//lib:sets.bzl", "sets")
+load("@tar.bzl//tar:tar.bzl", tar = "tar_lib")
 
 DEFAULT_GID = "0"
 DEFAULT_UID = "0"

--- a/distroless/toolchains.bzl
+++ b/distroless/toolchains.bzl
@@ -1,14 +1,12 @@
 "macro for registering toolchains required"
 
-load("@aspect_bazel_lib//lib:repositories.bzl", "register_expand_template_toolchains", "register_tar_toolchains", "register_yq_toolchains", "register_zstd_toolchains")
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_expand_template_toolchains", "register_zstd_toolchains")
 load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
 load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
 
 def distroless_register_toolchains():
     """Register all toolchains required by distroless."""
-    register_yq_toolchains()
     register_zstd_toolchains()
-    register_tar_toolchains()
     register_expand_template_toolchains()
     rules_java_dependencies()
     rules_java_toolchains()

--- a/e2e/smoke/.bazelrc
+++ b/e2e/smoke/.bazelrc
@@ -1,0 +1,1 @@
+test --test_output=errors

--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -8,11 +8,11 @@ NOTE:
     (test_linux_<ARCH> files and the bullseye YAML manifest)
 """
 
-load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_distroless//distroless:defs.bzl", "cacerts", "group", "passwd")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@tar.bzl", "tar")
 
 COMPATIBLE_WITH = select({
     "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],

--- a/e2e/smoke/BUILD
+++ b/e2e/smoke/BUILD
@@ -8,7 +8,7 @@ NOTE:
     (test_linux_<ARCH> files and the bullseye YAML manifest)
 """
 
-load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_distroless//distroless:defs.bzl", "cacerts", "group", "passwd")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,9 +1,10 @@
 bazel_dep(name = "rules_distroless", version = "0.0.0", dev_dependency = True)
+bazel_dep(name = "bazel_lib", version = "3.0.0-rc.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.10", dev_dependency = True)
 bazel_dep(name = "rules_oci", version = "2.0.0", dev_dependency = True)
 bazel_dep(name = "container_structure_test", version = "1.16.0", dev_dependency = True)
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.3", dev_dependency = True)
+bazel_dep(name = "tar.bzl", version = "0.6.0", dev_dependency = True)
 
 local_path_override(
     module_name = "rules_distroless",

--- a/examples/debian_snapshot/BUILD.bazel
+++ b/examples/debian_snapshot/BUILD.bazel
@@ -8,11 +8,11 @@ NOTE:
     (test_linux_<ARCH> files and the bullseye YAML manifest)
 """
 
-load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_distroless//distroless:defs.bzl", "cacerts", "group", "passwd")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@tar.bzl", "tar")
 
 COMPATIBLE_WITH = select({
     "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],

--- a/examples/flatten/BUILD.bazel
+++ b/examples/flatten/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("@tar.bzl", "tar")
 load("//distroless:defs.bzl", "flatten", "home", "passwd")
 load("//distroless/tests:asserts.bzl", "assert_tar_listing", "assert_tar_mtree")
 

--- a/examples/ubuntu_snapshot/BUILD.bazel
+++ b/examples/ubuntu_snapshot/BUILD.bazel
@@ -1,7 +1,7 @@
-load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_distroless//distroless:defs.bzl", "group", "passwd")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@tar.bzl", "tar")
 
 COMPATIBLE_WITH = select({
     "@platforms//cpu:x86_64": ["@platforms//cpu:x86_64"],


### PR DESCRIPTION
Newer bazel-lib versions re-export the tar.bzl toolchain type. Since rules_distroless dererefences it from the `tar_lib` helper, we'd need to dep on it directly.

bazel-lib 3 will remove the redirect; to be forwards-compatible we shouldn't rely on it.

Also make our bzl_library targets correct, working around https://github.com/bazelbuild/bazel-skylib/issues/568