### PR TITLE
Fix compilation with incompatible flags in Bazel 8.x

### DIFF
--- a/apt/private/translate_dependency_set.bzl
+++ b/apt/private/translate_dependency_set.bzl
@@ -42,6 +42,7 @@ _ARCHITECTURES = {architectures}
        "@platforms//os:" + os,
        "@platforms//cpu:" + _ARCHITECTURE_MAP[arch],
     ],
+    visibility = ["//:__subpackages__"],
   )
   for os in ["linux"]
   for arch in _ARCHITECTURES


### PR DESCRIPTION
Fixes error with --incompatible_config_setting_private_default_visibility

This PR fixes the issues seen in https://buildkite.com/bazel/bcr-presubmit/builds/38830/list?sid=019fc337-1db7-4df6-b316-de43f33b7d48&tab=output