### PR TITLE
feat: adds coreutils toolchain for hermetic remote execution

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,6 +26,7 @@ use_repo(yq_toolchains, "yq_windows_amd64")
 
 bazel_lib_toolchains = use_extension("@bazel_lib//lib:extensions.bzl", "toolchains")
 use_repo(bazel_lib_toolchains, "zstd_toolchains")
+use_repo(bazel_lib_toolchains, "coreutils_toolchains")
 
 tar_toolchains = use_extension("@tar.bzl//tar:extensions.bzl", "toolchains")
 use_repo(tar_toolchains, "bsd_tar_toolchains")

--- a/apt/private/dpkg_status.bzl
+++ b/apt/private/dpkg_status.bzl
@@ -7,6 +7,7 @@ _DOC = """TODO: docs"""
 
 def _dpkg_status_impl(ctx):
     bsdtar = ctx.toolchains[tar_lib.TOOLCHAIN_TYPE]
+    coreutils = ctx.toolchains["@bazel_lib//lib:coreutils_toolchain_type"]
 
     output = ctx.actions.declare_file(ctx.attr.name + ".tar")
 
@@ -14,13 +15,18 @@ def _dpkg_status_impl(ctx):
     args.add(bsdtar.tarinfo.binary)
     args.add(output)
     args.add(ctx.executable._gawk.path)
+    args.add(coreutils.coreutils_info.bin)
     args.add_all(ctx.files.controls)
 
     ctx.actions.run(
         executable = ctx.executable._dpkg_status_sh,
         inputs = ctx.files.controls,
         outputs = [output],
-        tools = [bsdtar.default.files, ctx.executable._gawk],
+        tools = [
+            bsdtar.default.files,
+            ctx.executable._gawk,
+            coreutils.default.files,
+        ],
         arguments = [args],
     )
 
@@ -49,5 +55,5 @@ dpkg_status = rule(
         ),
     },
     implementation = _dpkg_status_impl,
-    toolchains = [tar_lib.TOOLCHAIN_TYPE],
+    toolchains = [tar_lib.TOOLCHAIN_TYPE, "@bazel_lib//lib:coreutils_toolchain_type"],
 )

--- a/apt/private/dpkg_status.sh
+++ b/apt/private/dpkg_status.sh
@@ -4,9 +4,10 @@ set -o pipefail -o errexit -o nounset
 readonly bsdtar="$1"
 readonly out="$2"
 readonly awk="$3"
-shift 3
+readonly coreutils="$4"
+shift 4
 
-tmp_out=$(mktemp)
+tmp_out=$($coreutils mktemp)
 
 while  (( $# > 0 )); do
     $bsdtar -xf "$1" --to-stdout ./control |
@@ -22,4 +23,4 @@ echo "#mtree
 ./var/lib/dpkg/status type=file uid=0 gid=0 mode=0644 time=1672560000 contents=$tmp_out
 " | "$bsdtar" $@ -cf "$out" "@-"
 
-rm $tmp_out
+$coreutils rm $tmp_out

--- a/apt/private/dpkg_statusd.bzl
+++ b/apt/private/dpkg_statusd.bzl
@@ -7,6 +7,7 @@ _DOC = """TODO: docs"""
 
 def _dpkg_statusd_impl(ctx):
     bsdtar = ctx.toolchains[tar_lib.TOOLCHAIN_TYPE]
+    coreutils = ctx.toolchains["@bazel_lib//lib:coreutils_toolchain_type"]
 
     ext = tar_lib.common.compression_to_extension[ctx.attr.compression] if ctx.attr.compression else ".tar"
     output = ctx.actions.declare_file(ctx.attr.name + ext)
@@ -17,13 +18,18 @@ def _dpkg_statusd_impl(ctx):
     args.add(ctx.file.control)
     args.add(ctx.attr.package_name)
     args.add(ctx.executable._gawk.path)
+    args.add(coreutils.coreutils_info.bin)
     tar_lib.common.add_compression_args(ctx.attr.compression, args)
 
     ctx.actions.run(
         executable = ctx.executable._dpkg_statusd_sh,
         inputs = [ctx.file.control],
         outputs = [output],
-        tools = [bsdtar.default.files, ctx.executable._gawk],
+        tools = [
+            bsdtar.default.files,
+            ctx.executable._gawk,
+            coreutils.default.files,
+        ],
         arguments = [args],
     )
 
@@ -57,5 +63,5 @@ dpkg_statusd = rule(
         ),
     },
     implementation = _dpkg_statusd_impl,
-    toolchains = [tar_lib.TOOLCHAIN_TYPE],
+    toolchains = [tar_lib.TOOLCHAIN_TYPE, "@bazel_lib//lib:coreutils_toolchain_type"],
 )

--- a/apt/private/dpkg_statusd.sh
+++ b/apt/private/dpkg_statusd.sh
@@ -6,11 +6,12 @@ readonly out="$2"
 readonly control_path="$3"
 readonly package_name="$4"
 readonly awk="$5"
-shift 5
+readonly coreutils="$6"
+shift 6
 
 include=(--include "^./control$" --include "^./md5sums$")
 
-tmp=$(mktemp -d)
+tmp=$($coreutils mktemp -d)
 "$bsdtar" -xf "$control_path" "${include[@]}" -C "$tmp"
 
 "$bsdtar" -cf - $@ --format=mtree "${include[@]}" --options '!gname,!uname,!sha1,!nlink,!time' "@$control_path" | \

--- a/distroless/private/cacerts.bzl
+++ b/distroless/private/cacerts.bzl
@@ -45,6 +45,7 @@ oci_image(
 
 def _cacerts_impl(ctx):
     bsdtar = ctx.toolchains[tar_lib.TOOLCHAIN_TYPE]
+    coreutils = ctx.toolchains["@bazel_lib//lib:coreutils_toolchain_type"]
 
     cacerts = ctx.actions.declare_file(ctx.attr.name + ".crt")
     copyright = ctx.actions.declare_file(ctx.attr.name + ".copyright")
@@ -52,12 +53,16 @@ def _cacerts_impl(ctx):
         executable = ctx.executable._cacerts_sh,
         inputs = [ctx.file.package],
         outputs = [cacerts, copyright],
-        tools = bsdtar.default.files,
+        tools = [
+            bsdtar.default.files,
+            coreutils.default.files,
+        ],
         arguments = [
             bsdtar.tarinfo.binary.path,
             ctx.file.package.path,
             cacerts.path,
             copyright.path,
+            coreutils.coreutils_info.bin.path,
         ],
     )
 
@@ -100,5 +105,5 @@ cacerts = rule(
         ),
     },
     implementation = _cacerts_impl,
-    toolchains = [tar_lib.TOOLCHAIN_TYPE],
+    toolchains = [tar_lib.TOOLCHAIN_TYPE, "@bazel_lib//lib:coreutils_toolchain_type"],
 )

--- a/distroless/private/cacerts.sh
+++ b/distroless/private/cacerts.sh
@@ -5,11 +5,12 @@ readonly bsdtar="$1"
 readonly package_path="$2"
 readonly cacerts_out="$3"
 readonly copyright_out="$4"
-readonly tmp="$(mktemp -d)"
+readonly coreutils="$5"
+readonly tmp="$($coreutils mktemp -d)"
 
 "$bsdtar" -xf "$package_path" -C "$tmp" ./usr/share/ca-certificates ./usr/share/doc/ca-certificates/copyright
 
-mv "$tmp/usr/share/doc/ca-certificates/copyright" "$copyright_out"
+$coreutils mv "$tmp/usr/share/doc/ca-certificates/copyright" "$copyright_out"
 
 function add_cert () {
     local dir="$1"
@@ -28,4 +29,4 @@ function add_cert () {
 }
 
 add_cert "$tmp/usr/share/ca-certificates"
-rm -rf "$tmp"
+$coreutils rm -rf "$tmp"

--- a/distroless/private/flatten.bzl
+++ b/distroless/private/flatten.bzl
@@ -6,6 +6,7 @@ _DOC = """Flatten multiple archives into single archive."""
 
 def _flatten_impl(ctx):
     bsdtar = ctx.toolchains[tar_lib.TOOLCHAIN_TYPE]
+    coreutils = ctx.toolchains["@bazel_lib//lib:coreutils_toolchain_type"]
 
     ext = tar_lib.common.compression_to_extension[ctx.attr.compress] if ctx.attr.compress else ".tar"
     output = ctx.actions.declare_file(ctx.attr.name + ext)
@@ -14,6 +15,7 @@ def _flatten_impl(ctx):
     args.add(bsdtar.tarinfo.binary)
     args.add(str(ctx.attr.deduplicate))
     args.add(ctx.executable._gawk.path)
+    args.add(coreutils.coreutils_info.bin)
     args.add_all(tar_lib.DEFAULT_ARGS)
     args.add("--create")
     tar_lib.common.add_compression_args(ctx.attr.compress, args)
@@ -24,7 +26,11 @@ def _flatten_impl(ctx):
         executable = ctx.executable._flatten_sh,
         inputs = ctx.files.tars,
         outputs = [output],
-        tools = [bsdtar.default.files, ctx.executable._gawk],
+        tools = [
+            bsdtar.default.files,
+            ctx.executable._gawk,
+            coreutils.default.files,
+        ],
         arguments = [args],
         mnemonic = "Flatten",
         progress_message = "Flattening %{label}",
@@ -62,5 +68,5 @@ Deduplication is performed only for directories.
         ),
     },
     implementation = _flatten_impl,
-    toolchains = [tar_lib.TOOLCHAIN_TYPE],
+    toolchains = [tar_lib.TOOLCHAIN_TYPE, "@bazel_lib//lib:coreutils_toolchain_type"],
 )

--- a/distroless/private/flatten.sh
+++ b/distroless/private/flatten.sh
@@ -4,12 +4,13 @@ set -o pipefail -o errexit
 bsdtar="$1";
 deduplicate="$2";
 readonly awk="$3"
-shift 3;
+readonly coreutils="$4"
+shift 4;
 
 # Deduplication requested, use this complex pipeline to deduplicate.
 if [[ "$deduplicate" == "True" ]]; then
 
-    mtree=$(mktemp)
+    mtree=$($coreutils mktemp)
 
     # List files in all archives and append to single column mtree.
     for arg in "$@"; do

--- a/distroless/private/locale.bzl
+++ b/distroless/private/locale.bzl
@@ -29,6 +29,7 @@ locale(
 
 def _locale_impl(ctx):
     bsdtar = ctx.toolchains[tar_lib.TOOLCHAIN_TYPE]
+    coreutils = ctx.toolchains["@bazel_lib//lib:coreutils_toolchain_type"]
 
     output = ctx.actions.declare_file(ctx.attr.name + ".tar.gz")
 
@@ -38,6 +39,8 @@ def _locale_impl(ctx):
     args.add(output)
     args.add(ctx.file.package)
     args.add(ctx.attr.time)
+    args.add(coreutils.coreutils_info.bin)
+    args.add(ctx.executable._gawk)
     args.add("--include", "^./usr/$")
     args.add("--include", "^./usr/lib/$")
     args.add("--include", "^./usr/lib/locale/$")
@@ -51,7 +54,11 @@ def _locale_impl(ctx):
         executable = ctx.executable._locale_sh,
         inputs = [ctx.file.package],
         outputs = [output],
-        tools = bsdtar.default.files,
+        tools = [
+            bsdtar.default.files,
+            coreutils.default.files,
+            ctx.executable._gawk,
+        ],
         arguments = [args],
     )
     return [
@@ -78,7 +85,13 @@ locale = rule(
             doc = "time for the entries",
             default = "0.0",
         ),
+        "_gawk": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+            default = "@gawk//:gawk",
+        ),
     },
     implementation = _locale_impl,
-    toolchains = [tar_lib.TOOLCHAIN_TYPE],
+    toolchains = [tar_lib.TOOLCHAIN_TYPE, "@bazel_lib//lib:coreutils_toolchain_type"],
 )

--- a/distroless/private/locale.sh
+++ b/distroless/private/locale.sh
@@ -5,15 +5,17 @@ readonly bsdtar="$1"
 readonly out="$2"
 readonly package_path="$3"
 readonly time="$4"
-shift 4
+readonly coreutils="$5"
+readonly awk="$6"
+shift 6
 
 # TODO: there must be a better way to manipulate tars!
 # "$bsdtar" -cf  $out --posix --no-same-owner --options="" $@ "@$package_path"
 # "$bsdtar" -cf to.mtree $@ --format=mtree --options '!gname,!uname,!sha1,!nlink' "@$package_path"
 # "$bsdtar" --older "0" -Uf $out @to.mtree
 
-tmp=$(mktemp -d)
+tmp=$($coreutils mktemp -d)
 "$bsdtar" -xf "$package_path" $@ -C "$tmp"
 "$bsdtar" -cf - $@ --format=mtree --options '!gname,!uname,!sha1,!nlink,!time' "@$package_path" |
-    sed 's/$/ time='"$time"'/' |
+    $awk '{ print $0 " time='"$time"'" }' |
     "$bsdtar" --gzip --options 'gzip:!timestamp' -cf "$out" -C "$tmp/" @-

--- a/distroless/toolchains.bzl
+++ b/distroless/toolchains.bzl
@@ -1,6 +1,6 @@
 "macro for registering toolchains required"
 
-load("@bazel_lib//lib:repositories.bzl", "register_expand_template_toolchains", "register_tar_toolchains", "register_yq_toolchains", "register_zstd_toolchains")
+load("@bazel_lib//lib:repositories.bzl", "register_expand_template_toolchains", "register_tar_toolchains", "register_yq_toolchains", "register_zstd_toolchains", "register_coreutils_toolchains")
 load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
 load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
 
@@ -8,6 +8,7 @@ def distroless_register_toolchains():
     """Register all toolchains required by distroless."""
     register_yq_toolchains()
     register_zstd_toolchains()
+    register_coreutils_toolchains()
     register_tar_toolchains()
     register_expand_template_toolchains()
     rules_java_dependencies()


### PR DESCRIPTION
This commit introduces the coreutils toolchain from `bazel-lib` across the entire rule set, ensuring that scripts invoke core utilities provided by the toolchain rather than the execution environment.

This change improves hermecity, particularly on bare‑bone executors like:

* [puqu-io/starterkit](https://github.com/puqu-io/starterkit)
* [GoogleContainerTools/distroless](https://github.com/GoogleContainerTools/distroless) 

where standard GNU coreutils may be missing.