### PR TITLE
docs: fix broken links in apt module extension docstring

### DIFF
--- a/apt/extensions.bzl
+++ b/apt/extensions.bzl
@@ -564,8 +564,8 @@ March 1st 2023.
 
 To use this services simply use a snapshot URL in the manifest. Here's two
 examples showing how to do this for Debian and Ubuntu:
-  * [/examples/debian_snapshot](/examples/debian_snapshot)
-  * [/examples/ubuntu_snapshot](/examples/ubuntu_snapshot)
+  * [/examples/debian_snapshot](https://github.com/bazel-contrib/rules_distroless/tree/main/examples/debian_snapshot)
+  * [/examples/ubuntu_snapshot](https://github.com/bazel-contrib/rules_distroless/tree/main/examples/ubuntu_snapshot)
 
 For more infomation, please check https://snapshot.debian.org and/or
 https://snapshot.ubuntu.com.


### PR DESCRIPTION
## Summary
- The Bazel registry ([registry.bazel.build](https://registry.bazel.build)) renders module extension docstrings as HTML. Relative paths like `/examples/debian_snapshot` resolve against `registry.bazel.build` instead of the GitHub repo, resulting in broken links (404s).
- Replaced relative paths with absolute GitHub URLs so the links work correctly on both GitHub and the Bazel registry.

You can see the broken links here: https://registry.bazel.build/docs/rules_distroless

## Test plan
Manual testing:
1. Check the current broken links at https://registry.bazel.build/docs/rules_distroless (search for "examples showing how to do this for Debian and Ubuntu")
2. Verify the links point to `/examples/debian_snapshot` which resolves to `https://registry.bazel.build/examples/debian_snapshot` (404)
3. After this fix, the links will point directly to the GitHub examples directory