### PR TITLE
Make the rules work on Bazel 9

### DIFF
--- a/apt/private/cc_deb_library.bzl
+++ b/apt/private/cc_deb_library.bzl
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
+
 "cc_deb_library"
 
 def _cc_deb_library_impl(ctx):

--- a/apt/private/so_library.bzl
+++ b/apt/private/so_library.bzl
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cpp_toolchain", "use_cc_toolchain")
 
 def _so_library_impl(ctx):

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -11,12 +11,14 @@ local_path_override(
     path = "..",
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.19.3")
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "rules_oci", version = "2.0.0")
-bazel_dep(name = "rules_java", version = "8.8.0")
+bazel_dep(name = "rules_java", version = "9.1.0")
 bazel_dep(name = "container_structure_test", version = "1.16.0")
-bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "tar.bzl", version = "0.10.7")
 
 # Toolchains from aspect_bazel_lib
 bazel_lib_toolchains = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")


### PR DESCRIPTION
## What?
Fix some imports so that the rules work on Bazel 9 now that the cc rules are no longer auto imported.