### PR TITLE
fix: parse unspaced apt version constraints

### DIFF
--- a/apt/private/version_constraint.bzl
+++ b/apt/private/version_constraint.bzl
@@ -3,10 +3,16 @@
 load(":version.bzl", version_lib = "version")
 
 def _parse_version_constraint(rawv):
-    vconst_i = rawv.find(" ")
-    if vconst_i == -1:
-        fail('invalid version string %s expected a version constraint ">=", "=", ">=", "<<", ">>"' % rawv)
-    return (rawv[:vconst_i], rawv[vconst_i + 1:])
+    rawv = rawv.strip()
+    for op in ["<<", ">>", "<=", ">=", "="]:
+        if rawv.startswith(op):
+            version = rawv[len(op):].strip()
+            if version:
+                return (op, version)
+
+            break
+
+    fail('invalid version string %s expected a version constraint ">=", "=", "<=", "<<", ">>"' % rawv)
 
 def _parse_dep(raw):
     raw = raw.strip()  # remove leading & trailing whitespace

--- a/apt/tests/resolution_test.bzl
+++ b/apt/tests/resolution_test.bzl
@@ -65,6 +65,9 @@ def _parse_depends_test(ctx):
         "python3:any": [
             {"name": "python3", "version": None, "arch": ["any"]},
         ],
+        "intel-oneapi-common-vars (=2025.1.0-387)": [
+            {"name": "intel-oneapi-common-vars", "version": ("=", "2025.1.0-387"), "arch": None},
+        ],
         " | ".join([
             "gcc-i686-linux-gnu (>= 4:10.2)",
             "gcc:i386, g++-i686-linux-gnu (>= 4:10.2)",

--- a/apt/tests/version_test.bzl
+++ b/apt/tests/version_test.bzl
@@ -95,6 +95,27 @@ def _sort_test(ctx):
 
 sort_test = unittest.make(_sort_test)
 
+def _parse_version_constraint_test(ctx):
+    parameters = [
+        (">= 1.1", (">=", "1.1")),
+        ("= 1.1", ("=", "1.1")),
+        ("=1.1", ("=", "1.1")),
+        ("<< 2.0", ("<<", "2.0")),
+        (">>2.0", (">>", "2.0")),
+    ]
+
+    env = unittest.begin(ctx)
+    for rawv, expected in parameters:
+        asserts.equals(
+            env,
+            expected,
+            version_constraint.parse_version_constraint(rawv),
+        )
+
+    return unittest.end(env)
+
+parse_version_constraint_test = unittest.make(_parse_version_constraint_test)
+
 def _is_satisfied_by_test(ctx):
     parameters = [
         (">= 1.1", "= 1.1", True),
@@ -123,5 +144,6 @@ is_satisfied_by_test = unittest.make(_is_satisfied_by_test)
 def version_tests():
     operators_test(name = _TEST_SUITE_PREFIX + "operators")
     parse_test(name = _TEST_SUITE_PREFIX + "parse")
+    parse_version_constraint_test(name = _TEST_SUITE_PREFIX + "parse_version_constraint")
     sort_test(name = _TEST_SUITE_PREFIX + "sort")
     is_satisfied_by_test(name = _TEST_SUITE_PREFIX + "is_satisfied_by")


### PR DESCRIPTION
Hello Bazel Contrib team.

I noticed that the rule fails to parse some of the version constraints in the package metadata, when there is no space between the operator and the version number.

I am using this rule to download and install Intel oneAPI packages from https://apt.repos.intel.com/oneapi.

Example of a dependency entry in the package metadata:

    Depends: intel-oneapi-common-vars (=2025.1.0-387)

I am sure that Intel will update their package and fix the formatting issue for future releases, but I think this kind of problem is not unique to Intel packages and could happen with other packages as well.

At the beginning i try to parse the version constraints with a regex.
I ended up implementing a simple parser that splits the constraint into operator and version number, and trims any whitespace from the version number.

```bash
mkdir -p platforms/oneapi/apt-sanitized/dists/all/main/binary-amd64
curl -fsSL https://apt.repos.intel.com/oneapi/dists/all/main/binary-amd64/Packages.gz \
    | gzip -dc \
    | sed 's/(=2025.1.0-387)/(= 2025.1.0-387)/g' \
    > platforms/oneapi/apt-sanitized/dists/all/main/binary-amd64/Packages
```

And have something like this in your WORKSPACE file:

```yaml
version: 1

sources:
  - channel: all main
    urls:
      - file:///home/zml/platforms/oneapi/apt-sanitized
      - https://apt.repos.intel.com/oneapi
```

It works but it seems a bit heavy, and I don't think it is a long-term solution.

I know that Intel should fix the package metadata but I do not know how long this can take and also this kind of error can happen again.

I find out that maybe we can make the rules_distroless less strict and accept unspaced version constraints.


I also corrected the error message:

from 

```fail('invalid version string %s expected a version constraint ">=", "=", ">=", "<<", ">>"' % rawv)```

to

```fail('invalid version string %s expected a version constraint ">=", "=", "<=", "<<", ">>"' % rawv)```

Test:

I added tests to cover the parsing of unspaced version.

```bash
bazel run @buildifier_prebuilt//:buildifier -- -mode=diff -lint=off \
  ${PWD}/rules_distroless/apt/private/version_constraint.bzl \
  ${PWD}/rules_distroless/apt/tests/resolution_test.bzl \
  ${PWD}/rules_distroless/apt/tests/version_test.bzl
```

```bash
bazel test //apt/tests:version/parse_version_constraint //apt/tests:package_resolution/parse_depends
```

```bash
bazel test //apt/tests:all
```

-> PASSED

