### PR TITLE
Fix compatibility with external modules.

### DIFF
--- a/distroless/private/group.bzl
+++ b/distroless/private/group.bzl
@@ -46,7 +46,7 @@ def group(name, entries, time = "0.0", mode = "0644", **kwargs):
         "file",
         mode = mode,
         time = time,
-        content = "$(BINDIR)/$(rootpath :%s_content)" % name,
+        content = "$(execpath :%s_content)" % name,
     )
 
     tar(

--- a/distroless/private/os_release.bzl
+++ b/distroless/private/os_release.bzl
@@ -47,7 +47,7 @@ def os_release(
         "file",
         mode = mode,
         time = time,
-        content = "$(BINDIR)/$(rootpath :%s_content)" % name,
+        content = "$(execpath :%s_content)" % name,
     )
 
     tar(

--- a/distroless/private/passwd.bzl
+++ b/distroless/private/passwd.bzl
@@ -56,7 +56,7 @@ def passwd(name, entries, mode = "0644", time = "0.0", **kwargs):
         "file",
         mode = mode,
         time = time,
-        content = "$(BINDIR)/$(rootpath :%s_content)" % name,
+        content = "$(execpath :%s_content)" % name,
     )
 
     tar(


### PR DESCRIPTION
If this modules is used with external modules located in subfolders, it generates wrong pathes, like:
`bazel-out/x64_windows-fastbuild/bin/../distroless_base+/os_release.content`, but correct path must be:
`bazel-out/x64_windows-fastbuild/bin/external/distroless_base+/os_release.content`
The patch must fix the issue.