### PR TITLE
use ape awk to replace gawk

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "bazel_lib", version = "3.0.0-rc.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "rules_java", version = "8.8.0")
 bazel_dep(name = "rules_shell", version = "0.4.1")
-bazel_dep(name = "gawk", version = "5.3.2.bcr.3")
+bazel_dep(name = "ape", version = "1.1.0")
 bazel_dep(name = "tar.bzl", version = "0.6.0")
 bazel_dep(name = "yq.bzl", version = "0.3.1")
 

--- a/apt/private/deb_postfix.bzl
+++ b/apt/private/deb_postfix.bzl
@@ -35,7 +35,7 @@ def deb_postfix(name, srcs, outs, mergedusr = False, **kwargs):
     # https://salsa.debian.org/md/usrmerge/-/tree/master/debian?ref_type=heads
     if mergedusr:
         toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"]
-        tools.append("@gawk//:gawk")
+        tools.append("@ape//ape:awk")
         apply = """\
             $(BSDTAR_BIN) --confirmation --gzip --options 'gzip:!timestamp' -cf "$$layer" \
             -s "#^\\./bin/\\(.\\)#./usr/bin/\\1#" \
@@ -45,7 +45,7 @@ def deb_postfix(name, srcs, outs, mergedusr = False, **kwargs):
             -s "#^\\./lib64/\\(.\\)#./usr/lib64/\\1#" \
             -s "#^\\./libx32/\\(.\\)#./usr/libx32/\\1#" \
             "@$$data_file" 2< <(
-                $(BSDTAR_BIN) -tvf "$$data_file" | $(location @gawk//:gawk) '{
+                $(BSDTAR_BIN) -tvf "$$data_file" | $(location @ape//ape:awk) '{
                     ORS=""
                     keep="y"
                     if (substr($$1, 1, 1) == "d" && (\\

--- a/apt/private/dpkg_status.bzl
+++ b/apt/private/dpkg_status.bzl
@@ -51,7 +51,7 @@ dpkg_status = rule(
             allow_single_file = True,
             executable = True,
             cfg = "exec",
-            default = "@gawk//:gawk",
+            default = "@ape//ape:awk",
         ),
     },
     implementation = _dpkg_status_impl,

--- a/apt/private/dpkg_statusd.bzl
+++ b/apt/private/dpkg_statusd.bzl
@@ -59,7 +59,7 @@ dpkg_statusd = rule(
             allow_single_file = True,
             executable = True,
             cfg = "exec",
-            default = "@gawk//:gawk",
+            default = "@ape//ape:awk",
         ),
     },
     implementation = _dpkg_statusd_impl,

--- a/distroless/private/flatten.bzl
+++ b/distroless/private/flatten.bzl
@@ -64,7 +64,7 @@ Deduplication is performed only for directories.
             allow_single_file = True,
             executable = True,
             cfg = "exec",
-            default = "@gawk//:gawk",
+            default = "@ape//ape:awk",
         ),
     },
     implementation = _flatten_impl,

--- a/distroless/private/locale.bzl
+++ b/distroless/private/locale.bzl
@@ -89,7 +89,7 @@ locale = rule(
             allow_single_file = True,
             executable = True,
             cfg = "exec",
-            default = "@gawk//:gawk",
+            default = "@ape//ape:awk",
         ),
     },
     implementation = _locale_impl,


### PR DESCRIPTION
this allow creating sysroot that directly referenced by cc toolchain.  

 in my test I have following setup

```python
apt.install(
    name = "jammy_x86_64_sysroot",
    lock = "//sysroot_creator:jammy_x86_64.lock.json",
    manifest = "//sysroot_creator:jammy_x86_64.yaml",
)
use_repo(apt, "jammy_x86_64_sysroot")


```
and 

```python
def _unpack_impl(ctx):
    out_dir = ctx.actions.declare_directory(ctx.label.name + "_unpacked")

    ctx.actions.run_shell(
        inputs = [ctx.file.tar],
        outputs = [out_dir],
        command = """ tar -xf {src} -C {out}""".format(src = ctx.file.tar.path, out = out_dir.path)
    )

    return [DefaultInfo(files = depset([out_dir]))]

unpack = rule(
    implementation = _unpack_impl,
    attrs = {
        "tar": attr.label(mandatory = True, allow_single_file = True)
    }
)

...

unpack(
    name = "jammy_unpack",
    tar = "@jammy_x86_64_sysroot//:jammy_x86_64_sysroot",  # or @jammy_x86_64_sysroot//:flat
    visibility = ["//visibility:public"]
)

# and jammy_unpack is used as cc toolchain sysroot
```




https://github.com/bazel-contrib/rules_distroless/issues/124#issuecomment-4217265214 mentioned that gawk is only used by flatten,  however directly  using `@jammy_x86_64_sysroot//:jammy_x86_64_sysroot` or `@jammy_x86_64_sysroot//:flat`  as my unpack rule input trigger similar errors:

```
     @@rules_distroless++apt+jammy_x86_64_sysroot//:jammy_x86_64_sysroot (5c3ac65ce1c8329cc5f7202959c1aceda00db4bbc8a0148931c8e5ed92b61cf2)
    @@rules_distroless++apt+jammy_x86_64_sysroot//:jammy_x86_64_sysroot (fcc255dcd92f8a7c8464439d77cfb04da9617fbc87079de9a2f3462df62874c2)
    @@rules_distroless++apt+jammy_x86_64_sysroot//:dpkg_status (fcc255dcd92f8a7c8464439d77cfb04da9617fbc87079de9a2f3462df62874c2)
.-> @@gawk+//:gawk (38c6768e959f095860edbca0f0d106bbb7ba105ca378e880c8947a6ed3a0b464)
|   @@bazel_tools//tools/cpp:current_cc_toolchain (38c6768e959f095860edbca0f0d106bbb7ba105ca378e880c8947a6ed3a0b464)
|   @@rules_cc+//cc:current_cc_toolchain (38c6768e959f095860edbca0f0d106bbb7ba105ca378e880c8947a6ed3a0b464)
|   @@toolchains_llvm++llvm+llvm_toolchain//:cc-clang-x86_64-linux (38c6768e959f095860edbca0f0d106bbb7ba105ca378e880c8947a6ed3a0b464)
|   @@toolchains_llvm++llvm+llvm_toolchain//:module-x86_64-linux (38c6768e959f095860edbca0f0d106bbb7ba105ca378e880c8947a6ed3a0b464)
|   @@toolchains_llvm++llvm+llvm_toolchain//:include-components-x86_64-linux (38c6768e959f095860edbca0f0d106bbb7ba105ca378e880c8947a6ed3a0b464)
|   @@toolchains_llvm++llvm+llvm_toolchain//:sysroot-components-x86_64-linux (38c6768e959f095860edbca0f0d106bbb7ba105ca378e880c8947a6ed3a0b464)
|   //sysroot_creator:jammy_unpack (38c6768e959f095860edbca0f0d106bbb7ba105ca378e880c8947a6ed3a0b464)
|   @@rules_distroless++apt+jammy_x86_64_sysroot//:flat (38c6768e959f095860edbca0f0d106bbb7ba105ca378e880c8947a6ed3a0b464)
`-- @@gawk+//:gawk (38c6768e959f095860edbca0f0d106bbb7ba105ca378e880c8947a6ed3a0b464)

```

