### PR TITLE
fix: Flatten was not working due to missing rm binary

### DIFF
--- a/distroless/private/flatten.sh
+++ b/distroless/private/flatten.sh
@@ -61,7 +61,7 @@ if [[ "$deduplicate" == "True" ]]; then
             fflush()
         }
     }' "$mtree")
-    rm "$mtree"
+    $coreutils rm "$mtree"
 else
     # No deduplication, business as usual
     $bsdtar "$@"


### PR DESCRIPTION
`flatten.sh` is ran with an empty environment, so no $PATH either. I am using Bazel on NixOS where the binaries are in odd places which could be why this went unnoticed until now.