### PR TITLE
[apt]: Drain all async download tokens before returning

### DIFF
--- a/apt/extensions.bzl
+++ b/apt/extensions.bzl
@@ -104,17 +104,23 @@ def _resolve_downloads(mctx, tokens, index_type, dist, comp, arch):
     Returns None for optional Contents when all attempts fail.
     """
     failed_attempts = []
+    result = None
     for (ext, cmd, url, url_idx, ext_name, output, token) in tokens:
         download = token.wait()
         decompress_r = None
+        if result != None:
+            continue
         if download.success:
             decompress_r = mctx.execute(cmd + [output])
             if decompress_r.return_code == 0:
                 target_triple = "{}/{}/{}".format(dist, comp, arch)
 
                 # Decompressed file lives in its own ext_name subdirectory
-                return ("{}/{}/{}/{}".format(target_triple, url_idx, ext_name, index_type), url, download.integrity, ext)
+                result = ("{}/{}/{}/{}".format(target_triple, url_idx, ext_name, index_type), url, download.integrity, ext)
+                continue
         failed_attempts.append((url + "/.../" + index_type + ext, download, decompress_r))
+    if result != None:
+        return result
 
     if index_type == "Contents":
         # Contents files are optional; some repositories (e.g. packages.cloud.google.com/apt)


### PR DESCRIPTION
#### Why I did it

`_resolve_downloads()` in `apt/extensions.bzl` starts multiple parallel downloads with `block=False`, then iterates through tokens calling `.wait()`. On the first successful download+decompress, it returns immediately without waiting on the remaining async tokens. Bazel 8.x requires all async work started by a module extension to be drained before the extension finishes, causing a hard error:

```
ERROR: Work pending after module extension @@rules_distroless+//apt:extensions.bzl%apt finished execution
ERROR: Pending asynchronous work after module extension finished execution
```

This affects every project using this branch with Bazel 8.x (e.g., the SONiC Bazel build).

#### How I did it

* Replace early `return` with deferred result pattern — store first successful result, continue loop to `.wait()` all remaining tokens, return after loop completes

#### How to verify it

1. Build any project that uses `rules_distroless@new_api` with Bazel 8.5.1 (e.g., `bazel build //...` from a repo using apt module extension)
2. Confirm no "Work pending" or "Pending asynchronous work" errors

#### Description for the changelog

Fix async download token drain in apt extension to comply with Bazel 8.x module extension requirements