### PR TITLE
Avoid mixing architectures

### DIFF
--- a/apt/private/translate_dependency_set.bzl
+++ b/apt/private/translate_dependency_set.bzl
@@ -55,7 +55,7 @@ _PACKAGES = {packages}
 dpkg_status(
     name = "dpkg_status",
     controls = select({{
-        "//:linux_%s" % arch: ["//%s:control" % package for package in packages]
+        "//:linux_%s" % arch: ["//%s/%s:control" % (package, arch) for package in packages]
         for arch, packages in _PACKAGES.items()
     }}) if _PACKAGES else {{}},
     visibility = ["//visibility:public"],
@@ -64,7 +64,7 @@ dpkg_status(
 filegroup(
     name = "packages",
     srcs = select({{
-        "//:linux_%s" % arch: ["//%s" % package for package in packages]
+        "//:linux_%s" % arch: ["//%s/%s" % (package, arch) for package in packages]
         for arch, packages in _PACKAGES.items()
     }}) if _PACKAGES else {{}},
     visibility = ["//visibility:public"],
@@ -132,6 +132,21 @@ alias(
 )
 """
 
+# Computes the `@repo//:data` labels a package's per-architecture BUILD.bazel
+# should depend on for the given architecture.
+#
+# Avoids mixing architectures: a dependency is only included if it was built
+# for this exact architecture, or is architecture-independent ("all"). Without
+# this scoping, a package's `depends_on` (which spans every architecture the
+# lockfile knows about) would leak foreign-architecture deps into a single
+# architecture's target, causing file duplication that confuses `flatten`.
+def package_deps_for_architecture(packages, package, architecture):
+    return [
+        "@" + util.sanitize(dep_key) + "//:data"
+        for dep_key in package["depends_on"]
+        if packages[dep_key]["architecture"] in [architecture, "all"]
+    ]
+
 def _translate_dependency_set_impl(rctx):
     package_template = rctx.read(rctx.attr.package_template)
     lockf = lockfile.from_json(rctx, rctx.attr.lock_content)
@@ -192,7 +207,7 @@ Please unify the versions manually, or use separate `apt.install` calls (with di
                     data_targets = '"@%s//:data"' % repo_name,
                     control_targets = '"@%s//:control"' % repo_name,
                     src = '"@%s//:data"' % repo_name,
-                    deps = ["@" + util.sanitize(dep_key) for dep_key in package["depends_on"]],
+                    deps = package_deps_for_architecture(packages, package, architecture),
                     urls = [
                         uri + "/" + package["filename"]
                         for uri in sources[package["suite"]]["uris"]

--- a/apt/tests/BUILD.bazel
+++ b/apt/tests/BUILD.bazel
@@ -1,6 +1,7 @@
 load(":facts_test.bzl", "facts_tests")
 load(":linker_script_test.bzl", "linker_script_tests")
 load(":resolution_test.bzl", "resolution_tests")
+load(":translate_dependency_set_test.bzl", "translate_dependency_set_tests")
 load(":version_test.bzl", "version_tests")
 
 version_tests()
@@ -10,3 +11,5 @@ resolution_tests()
 facts_tests()
 
 linker_script_tests()
+
+translate_dependency_set_tests()

--- a/apt/tests/translate_dependency_set_test.bzl
+++ b/apt/tests/translate_dependency_set_test.bzl
@@ -1,0 +1,48 @@
+"unit tests for dependency set translation"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//apt/private:translate_dependency_set.bzl", "package_deps_for_architecture")
+
+_TEST_SUITE_PREFIX = "translate_dependency_set/"
+
+# Regression test for commit "Avoid mixing architectures": dpkg_status and
+# packages targets accidentally mixed architectures, leading to file
+# duplications which confuse flatten and lead to unusable artifacts. A
+# package's `depends_on` (computed from the whole, possibly multi-arch,
+# lockfile) must only contribute deps that match the architecture being
+# built (or are architecture-independent).
+def _no_mixed_architectures_test(ctx):
+    env = unittest.begin(ctx)
+
+    packages = {
+        "/repo/libfoo:amd64=1.0": {
+            "architecture": "amd64",
+        },
+        "/repo/libfoo:arm64=1.0": {
+            "architecture": "arm64",
+        },
+        "/repo/libbar:all=1.0": {
+            "architecture": "all",
+        },
+    }
+    package = {
+        "depends_on": [
+            "/repo/libfoo:amd64=1.0",
+            "/repo/libfoo:arm64=1.0",
+            "/repo/libbar:all=1.0",
+        ],
+    }
+
+    deps = package_deps_for_architecture(packages, package, "amd64")
+
+    asserts.true(env, "@repo_libfoo-amd64_1.0//:data" in deps)
+    asserts.true(env, "@repo_libbar-all_1.0//:data" in deps)
+    asserts.false(env, "@repo_libfoo-arm64_1.0//:data" in deps)
+    asserts.equals(env, 2, len(deps))
+
+    return unittest.end(env)
+
+no_mixed_architectures_test = unittest.make(_no_mixed_architectures_test)
+
+def translate_dependency_set_tests():
+    no_mixed_architectures_test(name = _TEST_SUITE_PREFIX + "no_mixed_architectures")


### PR DESCRIPTION
dpkg_status and packages targets accidentally mixed architectures.

This leads to file duplications which confuse flatten and lead to unusable artifacts.