### PR TITLE
refactor: Reduce lockfile size and refactor symlinks

### DIFF
--- a/apt/BUILD.bazel
+++ b/apt/BUILD.bazel
@@ -21,6 +21,7 @@ bzl_library(
     deps = [
         "//apt/private:apt_deb_repository",
         "//apt/private:apt_dep_resolver",
+        "//apt/private:deb_filemap",
         "//apt/private:deb_import",
         "//apt/private:lockfile",
         "//apt/private:translate_dependency_set",

--- a/apt/extensions.bzl
+++ b/apt/extensions.bzl
@@ -3,6 +3,7 @@
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "read_user_netrc", "use_netrc")
 load("//apt/private:apt_deb_repository.bzl", "deb_repository")
 load("//apt/private:apt_dep_resolver.bzl", "dependency_resolver")
+load("//apt/private:deb_filemap.bzl", "deb_filemap")
 load("//apt/private:deb_import.bzl", "deb_import")
 load("//apt/private:lockfile.bzl", "lockfile")
 load("//apt/private:translate_dependency_set.bzl", "translate_dependency_set")
@@ -425,13 +426,14 @@ def _distroless_extension(mctx):
 
     # Generate a repo per package which will be aliased by hub repo.
     for (package_key, package) in glock.packages().items():
-        filemap = {}
-        for key in package["depends_on"]:
-            (suite, name, arch, version) = lockfile.parse_package_key(key)
-            filemap[name] = repo.filemap(
-                name = name,
-                arch = arch,
-            )
+        (suite, name, arch, version) = lockfile.parse_package_key(package_key)
+
+        # Each package publishes its own file list in a leaf repo to avoid circular deps.
+        # Storing these in a file instead of passing filemaps as attributes cuts down lockfile size considerably.
+        deb_filemap(
+            name = util.sanitize(package_key) + "_filemap",
+            files = json.encode(repo.filemap(name = name, arch = arch) or []),
+        )
 
         deb_import(
             name = util.sanitize(package_key),
@@ -443,7 +445,12 @@ def _distroless_extension(mctx):
             sha256 = package["sha256"],
             mergedusr = False,
             depends_on = package["depends_on"],
-            depends_file_map = json.encode(filemap),
+            # Label of each dependency's own filemap, in depends_on order,
+            # so deb_import can rebuild the {file: dependency} index by lookup.
+            dep_filemaps = [
+                "@" + util.sanitize(dep) + "_filemap//:filemap.json"
+                for dep in package["depends_on"]
+            ],
             package_name = package["name"],
         )
 

--- a/apt/private/BUILD.bazel
+++ b/apt/private/BUILD.bazel
@@ -63,6 +63,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "deb_filemap",
+    srcs = ["deb_filemap.bzl"],
+    visibility = ["//apt:__subpackages__"],
+)
+
+bzl_library(
     name = "version_constraint",
     srcs = ["version_constraint.bzl"],
     visibility = ["//apt:__subpackages__"],

--- a/apt/private/deb_filemap.bzl
+++ b/apt/private/deb_filemap.bzl
@@ -1,0 +1,20 @@
+"""A repository that exposes a single package's file list as a file.
+
+Useful for dependents to build a file -> package filemap to resolve symlinks.
+Using a file instead of raw JSON-encoded attrs saves significant space in MODULE.bazel.lock files.
+This is a separate repository to avoid dependency cycle issues, which Debian package graphs allow.
+"""
+
+def _deb_filemap_impl(rctx):
+    # `files` is a JSON-encoded list of the paths this package installs.
+    rctx.file("filemap.json", rctx.attr.files)
+    rctx.file("BUILD.bazel", 'exports_files(["filemap.json"], visibility = ["//visibility:public"])\n')
+
+deb_filemap = repository_rule(
+    implementation = _deb_filemap_impl,
+    attrs = {
+        "files": attr.string(
+            doc = "JSON-encoded list of file paths this package installs.",
+        ),
+    },
+)

--- a/apt/private/deb_import.bzl
+++ b/apt/private/deb_import.bzl
@@ -204,32 +204,24 @@ def _discover_contents(rctx, depends_on, depends_file_map, target_name):
         if resolved_symlink:
             symlinks[line] = resolved_symlink
 
-    # Resolve symlinks:
-    unresolved_symlinks = {} | symlinks
-
-    # TODO: this is highly inefficient, change the filemapping to be
-    # file -> package instead of package -> files
-    for dep in depends_on:
-        (suite, name, arch, _) = lockfile.parse_package_key(dep)
-        filemap = depends_file_map.get(name, []) or []
-        for file in filemap:
-            if len(unresolved_symlinks) == 0:
-                break
-            for (symlink, symlink_target) in unresolved_symlinks.items():
-                if file == symlink_target:
-                    unresolved_symlinks.pop(symlink)
-                    symlinks[symlink] = "@{dep}//:{file}".format(
-                        dep = util.sanitize(dep),
-                        file = file
-                    )
-
-    # Resolve self symlinks
-    for file in so_files + h_files + hpp_files + a_files + hpp_files_woext:
-        for (symlink, symlink_target) in unresolved_symlinks.items():
-            if file == symlink_target:
-                unresolved_symlinks.pop(symlink)
-                if len(unresolved_symlinks) == 0:
-                    break
+    # Resolve symlinks
+    # For each symlink, we check:
+    #  - If provided by a dependency -> rewrite to that dependency's label
+    #  - If shipped by this package  -> drop it from `symlinks` so it is emitted as a plain output
+    #  - Else                        -> leave unresolved, and warn
+    self_files = {
+        f: None
+        for f in so_files + h_files + hpp_files + a_files + hpp_files_woext
+    }
+    unresolved_symlinks = {}
+    for (symlink, symlink_target) in symlinks.items():
+        dep_repo = depends_file_map.get(symlink_target)
+        if dep_repo:
+            symlinks[symlink] = "@{dep}//:{file}".format(dep = dep_repo, file = symlink_target)
+        elif symlink_target in self_files:
+            symlinks.pop(symlink)
+        else:
+            unresolved_symlinks[symlink] = symlink_target
 
     if len(unresolved_symlinks):
         util.warning(
@@ -402,18 +394,20 @@ def _deb_import_impl(rctx):
         sha256 = rctx.attr.sha256,
     )
 
-    # Reconstruct the {package: [files]} dependency map by reading each
-    # dependency's own filemap (in depends_on order).
-    depends_file_map = {}
+    # Rebuild the {file: dependency_repo} index from each dependency's own filemap.
+    # The first dependency that provides a path wins.
+    provided_by = {}
     for (i, dep) in enumerate(rctx.attr.depends_on):
-        (suite, name, arch, version) = lockfile.parse_package_key(dep)
-        depends_file_map[name] = json.decode(rctx.read(rctx.path(rctx.attr.dep_filemaps[i])))
+        dep_repo = util.sanitize(dep)
+        for file in json.decode(rctx.read(rctx.path(rctx.attr.dep_filemaps[i]))):
+            if file not in provided_by:
+                provided_by[file] = dep_repo
 
     # TODO: only do this if package is -dev or dependent of a -dev pkg.
     cc_import_targets, outs, symlinks = _discover_contents(
         rctx,
         rctx.attr.depends_on,
-        depends_file_map,
+        provided_by,
         rctx.attr.package_name.removesuffix("-dev"),
     )
 
@@ -443,8 +437,8 @@ deb_import = repository_rule(
     attrs = {
         "urls": attr.string_list(mandatory = True, allow_empty = False),
         "sha256": attr.string(),
-        "depends_on": attr.string_list(),
-        "dep_filemaps": attr.label_list(doc = "Each dependency's filemap.json, in depends_on order."),
+        "depends_on": attr.string_list(doc = "Names of packages this package depends on"),
+        "dep_filemaps": attr.label_list(doc = "Each dependency's filemap.json, in depends_on order, used to resolve cross-package symlinks."),
         "mergedusr": attr.bool(),
         "target_name": attr.string(),
         "package_name": attr.string(),

--- a/apt/private/deb_import.bzl
+++ b/apt/private/deb_import.bzl
@@ -218,14 +218,15 @@ def _discover_contents(rctx, depends_on, depends_file_map, target_name):
             for (symlink, symlink_target) in unresolved_symlinks.items():
                 if file == symlink_target:
                     unresolved_symlinks.pop(symlink)
-                    symlinks[symlink] = "@%s//:%s" % (util.sanitize(dep), file)
+                    symlinks[symlink] = "@{dep}//:{file}".format(
+                        dep = util.sanitize(dep),
+                        file = file
+                    )
 
     # Resolve self symlinks
-    self_symlinks = {}
     for file in so_files + h_files + hpp_files + a_files + hpp_files_woext:
         for (symlink, symlink_target) in unresolved_symlinks.items():
             if file == symlink_target:
-                self_symlinks[symlink] = symlinks.pop(symlink)
                 unresolved_symlinks.pop(symlink)
                 if len(unresolved_symlinks) == 0:
                     break

--- a/apt/private/deb_import.bzl
+++ b/apt/private/deb_import.bzl
@@ -402,11 +402,18 @@ def _deb_import_impl(rctx):
         sha256 = rctx.attr.sha256,
     )
 
+    # Reconstruct the {package: [files]} dependency map by reading each
+    # dependency's own filemap (in depends_on order).
+    depends_file_map = {}
+    for (i, dep) in enumerate(rctx.attr.depends_on):
+        (suite, name, arch, version) = lockfile.parse_package_key(dep)
+        depends_file_map[name] = json.decode(rctx.read(rctx.path(rctx.attr.dep_filemaps[i])))
+
     # TODO: only do this if package is -dev or dependent of a -dev pkg.
     cc_import_targets, outs, symlinks = _discover_contents(
         rctx,
         rctx.attr.depends_on,
-        json.decode(rctx.attr.depends_file_map),
+        depends_file_map,
         rctx.attr.package_name.removesuffix("-dev"),
     )
 
@@ -437,7 +444,7 @@ deb_import = repository_rule(
         "urls": attr.string_list(mandatory = True, allow_empty = False),
         "sha256": attr.string(),
         "depends_on": attr.string_list(),
-        "depends_file_map": attr.string(),
+        "dep_filemaps": attr.label_list(doc = "Each dependency's filemap.json, in depends_on order."),
         "mergedusr": attr.bool(),
         "target_name": attr.string(),
         "package_name": attr.string(),


### PR DESCRIPTION
This PR is just a refactor, with two changes:
- Instead of passing the dependency filemaps as raw JSON strings, we store them in files, and depend on those files from the `deb_imports`. These files must be kept in their own repos to avoid cycles. This should cut the lockfile footprint of `rules_distroless` considerably (~50% in back-of-the-envelope testing). In SONiC, it reduces it by almost 75%.
- We simplify how to resolve symlinks.