### PR TITLE
fix: Expand 'Architecture: all' packages into all target architectures

### DIFF
--- a/apt/extensions.bzl
+++ b/apt/extensions.bzl
@@ -393,20 +393,28 @@ def _distroless_extension(mctx):
                 ),
             )
 
+        # Key every package by the architecture we are resolving for, not by the
+        # package's own `Architecture` field. 
+        # For arch-specific packages these are the same.
+        # For `Architecture: all` packages this "expands" them into one entry per target architecture,
+        # so each carries its own arch-specific dependency closure instead of a single frozen one shared across arches.
+        # This solves the cases where an `Architecture: all` package depends on a per-architecture package
+        # (e.g. bullseye ucf: https://packages.debian.org/bullseye/ucf).
+        #
         # TODO:
         # Ensure following statements are true.
         #  1- Package was resolved from a source that module listed explicitly.
         #  2- Package resolution was skipped because some other module asked for this package.
         #  3- 1) is enforced even if 2) is the case.
-        glock.add_package(package)
+        glock.add_package(package, arch)
 
-        pkg_short_key = lockfile.short_package_key(package)
+        pkg_short_key = lockfile.short_package_key(package, arch)
 
         already_resolved[pkg_short_key] = True
 
         for dep in dependencies:
-            glock.add_package(dep)
-            dep_key = lockfile.short_package_key(dep)
+            glock.add_package(dep, arch)
+            dep_key = lockfile.short_package_key(dep, arch)
             if dep_key not in already_resolved:
                 resolution_queue.append((
                     None,
@@ -415,7 +423,7 @@ def _distroless_extension(mctx):
                     arch,
                     suites,
                 ))
-            glock.add_package_dependency(package, dep)
+            glock.add_package_dependency(package, dep, arch)
 
         # Add it to dependency set
         if dependency_set_name:

--- a/apt/private/lockfile.bzl
+++ b/apt/private/lockfile.bzl
@@ -15,18 +15,30 @@ def _parse_package_key(key):
     (arch, version) = rest.split("=", 1)
     return (suite, name, arch, version)
 
-def _short_package_key(package):
+# `arch`, when set, overrides the package's own `Architecture` field for keying
+# purposes. This is how `Architecture: all` packages are "expanded": the same
+# package is keyed once per target architecture (e.g. `.../ucf:amd64` and
+# `.../ucf:arm64`) so each can carry its own architecture-specific dependency
+# closure.
+def _short_package_key(package, arch = None):
+    """Create a key for a given package.
+
+    `arch`, when set, overrides the package's own `Architecture` field in the key.
+    This is used to "expand" `Architecture: all` packages, to create one package per relevant architecture.
+    This allows `Architecture: all` packages that depend on per-architecture packages (e.g. `/bullseye/ucf`)
+    to create one dependency closure per architecture.
+    """
     return "/%s/%s:%s" % (
         package["Dist"],
         package["Package"],
-        package["Architecture"],
+        arch or package["Architecture"],
     )
 
-def _package_key(package):
-    return _make_package_key(package["Dist"], package["Package"], package["Version"], package["Architecture"])
+def _package_key(package, arch = None):
+    return _make_package_key(package["Dist"], package["Package"], package["Version"], arch or package["Architecture"])
 
-def _add_package(lock, package):
-    k = _package_key(package)
+def _add_package(lock, package, arch = None):
+    k = _package_key(package, arch)
     if k in lock.packages:
         return
     lock.packages[k] = {
@@ -41,11 +53,11 @@ def _add_package(lock, package):
         "depends_on": [],
     }
 
-def _add_package_dependency(lock, package, dependency):
-    k = _package_key(package)
+def _add_package_dependency(lock, package, dependency, arch = None):
+    k = _package_key(package, arch)
     if k not in lock.packages:
         fail("illegal state: %s is not in the lockfile." % package["Package"])
-    sk = _package_key(dependency)
+    sk = _package_key(dependency, arch)
     if sk in lock.packages[k]["depends_on"]:
         return
     lock.packages[k]["depends_on"].append(sk)


### PR DESCRIPTION
An architecture-agnostic package can depend on per-architecture packages ((in `e2e/smoke`, it's  `ucf` that depends on `coreutils`). Because we store `ucf` as just a single `depends_on` with `Architecture: All`, it just depends on "whatever `coreutils` happened to resolve first", which is not correct.

This PR expands `Architecture: all` packages into per-architecture targets, that each depend on the right version of their dependencies. So, before we had `ucf:all`, and now we'll have `ucf:amd64` which depends on `coreutils:amd64`, and `ucf:arm64` which depends on `coreutils:arm64`.

This is only one of several possible solutions. For instance, we could make `depends_on` be a per-architecture dict. However, this change would be further-reaching (we'd have to touch `deb_import` to fix symlink resolution, for instance), so the benefit is unclear. Happy to try that approach.

This PR makes the e2e tests pass.