### PR TITLE
fix: duplicate package dependencies in lock file

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -89,8 +89,13 @@ apt.install(
     nolock = True,
 )
 apt.install(
+    name = "unique_dependencies",
+    manifest = "//apt/tests/resolution:dependencies.yaml",
+    nolock = True,
+)
+apt.install(
     name = "clang",
     manifest = "apt/tests/resolution/clang.yaml",
     nolock = True,
 )
-use_repo(apt, "arch_all_test", "arch_all_test_resolve", "bullseye", "bullseye_nolock", "clang", "noble", "resolution_test", "resolution_test_empty_lock_resolve", "resolution_test_resolve")
+use_repo(apt, "arch_all_test", "arch_all_test_resolve", "bullseye", "bullseye_nolock", "clang", "noble", "resolution_test", "resolution_test_empty_lock_resolve", "resolution_test_resolve", "unique_dependencies_resolve")

--- a/apt/tests/resolution/BUILD.bazel
+++ b/apt/tests/resolution/BUILD.bazel
@@ -62,6 +62,21 @@ assert_contains(
     expected = "73",
 )
 
+jq(
+    name = "unique_dependencies",
+    srcs = [
+        "@unique_dependencies_resolve//:lockfile",
+    ],
+    args = ["-rj"],
+    filter = '.packages | map(select(.name == "gcc")) | .[0].dependencies | group_by(.) | map(select(length>1) | .[0]) | length',
+)
+
+assert_contains(
+    name = "test_unique_dependencies",
+    actual = ":unique_dependencies",
+    expected = "0",
+)
+
 build_test(
     name = "build_clang",
     target_compatible_with = [

--- a/apt/tests/resolution/dependencies.yaml
+++ b/apt/tests/resolution/dependencies.yaml
@@ -1,0 +1,15 @@
+version: 1
+sources:
+  - channel: jammy main
+    url: https://snapshot.ubuntu.com/ubuntu/20250302T030400Z
+  - channel: jammy universe
+    url: https://snapshot.ubuntu.com/ubuntu/20250302T030400Z
+  - channel: jammy-security main
+    url: https://snapshot.ubuntu.com/ubuntu/20250302T030400Z
+  - channel: jammy-updates main
+    url: https://snapshot.ubuntu.com/ubuntu/20250302T030400Z
+archs:
+  - "arm64"
+packages:
+  - "gcc"
+  - "gcc-aarch64-linux-gnu"


### PR DESCRIPTION
Make sure that package dependencies in a lock file are added only once.

Resolves #184 & Closes #184.