### PR TITLE
Update 0555 to 0644 on generated distroless files

### DIFF
--- a/distroless/private/cacerts.bzl
+++ b/distroless/private/cacerts.bzl
@@ -97,7 +97,7 @@ cacerts = rule(
         ),
         "mode": attr.string(
             doc = "mode for the entries",
-            default = "0555",
+            default = "0644",
         ),
         "time": attr.string(
             doc = "time for the entries",

--- a/distroless/private/java_keystore.bzl
+++ b/distroless/private/java_keystore.bzl
@@ -30,7 +30,7 @@ def _java_keystore_impl(ctx):
     mtree.add_parents("/etc/ssl/certs/java", mode = ctx.attr.mode, time = ctx.attr.time, skip = [1])
 
     # TODO: remove??
-    mtree.add_file("/etc/ssl/certs/java/cacerts", jks, mode = "0555", time = ctx.attr.time)
+    mtree.add_file("/etc/ssl/certs/java/cacerts", jks, mode = "0644", time = ctx.attr.time)
     mtree.build(output = output, mnemonic = "JavaKeyStore", inputs = [jks])
 
     return [

--- a/distroless/private/os_release.bzl
+++ b/distroless/private/os_release.bzl
@@ -9,7 +9,7 @@ def os_release(
         name,
         content,
         path = "/usr/lib/os-release",
-        mode = "0555",
+        mode = "0644",
         time = "0",
         **kwargs):
     """

--- a/examples/cacerts/BUILD.bazel
+++ b/examples/cacerts/BUILD.bazel
@@ -14,11 +14,11 @@ assert_tar_mtree(
 ./etc time=0.0 mode=755 gid=0 uid=0 type=dir
 ./etc/ssl time=0.0 mode=755 gid=0 uid=0 type=dir
 ./etc/ssl/certs time=0.0 mode=755 gid=0 uid=0 type=dir
-./etc/ssl/certs/ca-certificates.crt time=0.0 mode=555 gid=0 uid=0 type=file size=200313
+./etc/ssl/certs/ca-certificates.crt time=0.0 mode=644 gid=0 uid=0 type=file size=200313
 ./usr time=0.0 mode=755 gid=0 uid=0 type=dir
 ./usr/share time=0.0 mode=755 gid=0 uid=0 type=dir
 ./usr/share/doc time=0.0 mode=755 gid=0 uid=0 type=dir
 ./usr/share/doc/ca-certificates time=0.0 mode=755 gid=0 uid=0 type=dir
-./usr/share/doc/ca-certificates/copyright time=0.0 mode=555 gid=0 uid=0 type=file size=18940
+./usr/share/doc/ca-certificates/copyright time=0.0 mode=644 gid=0 uid=0 type=file size=18940
 """,
 )

--- a/examples/java_keystore/BUILD.bazel
+++ b/examples/java_keystore/BUILD.bazel
@@ -32,6 +32,6 @@ assert_tar_mtree(
 ./etc/ssl time=0.0 mode=755 gid=0 uid=0 type=dir
 ./etc/ssl/certs time=0.0 mode=755 gid=0 uid=0 type=dir
 ./etc/ssl/certs/java time=0.0 mode=755 gid=0 uid=0 type=dir
-./etc/ssl/certs/java/cacerts time=0.0 mode=555 gid=0 uid=0 type=file size=5349
+./etc/ssl/certs/java/cacerts time=0.0 mode=644 gid=0 uid=0 type=file size=5349
 """,
 )

--- a/examples/os_release/BUILD.bazel
+++ b/examples/os_release/BUILD.bazel
@@ -23,7 +23,7 @@ assert_tar_mtree(
 #mtree
 ./usr time=0.0 mode=755 gid=0 uid=0 type=dir
 ./usr/lib time=0.0 mode=755 gid=0 uid=0 type=dir
-./usr/lib/os-release time=0.0 mode=555 gid=0 uid=0 type=file size=48
+./usr/lib/os-release time=0.0 mode=644 gid=0 uid=0 type=file size=48
 """,
 )
 
@@ -43,6 +43,6 @@ assert_tar_mtree(
     expected = """\
 #mtree
 ./etc time=0.0 mode=755 gid=0 uid=0 type=dir
-./etc/os-release time=0.0 mode=555 gid=0 uid=0 type=file size=67
+./etc/os-release time=0.0 mode=644 gid=0 uid=0 type=file size=67
 """,
 )


### PR DESCRIPTION
These were previously set to `0555` to minimize diffs on distroless, but that is no longer a concern and these should align with the normal defaults of `0644`