### PR TITLE
fix: preserve previously recorded architectures in lockfile sources

### DIFF
--- a/apt/private/lockfile.bzl
+++ b/apt/private/lockfile.bzl
@@ -66,6 +66,14 @@ def _has_package(lock, suite, name, version, arch):
     return _make_package_key(suite, name, version, arch) in lock.packages
 
 def _add_source(lock, suite, types, uris, components, architectures):
+    existing = lock.sources.get(suite)
+    if existing:
+        architectures = existing["architectures"] + [
+            arch
+            for arch in architectures
+            if arch not in existing["architectures"]
+        ]
+
     lock.sources[suite] = {
         "types": types,
         "uris": uris,

--- a/apt/tests/BUILD.bazel
+++ b/apt/tests/BUILD.bazel
@@ -1,5 +1,6 @@
 load(":facts_test.bzl", "facts_tests")
 load(":linker_script_test.bzl", "linker_script_tests")
+load(":lockfile_test.bzl", "lockfile_tests")
 load(":resolution_test.bzl", "resolution_tests")
 load(":translate_dependency_set_test.bzl", "translate_dependency_set_tests")
 load(":version_test.bzl", "version_tests")
@@ -11,5 +12,7 @@ resolution_tests()
 facts_tests()
 
 linker_script_tests()
+
+lockfile_tests()
 
 translate_dependency_set_tests()

--- a/apt/tests/lockfile_test.bzl
+++ b/apt/tests/lockfile_test.bzl
@@ -1,0 +1,66 @@
+"unit tests for lockfile.bzl"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//apt/private:lockfile.bzl", "lockfile")
+
+_TEST_SUITE_PREFIX = "lockfile/"
+
+# Regression test for `_add_source`: previously, calling `add_source` twice
+# for the same suite (e.g. once per architecture, as `apt_deb_repository`
+# does when resolving multiple architectures for the same suite) made the
+# second call clobber the first, so the lockfile's `sources` entry only ever
+# recorded the architectures from the *last* call. This test proves that
+# architectures accumulate across calls instead of being overwritten, while
+# still deduplicating repeated architectures.
+def _add_source_merges_architectures_test(ctx):
+    env = unittest.begin(ctx)
+
+    lock = lockfile.empty(struct())
+
+    lock.add_source(
+        suite = "bookworm",
+        types = ["deb"],
+        uris = ["https://deb.debian.org/debian"],
+        components = ["main"],
+        architectures = ["amd64"],
+    )
+    lock.add_source(
+        suite = "bookworm",
+        types = ["deb"],
+        uris = ["https://deb.debian.org/debian"],
+        components = ["main"],
+        architectures = ["arm64"],
+    )
+
+    source = lock.sources()["bookworm"]
+    asserts.equals(env, ["amd64", "arm64"], source["architectures"])
+
+    # Re-adding an architecture that's already recorded must not duplicate it.
+    lock.add_source(
+        suite = "bookworm",
+        types = ["deb"],
+        uris = ["https://deb.debian.org/debian"],
+        components = ["main"],
+        architectures = ["amd64", "arm64"],
+    )
+
+    source = lock.sources()["bookworm"]
+    asserts.equals(env, ["amd64", "arm64"], source["architectures"])
+
+    # A different suite must not be affected by other suites' architectures.
+    lock.add_source(
+        suite = "sid",
+        types = ["deb"],
+        uris = ["https://deb.debian.org/debian"],
+        components = ["main"],
+        architectures = ["riscv64"],
+    )
+    asserts.equals(env, ["riscv64"], lock.sources()["sid"]["architectures"])
+    asserts.equals(env, ["amd64", "arm64"], lock.sources()["bookworm"]["architectures"])
+
+    return unittest.end(env)
+
+add_source_merges_architectures_test = unittest.make(_add_source_merges_architectures_test)
+
+def lockfile_tests():
+    add_source_merges_architectures_test(name = _TEST_SUITE_PREFIX + "add_source_merges_architectures")


### PR DESCRIPTION
`_add_source` overwrote a suite's `sources` entry on every call, so when the same suite was added more than once (e.g. once per architecture), only the architectures from the most recent call survived in the lockfile. Merge the new architectures into the existing ones instead, deduplicating repeats.

This is especially important if dependencies of a module also use rules_distroless and define the same suites but with differing architectures.

Adds a regression test in apt/tests/lockfile_test.bzl covering this merge behavior.