### PR TITLE
add directory target to dependency_set, fix symlink and linker script issues

### DIFF
--- a/apt/private/deb_export.bzl
+++ b/apt/private/deb_export.bzl
@@ -45,23 +45,43 @@ def _deb_export_impl(ctx):
 
     if len(ctx.outputs.outs):
         fout = ctx.outputs.outs[0]
-        output = fout.path[:fout.path.find(fout.owner.repo_name) + len(fout.owner.repo_name)]
+        output_base = fout.path[:fout.path.find(fout.owner.repo_name) + len(fout.owner.repo_name)]
+        fix_linker_scripts_cmd = """
+find "{output_base}" -name "*.so" -type f | while read f; do
+    if grep -qE "^(GROUP|INPUT|OUTPUT_FORMAT)" "$f" 2>/dev/null; then
+        sed -i \\
+            -e 's|/usr/lib/x86_64-linux-gnu/||g' \\
+            -e 's|/lib/x86_64-linux-gnu/||g' \\
+            -e 's|/usr/lib/aarch64-linux-gnu/||g' \\
+            -e 's|/lib/aarch64-linux-gnu/||g' \\
+            -e 's|/usr/lib/||g' \\
+            -e 's|/lib64/||g' \\
+            -e 's|/lib/||g' \\
+            "$f" 2>/dev/null || true
+    fi
+done
+""".format(output_base = output_base)
         args = ctx.actions.args()
-        args.add("-xf")
         args.add_all(ctx.files.srcs)
-        args.add("-C")
-        args.add(output)
+        args.add(output_base)
         args.add_all(
             ctx.outputs.outs,
             map_each = lambda src: src.short_path[len(src.owner.repo_name) + 4:],
             allow_closure = True,
         )
-        ctx.actions.run(
-            executable = bsdtar.tarinfo.binary,
-            inputs = ctx.files.srcs,
+        ctx.actions.run_shell(
             outputs = ctx.outputs.outs,
+            inputs = ctx.files.srcs,
+            tools = [bsdtar.tarinfo.binary],
+            command = """
+                "{tar}" -xf $1 -C $2 "${{@:3}}"
+                {fix_scripts}
+            """.format(
+                tar = bsdtar.tarinfo.binary.path,
+                fix_scripts = fix_linker_scripts_cmd,
+            ),
             arguments = [args],
-            mnemonic = "Unpack",
+            mnemonic = "UnpackAndFixScripts",
             toolchain = TAR_TOOLCHAIN_TYPE,
         )
 

--- a/apt/private/deb_export.bzl
+++ b/apt/private/deb_export.bzl
@@ -8,19 +8,40 @@ def _deb_export_impl(ctx):
     bsdtar = ctx.toolchains[TAR_TOOLCHAIN_TYPE]
 
     foreign_symlinks = {
-      symlink: json.decode(indices_json)
-      for (symlink, indices_json) in ctx.attr.foreign_symlinks.items()
+        symlink: json.decode(indices_json)
+        for (symlink, indices_json) in ctx.attr.foreign_symlinks.items()
     }
 
     # foreign_symlinks maps label -> index string (reversed for Bazel 7.0.0 compatibility)
     for (target, indices_json) in ctx.attr.foreign_symlinks.items():
         indices = json.decode(indices_json)
         for i in indices:
-          ctx.actions.symlink(
-              output = ctx.outputs.symlink_outs[i],
-              # grossly inefficient
-              target_file = target[DefaultInfo].files.to_list()[0],
-          )
+            ctx.actions.symlink(
+                output = ctx.outputs.symlink_outs[i],
+                # grossly inefficient
+                target_file = target[DefaultInfo].files.to_list()[0],
+            )
+
+    # self_symlinks maps symlink path -> target path (both within this package)
+    # symlink_outs contains foreign symlink outputs first, then self symlink outputs
+    foreign_symlink_count = 0
+    for v in foreign_symlinks.values():
+        foreign_symlink_count += len(v)
+    self_symlink_keys = list(ctx.attr.self_symlinks.keys())
+    for i, symlink_path in enumerate(self_symlink_keys):
+        target_path = ctx.attr.self_symlinks[symlink_path]
+
+        # Find the target File object in outs
+        target_file = None
+        for f in ctx.outputs.outs:
+            if f.short_path[len(f.owner.repo_name) + 4:] == target_path:
+                target_file = f
+                break
+        if target_file != None:
+            ctx.actions.symlink(
+                output = ctx.outputs.symlink_outs[foreign_symlink_count + i],
+                target_file = target_file,
+            )
 
     if len(ctx.outputs.outs):
         fout = ctx.outputs.outs[0]
@@ -37,10 +58,7 @@ def _deb_export_impl(ctx):
         )
         ctx.actions.run(
             executable = bsdtar.tarinfo.binary,
-            # the archive may contain symlinks that point to symlinks that reference
-            # files from other packages, therefore symlink_outs must be present in the
-            # sandbox for Bazel to succesfully track them.
-            inputs = ctx.files.srcs + ctx.outputs.symlink_outs,
+            inputs = ctx.files.srcs,
             outputs = ctx.outputs.outs,
             arguments = [args],
             mnemonic = "Unpack",
@@ -61,6 +79,8 @@ deb_export = rule(
         "srcs": attr.label_list(allow_files = True),
         # mapping of foreign label -> symlink_outs index (label_keyed for Bazel 7.0 compat)
         "foreign_symlinks": attr.label_keyed_string_dict(allow_files = True),
+        # mapping of symlink path -> target path (both within this package)
+        "self_symlinks": attr.string_dict(),
         "symlink_outs": attr.output_list(),
         "outs": attr.output_list(),
     },

--- a/apt/private/deb_import.bzl
+++ b/apt/private/deb_import.bzl
@@ -40,6 +40,7 @@ deb_export(
     srcs = glob(["data.tar*"]),
     foreign_symlinks = {foreign_symlinks},
     symlink_outs = {symlink_outs},
+    self_symlinks = {self_symlinks},
     outs = {outs},
     visibility = ["//visibility:public"]
 )
@@ -207,6 +208,8 @@ def _discover_contents(rctx, depends_on, depends_file_map, target_name):
     # Resolve symlinks:
     unresolved_symlinks = {} | symlinks
 
+    foreign_symlinks = {}
+
     # TODO: this is highly inefficient, change the filemapping to be
     # file -> package instead of package -> files
     for dep in depends_on:
@@ -218,15 +221,14 @@ def _discover_contents(rctx, depends_on, depends_file_map, target_name):
             for (symlink, symlink_target) in unresolved_symlinks.items():
                 if file == symlink_target:
                     unresolved_symlinks.pop(symlink)
-                    symlinks[symlink] = "@%s//:%s" % (util.sanitize(dep), file)
+                    foreign_symlinks[symlink] = "@%s//:%s" % (util.sanitize(dep), file)
 
     # Resolve self symlinks
     self_symlinks = {}
     for file in so_files + h_files + hpp_files + a_files + hpp_files_woext:
         for (symlink, symlink_target) in unresolved_symlinks.items():
             if file == symlink_target:
-                self_symlinks[symlink] = symlinks.pop(symlink)
-                unresolved_symlinks.pop(symlink)
+                self_symlinks[symlink] = unresolved_symlinks.pop(symlink)
                 if len(unresolved_symlinks) == 0:
                     break
 
@@ -393,7 +395,7 @@ so_library(
             direct_deps = [":_so_libs"],
         )
 
-    return (build_file_content, outs, symlinks)
+    return (build_file_content, outs, foreign_symlinks, self_symlinks)
 
 def _deb_import_impl(rctx):
     rctx.download_and_extract(
@@ -402,7 +404,7 @@ def _deb_import_impl(rctx):
     )
 
     # TODO: only do this if package is -dev or dependent of a -dev pkg.
-    cc_import_targets, outs, symlinks = _discover_contents(
+    cc_import_targets, outs, symlinks, self_symlinks = _discover_contents(
         rctx,
         rctx.attr.depends_on,
         json.decode(rctx.attr.depends_file_map),
@@ -427,7 +429,8 @@ def _deb_import_impl(rctx):
         cc_import_targets = cc_import_targets,
         outs = outs,
         foreign_symlinks = foreign_symlinks,
-        symlink_outs = symlinks.keys(),
+        self_symlinks = self_symlinks,
+        symlink_outs = symlinks.keys() + self_symlinks.keys(),
     ))
 
 deb_import = repository_rule(

--- a/apt/private/merge_directory.bzl
+++ b/apt/private/merge_directory.bzl
@@ -1,0 +1,134 @@
+"Rule to merge multiple directory/export targets into a single unified directory structure."
+
+load("@bazel_skylib//rules/directory:providers.bzl", "DirectoryInfo", "create_directory_info")
+
+def _merge_directory_impl(ctx):
+    # Collect all input files
+    all_files = []
+    for src in ctx.attr.srcs:
+        all_files.extend(src[DefaultInfo].files.to_list())
+    
+    # Build entries map
+    entries = {}
+    for f in all_files:
+        path = f.short_path
+        if path.startswith("../"):
+            second_slash = path.find("/", len("../"))
+            if second_slash != -1:
+                canonical_path = path[second_slash + 1:]
+                entries[canonical_path] = f
+    
+    # Create a directory artifact
+    output_dir = ctx.actions.declare_directory(ctx.label.name)
+    
+    # Create a manifest file
+    manifest_content = "\n".join([
+        "%s\t%s" % (f.path, f.short_path)
+        for f in all_files
+    ])
+    manifest_file = ctx.actions.declare_file(ctx.label.name + ".manifest")
+    ctx.actions.write(manifest_file, manifest_content)
+    
+    # Use Python for reliable path handling
+    ctx.actions.run_shell(
+        outputs = [output_dir],
+        inputs = [manifest_file] + all_files,
+        command = """
+python3 -c '
+import os
+import sys
+
+output_dir = sys.argv[1]
+manifest_file = sys.argv[2]
+
+os.makedirs(output_dir, exist_ok=True)
+
+with open(manifest_file, "r") as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        full_path, short_path = line.split("\\t", 1)
+        
+        # Strip ../repo_name/ prefix from short_path
+        if short_path.startswith("../"):
+            second_slash = short_path.find("/", len("../"))
+            if second_slash != -1:
+                rel_path = short_path[second_slash + 1:]
+            else:
+                continue
+        elif short_path.startswith("external/"):
+            second_slash = short_path.find("/", len("external/"))
+            if second_slash != -1:
+                rel_path = short_path[second_slash + 1:]
+            else:
+                continue
+        else:
+            rel_path = short_path
+        
+        dest = os.path.join(output_dir, rel_path)
+        dest_dir = os.path.dirname(dest)
+        os.makedirs(dest_dir, exist_ok=True)
+        
+        # Skip if destination already exists
+        if os.path.exists(dest) or os.path.islink(dest):
+            continue
+        
+        # Check if source is a symlink
+        if os.path.islink(full_path):
+            link_target = os.readlink(full_path)
+            
+            # Resolve symlink target
+            if not os.path.isabs(link_target):
+                source_dir = os.path.dirname(full_path)
+                resolved_target = os.path.normpath(os.path.join(source_dir, link_target))
+            else:
+                resolved_target = link_target
+            
+            # Skip dangling symlinks
+            if not os.path.exists(resolved_target):
+                continue
+            
+            try:
+                os.symlink(link_target, dest)
+            except OSError:
+                continue
+        else:
+            abs_full_path = os.path.abspath(full_path)
+            try:
+                os.symlink(abs_full_path, dest)
+            except OSError:
+                continue
+' {output_dir} {manifest}
+""".format(output_dir=output_dir.path, manifest=manifest_file.path),
+        progress_message = "Merging %d package exports into directory" % len(all_files),
+    )
+    
+    # CRITICAL: Use output_dir.path for DirectoryInfo
+    # This is the actual path in the sandbox: bazel-out/k8-opt/bin/external/.../directory
+    # cc_args format mechanism will use this path for --sysroot
+    directory_info = create_directory_info(
+        entries = entries,
+        transitive_files = depset([output_dir]),
+        path = output_dir.path,  # THIS IS THE FIX!
+        human_readable = str(ctx.label),
+    )
+    
+    return [
+        directory_info,
+        DefaultInfo(
+            files = depset([output_dir]),
+            runfiles = ctx.runfiles(files = [output_dir]),
+        ),
+    ]
+
+merge_directory = rule(
+    implementation = _merge_directory_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            doc = "List of directory or export targets to merge",
+            mandatory = True,
+        ),
+    },
+    provides = [DirectoryInfo],
+)

--- a/apt/private/translate_dependency_set.bzl
+++ b/apt/private/translate_dependency_set.bzl
@@ -9,6 +9,7 @@ _ROOT_BUILD_TMPL = """\
 
 load("@rules_distroless//apt:defs.bzl", "dpkg_status")
 load("@rules_distroless//distroless:defs.bzl", "flatten")
+load("@rules_distroless//apt/private:merge_directory.bzl", "merge_directory")
 
 exports_files(['packages.bzl'])
 
@@ -88,6 +89,12 @@ flatten(
     deduplicate = True,
     visibility = ["//visibility:public"],
 )
+
+merge_directory(
+    name = "directory",
+    srcs = {export_targets},
+    visibility = ["//visibility:public"],
+)
 """
 
 _PACKAGE_TEMPLATE = '''\
@@ -140,6 +147,8 @@ def _translate_dependency_set_impl(rctx):
     dependency_sets = lockf.dependency_sets()
     dependency_set = dependency_sets[rctx.attr.depset_name]
 
+    export_targets = []
+    export_targets_seen = {}
     packages_to_architectures = {}
 
     for architecture in dependency_set["sets"].keys():
@@ -147,6 +156,10 @@ def _translate_dependency_set_impl(rctx):
             package_key = short_key + "=" + version
             repo_name = util.sanitize(package_key)
             package = packages[package_key]
+
+            if package_key not in export_targets_seen:
+                export_targets.append("@%s//:export" % repo_name)
+                export_targets_seen[package_key] = True
 
             packages_to_architectures.setdefault(
                 package["name"] + "=" + version,
@@ -174,6 +187,19 @@ def _translate_dependency_set_impl(rctx):
                     repo_name = repo_name,
                 ),
             )
+
+            # Also add export targets for transitive dependencies.
+            # Without this, foreign symlinks pointing to dependency packages
+            # (e.g. libc6-dev's libm.so symlink -> libc6's libm.so.6) will
+            # have missing targets in the merged directory.
+            for dep_key in package["depends_on"]:
+                if dep_key in export_targets_seen:
+                    continue
+                if dep_key not in packages:
+                    continue
+                export_targets_seen[dep_key] = True
+                dep_repo = util.sanitize(dep_key)
+                export_targets.append("@%s//:export" % dep_repo)
 
     for (_, info) in packages_to_architectures.items():
         package_name = info.name
@@ -219,6 +245,7 @@ def _translate_dependency_set_impl(rctx):
         target_name = util.get_repo_name(rctx.attr.name),
         packages = starlark_codegen_utils.to_dict_list_attr({}),
         architectures = starlark_codegen_utils.to_list_attr(dependency_set["sets"].keys()),
+        export_targets = starlark_codegen_utils.to_list_attr(export_targets),
     ))
 
 translate_dependency_set = repository_rule(


### PR DESCRIPTION
  Summary

  - Add merge_directory rule: Merges multiple deb_export outputs into a unified directory structure, enabling dependency_set to be used as a sysroot
  - Fix dangling symbolic links: Introduce self_symlinks attribute to correctly handle intra-package symlinks
  - Fix linker script absolute paths: Strip host-system absolute paths from .so linker scripts after deb extraction

  Detailed Changes

  1. merge_directory Rule (new file: apt/private/merge_directory.bzl)

  - New merge_directory rule that takes multiple directory/export targets and merges them into a single DirectoryInfo provider
  - Automatically generates a directory target in the BUILD file produced by translate_dependency_set, aggregating all package exports
  - The merged directory can be passed as --sysroot to C/C++ compilation actions

  2. Intra-package Symlink Fix (apt/private/deb_export.bzl, apt/private/deb_import.bzl)

  - In deb_import, distinguish between foreign_symlinks (cross-package links) and self_symlinks (intra-package links)
  - deb_export gains a new self_symlinks attribute (string_dict) to correctly create intra-package symlinks within the sandbox
  - Prevents dangling symlinks caused by targets not being present in the same package

  3. Linker Script Absolute Path Fix (apt/private/deb_export.bzl)

  - Some .so files in deb packages are actually linker scripts (text files starting with GROUP/INPUT) containing host-system absolute paths
  - After extraction, a post-processing shell script strips these absolute path prefixes (covers common x86_64/aarch64 paths: /usr/lib/, /lib/, /lib64/, etc.)
  - Action changed from ctx.actions.run to ctx.actions.run_shell to accommodate the post-processing step