### PR TITLE
fix: remove realpath call from decompression logic

### DIFF
--- a/apt/private/deb_postfix.bzl
+++ b/apt/private/deb_postfix.bzl
@@ -12,7 +12,6 @@ def deb_postfix(name, srcs, outs, mergedusr = False, **kwargs):
             $(ZSTD_BIN) --compress --format=gzip "$$data_file" > "$$layer"
         ;;
         *data.tar.xz|*data.tar.zst|*data.tar.lzma)
-            realpath "$$data_file"
             $(ZSTD_BIN) --force --decompress --stdout "$$data_file" |
             $(ZSTD_BIN) --compress --format=gzip - > "$$layer"
         ;;


### PR DESCRIPTION
Remove realpath call for data.tar.xz, data.tar.zst, and data.tar.lzma handling.