### PR TITLE
fix: Add snapshot URL to facts keys

### DIFF
--- a/apt/extensions.bzl
+++ b/apt/extensions.bzl
@@ -129,9 +129,14 @@ def _resolve_downloads(mctx, tokens, index_type, dist, comp, arch):
         """.format(len(failed_attempts), "\n".join(attempt_messages)))
 
 def _fetch_and_parse_sources(mctx, repo, glock, snapshot_suites, formats):
-    """Fetch all package indices and contents in parallel, then parse them."""
+    """Fetch all package indices and contents in parallel, then parse them.
+
+    Returns the set (as a dict) of fact keys that belong to the current sources,
+    so the caller can prune stale facts left behind by previous URLs.
+    """
     pending = []
     seen = {}
+    used_keys = {}
     for source_key, source in repo.sources().items():
         (urls, dist, component, architecture) = source
 
@@ -148,8 +153,10 @@ def _fetch_and_parse_sources(mctx, repo, glock, snapshot_suites, formats):
         # redirects properly when a path contains "//"
         urls = [url.rstrip("/") for url in urls]
 
-        pkg_fact_key = dist + "/" + component + "/" + architecture + "/Packages"
-        cnt_fact_key = dist + "/" + component + "/" + architecture + "/Contents"
+        pkg_fact_key = util.index_fact_key(dist, component, architecture, "Packages", urls)
+        cnt_fact_key = util.index_fact_key(dist, component, architecture, "Contents", urls)
+        used_keys[pkg_fact_key] = True
+        used_keys[cnt_fact_key] = True
 
         # Check cached format info to avoid 404 warnings on subsequent runs
         cached_pkg_format = formats.get(pkg_fact_key)
@@ -222,6 +229,8 @@ def _fetch_and_parse_sources(mctx, repo, glock, snapshot_suites, formats):
         else:
             formats[cnt_fk] = "unavailable"
 
+    return used_keys
+
 def _distroless_extension(mctx):
     # Detect facts API availability
     use_facts = hasattr(mctx, "facts")
@@ -277,8 +286,9 @@ def _distroless_extension(mctx):
     # Seed cached formats from facts (which extensions each remote serves)
     formats = dict(cached_facts.get("formats", {}))
 
-    # Fetch all sources_list in parallel and parse them.
-    _fetch_and_parse_sources(mctx, repo, glock, snapshot_suites, formats)
+    # Fetch all sources_list in parallel and parse them. `used_keys` is the set
+    # of fact keys for the current sources, used below to prune stale facts.
+    used_keys = _fetch_and_parse_sources(mctx, repo, glock, snapshot_suites, formats)
 
     sources = glock.sources()
     dependency_sets = glock.dependency_sets()
@@ -464,13 +474,14 @@ def _distroless_extension(mctx):
                 )
 
     if use_facts:
-        filtered_indices = {
-            k: v
-            for k, v in glock.facts().items()
-            if k.split("/")[0] in snapshot_suites
-        }
+        (cacheable_indices, cacheable_formats) = util.prune_uncacheable_facts(
+            glock.facts(),
+            formats,
+            used_keys,
+            snapshot_suites,
+        )
         return mctx.extension_metadata(
-            facts = {"indices": filtered_indices, "formats": formats},
+            facts = {"indices": cacheable_indices, "formats": cacheable_formats},
         )
 
 _doc = """

--- a/apt/private/util.bzl
+++ b/apt/private/util.bzl
@@ -42,6 +42,43 @@ def _is_snapshot_uri(uri):
             return True
     return False
 
+def _index_fact_key(dist, component, architecture, index_type, urls):
+    """Cache key for the integrity/format facts of a single package index.
+
+    The key must include the snapshot urls (so that updating a source doesn't leave stale facts),
+    as well as dist, component, architecture, and index type.
+
+    The suite (`dist`) stays first so callers relying on `key.split("/")[0]` still recover the suite.
+    URLs are deduplicated and sorted so that mirror order / `mirror+` duplicates don't spuriously invalidate the cache.
+    """
+    sorted_deduplicated_urls = sorted({url: None for url in urls}.keys())
+    url_token = "|".join(sorted_deduplicated_urls)
+    return "{}/{}/{}/{}/{}".format(dist, component, architecture, index_type, url_token)
+
+def _prune_uncacheable_facts(indices, formats, used_keys, snapshot_suites):
+    """Keep only the facts that can be cached.
+
+    `used_keys` holds the fact keys produced for this run's sources (see `index_fact_key`).
+    Entries left over from a previous snapshot URL are not in `used_keys`,
+    so they get dropped here instead of accumulating across runs.
+
+    `snapshot_suites` holds a list of suites from snapshots,
+    because we don't want to cache rolling suites.
+
+    Returns `(cacheable_indices, cacheable_formats)`.
+    """
+    cacheable_indices = {
+        k: v
+        for k, v in indices.items()
+        if k in used_keys and k.split("/")[0] in snapshot_suites
+    }
+    cacheable_formats = {
+        k: v
+        for k, v in formats.items()
+        if k in used_keys
+    }
+    return (cacheable_indices, cacheable_formats)
+
 def _warning(rctx, message):
     rctx.execute([
         "echo",
@@ -55,4 +92,6 @@ util = struct(
     warning = _warning,
     get_repo_name = _get_repo_name,
     is_snapshot_uri = _is_snapshot_uri,
+    index_fact_key = _index_fact_key,
+    prune_uncacheable_facts = _prune_uncacheable_facts,
 )

--- a/apt/tests/BUILD.bazel
+++ b/apt/tests/BUILD.bazel
@@ -1,6 +1,9 @@
+load(":facts_test.bzl", "facts_tests")
 load(":resolution_test.bzl", "resolution_tests")
 load(":version_test.bzl", "version_tests")
 
 version_tests()
 
 resolution_tests()
+
+facts_tests()

--- a/apt/tests/facts_test.bzl
+++ b/apt/tests/facts_test.bzl
@@ -1,0 +1,70 @@
+"unit tests for snapshot fact cache keys"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//apt/private:util.bzl", "util")
+
+_TEST_SUITE_PREFIX = "facts/"
+
+_TEST_SNAPSHOT_1 = ["https://snapshot.debian.org/archive/debian/20251001T023456Z"]
+_TEST_SNAPSHOT_2 = ["https://snapshot.debian.org/archive/debian/20240210T223313Z"]
+
+def _url_scoped_fact_key_test(ctx):
+    env = unittest.begin(ctx)
+
+    k1 = util.index_fact_key("bookworm", "main", "amd64", "Packages", _TEST_SNAPSHOT_1)
+    k2 = util.index_fact_key("bookworm", "main", "amd64", "Packages", _TEST_SNAPSHOT_2)
+
+    asserts.true(env, k1 != k2, "changing the snapshot URL must change the fact key")
+
+    # The suite (dist) must stay first so we can still recover the suite with `key.split("/")[0]`
+    asserts.equals(env, "bookworm", k1.split("/")[0])
+
+    # Same source is stable across calls.
+    asserts.equals(env, k1, util.index_fact_key("bookworm", "main", "amd64", "Packages", _TEST_SNAPSHOT_1))
+
+    # Mirror URL order and duplicates must not change the key (because the contents are the same)
+    a = _TEST_SNAPSHOT_1[0]
+    b = "https://deb.debian.org/debian"
+    asserts.equals(
+        env,
+        util.index_fact_key("bookworm", "main", "amd64", "Packages", [a, b]),
+        util.index_fact_key("bookworm", "main", "amd64", "Packages", [b, a, a]),
+    )
+
+    # Packages and Contents for the same source must not collide.
+    asserts.true(
+        env,
+        k1 != util.index_fact_key("bookworm", "main", "amd64", "Contents", _TEST_SNAPSHOT_1),
+        "Packages and Contents keys must differ",
+    )
+
+    return unittest.end(env)
+
+def _prune_facts_test(ctx):
+    env = unittest.begin(ctx)
+
+    old_key = util.index_fact_key("bookworm", "main", "amd64", "Packages", _TEST_SNAPSHOT_1)
+    new_key = util.index_fact_key("bookworm", "main", "amd64", "Packages", _TEST_SNAPSHOT_2)
+    rolling_key = util.index_fact_key("sid", "main", "amd64", "Packages", ["https://deb.debian.org/debian"])
+
+    indices = {old_key: "sha256-OLD", new_key: "sha256-NEW", rolling_key: "sha256-ROLLING"}
+    formats = {old_key: ".xz", new_key: ".xz", rolling_key: ".xz"}
+
+    # Only the current sources' keys are used this run.
+    used_keys = {new_key: True, rolling_key: True}
+    snapshot_suites = {"bookworm": True}
+
+    (cacheable_indices, cacheable_formats) = util.prune_uncacheable_facts(indices, formats, used_keys, snapshot_suites)
+
+    # The stale previous-URL entry is dropped, and indices from rolling indexes are not cached.
+    asserts.equals(env, {new_key: "sha256-NEW"}, cacheable_indices)
+    asserts.equals(env, {new_key: ".xz", rolling_key: ".xz"}, cacheable_formats)
+
+    return unittest.end(env)
+
+url_scoped_fact_key_test = unittest.make(_url_scoped_fact_key_test)
+prune_facts_test = unittest.make(_prune_facts_test)
+
+def facts_tests():
+    url_scoped_fact_key_test(name = _TEST_SUITE_PREFIX + "url_scoped_fact_key")
+    prune_facts_test(name = _TEST_SUITE_PREFIX + "prune_facts")


### PR DESCRIPTION
Previously, the URL of the snapshot was not part of the cache key for facts. This meant that if we upgrade the snapshot (but leave everything else the same), we'd get stale facts and stale packages.

We bake the URLs of _snapshot_ sources into the facts key, to avoid that. Furthermore, we filter out facts from unused URLs, to avoid having them grow unbounded.